### PR TITLE
Fix usage of deprecated field

### DIFF
--- a/custom_components/petlibro/number.py
+++ b/custom_components/petlibro/number.py
@@ -57,7 +57,7 @@ class PetLibroNumberEntity(PetLibroEntity[_DeviceT], NumberEntity):
         return self.entity_description.device_class
 
     @property
-    def value(self) -> float:
+    def native_value(self) -> float | None:
         """Return the current state."""
         state = getattr(self.device, self.entity_description.key, None)
         if state is None:


### PR DESCRIPTION
As described in https://developers.home-assistant.io/blog/2022/06/14/number_entity_refactoring/ NumberEntities should not override the property `value`. This should fix the following warning that is shown in Home Assistant when the integration loads up:

> custom_components.petlibro.number::PetLibroNumberEntity is overriding deprecated methods on an instance of NumberEntity, this is not valid and will be unsupported from Home Assistant 2022.10. Please report it to the custom integration author