### PR TITLE
Fix device class properties

### DIFF
--- a/custom_components/petlibro/sensor.py
+++ b/custom_components/petlibro/sensor.py
@@ -178,7 +178,9 @@ class PetLibroSensorEntity(PetLibroEntity[_DeviceT], SensorEntity):
     @property
     def device_class(self) -> SensorDeviceClass | None:
         """Return the device class to use in the frontend, if any."""
-        return self.entity_description.device_class_fn(self.device)
+        if (device_class := self.entity_description.device_class_fn(self.device)) is not None:
+            return device_class
+        return super().device_class
 
 
 DEVICE_SENSOR_MAP: dict[type[Device], list[PetLibroSensorEntityDescription]] = {


### PR DESCRIPTION
Currently, sensors do not include device classes. This is because they are only fetched from `device_class_fn`. If instead, `device_class` is used, that would be ignored.

The change restores this functionality by falling back to `device_class` if `device_class_fn` returns None. This was previously in place but apparently changed in f88f786c. Reverting this particular line adds the device classes back and I can't see any other regression.