### PR TITLE
Add Support for Manual Lid Opening & On/Off of Display Matrix for OneRFIDFeeder PLAF301 - Resolves Issue #20 & Resolves Issue #15

### DIFF
--- a/custom_components/petlibro/api.py
+++ b/custom_components/petlibro/api.py
@@ -382,8 +382,8 @@ class PetLibroAPI:
         """Trigger manual lid opening for a specific device."""
         await self.session.post("/device/device/doorStateChange", json={
             "deviceSn": serial,
-            "barnDoorState": 'true',
-            "timeout": 8000 # Can make this dynamic in the future?
+            "barnDoorState": True,
+            "timeout": 8000
         })
 
 ## Added this to fix dupe logs

--- a/custom_components/petlibro/api.py
+++ b/custom_components/petlibro/api.py
@@ -385,6 +385,26 @@ class PetLibroAPI:
             "barnDoorState": True,
             "timeout": 8000
         })
+    
+    async def set_display_matrix_on(self, serial: str):
+        """Trigger turn display matrix on"""
+        await self.session.post("/device/setting/updateDisplayMatrixSetting", json={
+            "deviceSn": serial,
+            "screenDisplayAgingType": 1,
+            "screenDisplayStartTime": None,
+            "screenDisplayEndTime": None,
+            "screenDisplaySwitch": True
+        })
+    
+    async def set_display_matrix_off(self, serial: str):
+        """Trigger turn display matrix off"""
+        await self.session.post("/device/setting/updateDisplayMatrixSetting", json={
+            "deviceSn": serial,
+            "screenDisplayAgingType": 1,
+            "screenDisplayStartTime": None,
+            "screenDisplayEndTime": None,
+            "screenDisplaySwitch": False
+        })
 
 ## Added this to fix dupe logs
 class PetLibroDataCoordinator(DataUpdateCoordinator):

--- a/custom_components/petlibro/api.py
+++ b/custom_components/petlibro/api.py
@@ -378,6 +378,14 @@ class PetLibroAPI:
             _LOGGER.error(f"Failed to trigger manual feeding for device {serial}: {err}")
             raise PetLibroAPIError(f"Error triggering manual feeding: {err}")
 
+    async def set_manual_lid_open(self, serial: str):
+        """Turn the sound on or off."""
+        await self.session.post("/device/device/doorStateChange", json={
+            "deviceSn": serial,
+            "barnDoorState": 'true'
+            "timeout": 8000 # Can make this dynamic in the future?
+        })
+
 ## Added this to fix dupe logs
 class PetLibroDataCoordinator(DataUpdateCoordinator):
     def __init__(self, hass, api):

--- a/custom_components/petlibro/api.py
+++ b/custom_components/petlibro/api.py
@@ -379,10 +379,10 @@ class PetLibroAPI:
             raise PetLibroAPIError(f"Error triggering manual feeding: {err}")
 
     async def set_manual_lid_open(self, serial: str):
-        """Turn the sound on or off."""
+        """Trigger manual lid opening for a specific device."""
         await self.session.post("/device/device/doorStateChange", json={
             "deviceSn": serial,
-            "barnDoorState": 'true'
+            "barnDoorState": 'true',
             "timeout": 8000 # Can make this dynamic in the future?
         })
 

--- a/custom_components/petlibro/button.py
+++ b/custom_components/petlibro/button.py
@@ -123,6 +123,12 @@ DEVICE_BUTTON_MAP: dict[type[Device], list[PetLibroButtonEntityDescription]] = {
             translation_key="disable_feeding_plan",
             set_fn=lambda device: device.set_feeding_plan(False),
             name="Disable Feeding Plan"
+        ),
+        PetLibroButtonEntityDescription[OneRFIDSmartFeeder](
+            key="manual_lid_open",
+            translation_key="manual_lid_open",
+            set_fn=lambda device: device.set_manual_lid_open(),
+            name="Manually Open Lid"
         )
     ],
     PolarWetFoodFeeder: [

--- a/custom_components/petlibro/button.py
+++ b/custom_components/petlibro/button.py
@@ -129,6 +129,18 @@ DEVICE_BUTTON_MAP: dict[type[Device], list[PetLibroButtonEntityDescription]] = {
             translation_key="manual_lid_open",
             set_fn=lambda device: device.set_manual_lid_open(),
             name="Manually Open Lid"
+        ),
+        PetLibroButtonEntityDescription[OneRFIDSmartFeeder](
+            key="display_matrix_on",
+            translation_key="display_matrix_on",
+            set_fn=lambda device: device.set_display_matrix_on(),
+            name="Turn On Display Matrix"
+        ),
+        PetLibroButtonEntityDescription[OneRFIDSmartFeeder](
+            key="display_matrix_off",
+            translation_key="display_matrix_off",
+            set_fn=lambda device: device.set_display_matrix_off(),
+            name="Turn Off Display Matrix"
         )
     ],
     PolarWetFoodFeeder: [

--- a/custom_components/petlibro/devices/feeders/one_rfid_smart_feeder.py
+++ b/custom_components/petlibro/devices/feeders/one_rfid_smart_feeder.py
@@ -279,3 +279,22 @@ class OneRFIDSmartFeeder(Device):
             _LOGGER.error(f"Failed to trigger manual lid opening for {self.serial}: {err}")
             raise PetLibroAPIError(f"Error triggering manual lid opening: {err}")
 
+    # Method for display matrix turn on
+    async def set_display_matrix_on(self) -> None:
+        _LOGGER.debug(f"Turning on the display matrix for {self.serial}")
+        try:
+            await self.api.set_display_matrix_on(self.serial)
+            await self.refresh()  # Refresh the state after the action
+        except aiohttp.ClientError as err:
+            _LOGGER.error(f"Failed to turn on the display matrix for {self.serial}: {err}")
+            raise PetLibroAPIError(f"Error turning on the display matrix: {err}")
+
+    # Method for display matrix turn off
+    async def set_display_matrix_off(self) -> None:
+        _LOGGER.debug(f"Turning off the display matrix for {self.serial}")
+        try:
+            await self.api.set_display_matrix_off(self.serial)
+            await self.refresh()  # Refresh the state after the action
+        except aiohttp.ClientError as err:
+            _LOGGER.error(f"Failed to turn off the display matrix for {self.serial}: {err}")
+            raise PetLibroAPIError(f"Error turning off the display matrix: {err}")

--- a/custom_components/petlibro/devices/feeders/one_rfid_smart_feeder.py
+++ b/custom_components/petlibro/devices/feeders/one_rfid_smart_feeder.py
@@ -269,3 +269,13 @@ class OneRFIDSmartFeeder(Device):
             _LOGGER.error(f"Failed to set feeding plan for {self.serial}: {err}")
             raise PetLibroAPIError(f"Error setting feeding plan: {err}")
 
+    # Method for manual lid opening
+    async def set_manual_lid_open(self) -> None:
+        _LOGGER.debug(f"Triggering manual lid opening for {self.serial}")
+        try:
+            await self.api.set_manual_lid_open(self.serial)
+            await self.refresh()  # Refresh the state after the action
+        except aiohttp.ClientError as err:
+            _LOGGER.error(f"Failed to trigger manual lid opening for {self.serial}: {err}")
+            raise PetLibroAPIError(f"Error triggering manual lid opening: {err}")
+

--- a/custom_components/petlibro/translations/en.json
+++ b/custom_components/petlibro/translations/en.json
@@ -135,6 +135,9 @@
             },
             "disable_feeding_plan": {
                 "name": "Disable Feeding Plan"
+            },
+            "manual_lid_open": {
+                "name": "Manually Open Lid"
             }
         },
         "binary_sensor": {

--- a/custom_components/petlibro/translations/en.json
+++ b/custom_components/petlibro/translations/en.json
@@ -138,6 +138,12 @@
             },
             "manual_lid_open": {
                 "name": "Manually Open Lid"
+            },
+            "display_matrix_on": {
+                "name": "Turn On Display Matrix"
+            },
+            "display_matrix_off": {
+                "name": "Turn Off Display Matrix"
             }
         },
         "binary_sensor": {


### PR DESCRIPTION
Resolves Issue #20 
Resolves Issue #15 

Tested and working on my devices.

We can keep this open to develop the timeout feature for the lid closing automatically. or i can open a new Feature Request for it.
We can keep this open to develop the different built in icons, and the text options. or i can open a new Feature Request for just those features, and i can then slowly develop this instead.
