### PR TITLE
Clean up/add Polar sensors

### DIFF
--- a/custom_components/petlibro/api.py
+++ b/custom_components/petlibro/api.py
@@ -336,6 +336,12 @@ class PetLibroAPI:
     async def device_feeding_plan_today_new(self, serial: str) -> Dict[str, Any]:
         return await self.session.post_serial("/device/feedingPlan/todayNew", serial)
 
+    async def device_feeding_plan_templates(self, serial: str) -> Dict[str, Any]:
+        return await self.session.post_serial("/device/feedingPlanTemplate/list", serial)
+
+    async def device_wet_feeding_plan(self, serial: str) -> Dict[str, Any]:
+        return await self.session.post_serial("/device/wetFeedingPlan/wetListV3", serial)
+
     # Support for new switch functions
     async def set_feeding_plan(self, serial: str, enable: bool):
         """Set the feeding plan on/off."""

--- a/custom_components/petlibro/binary_sensor.py
+++ b/custom_components/petlibro/binary_sensor.py
@@ -295,14 +295,6 @@ DEVICE_BINARY_SENSOR_MAP: dict[type[Device], list[PetLibroBinarySensorEntityDesc
     ],
     PolarWetFoodFeeder: [
         PetLibroBinarySensorEntityDescription[PolarWetFoodFeeder](
-            key="food_low",
-            translation_key="food_low",
-            icon="mdi:bowl-mix-outline",
-            device_class=BinarySensorDeviceClass.PROBLEM,
-            should_report=lambda device: device.food_low is not None,
-            name="Food Status"
-        ),
-        PetLibroBinarySensorEntityDescription[PolarWetFoodFeeder](
             key="online",
             translation_key="online",
             icon="mdi:wifi",
@@ -325,14 +317,6 @@ DEVICE_BINARY_SENSOR_MAP: dict[type[Device], list[PetLibroBinarySensorEntityDesc
             device_class=BinarySensorDeviceClass.PROBLEM,
             should_report=lambda device: device.door_blocked is not None,
             name="Lid Status"
-        ),
-        PetLibroBinarySensorEntityDescription[PolarWetFoodFeeder](
-            key="whether_in_sleep_mode",
-            translation_key="whether_in_sleep_mode",
-            icon="mdi:sleep",
-            device_class=BinarySensorDeviceClass.POWER,
-            should_report=lambda device: device.whether_in_sleep_mode is not None,
-            name="Sleep Mode"
         ),
     ],
     DockstreamSmartFountain: [

--- a/custom_components/petlibro/devices/feeders/polar_wet_food_feeder.py
+++ b/custom_components/petlibro/devices/feeders/polar_wet_food_feeder.py
@@ -68,10 +68,6 @@ class PolarWetFoodFeeder(Device):
         return bool(self._data.get("enableFeedingPlan", False))
 
     @property
-    def food_low(self) -> bool:
-        return not bool(self._data.get("surplusGrain", True))  # Surplus grain available
-
-    @property
     def mac_address(self) -> str:
         """Returns the MAC address of the device."""
         return self._data.get("mac", "unknown")
@@ -132,10 +128,6 @@ class PolarWetFoodFeeder(Device):
     @property
     def unit_type(self) -> int:
         return self._data.get("realInfo", {}).get("unitType", 1)
-
-    @property
-    def whether_in_sleep_mode(self) -> bool:
-        return bool(self._data.get("realInfo", {}).get("whetherInSleepMode", False))
 
     @property
     def enable_low_battery_notice(self) -> bool:

--- a/custom_components/petlibro/devices/feeders/polar_wet_food_feeder.py
+++ b/custom_components/petlibro/devices/feeders/polar_wet_food_feeder.py
@@ -36,6 +36,11 @@ class PolarWetFoodFeeder(Device):
         return self._data.get("batteryState")
 
     @property
+    def device_sn(self) -> str:
+        """Returns the serial number of the device."""
+        return self._data.get("deviceSn", "unknown")
+
+    @property
     def door_blocked(self) -> bool | None:
         return self._data.get("realInfo", {}).get("barnDoorError")
 

--- a/custom_components/petlibro/sensor.py
+++ b/custom_components/petlibro/sensor.py
@@ -600,15 +600,6 @@ DEVICE_SENSOR_MAP: dict[type[Device], list[PetLibroSensorEntityDescription]] = {
             name="Feeding Ends"
         ),
         PetLibroSensorEntityDescription[PolarWetFoodFeeder](
-            key="temperature",
-            translation_key="temperature",
-            icon="mdi:thermometer",
-            native_unit_of_measurement="°F",
-            device_class=SensorDeviceClass.TEMPERATURE,
-            state_class=SensorStateClass.MEASUREMENT,
-            name="Temperature"
-        ),
-        PetLibroSensorEntityDescription[PolarWetFoodFeeder](
             key="plate_position",
             translation_key="plate_position",
             icon="mdi:rotate-3d-variant",

--- a/custom_components/petlibro/sensor.py
+++ b/custom_components/petlibro/sensor.py
@@ -210,7 +210,9 @@ DEVICE_SENSOR_MAP: dict[type[Device], list[PetLibroSensorEntityDescription]] = {
             translation_key="wifi_rssi",
             icon="mdi:wifi",
             native_unit_of_measurement="dBm",
-            name="Wi-Fi Signal Strength"
+            name="Wi-Fi Signal Strength",
+            device_class=SensorDeviceClass.SIGNAL_STRENGTH,
+            state_class=SensorStateClass.MEASUREMENT
         ),
         PetLibroSensorEntityDescription[AirSmartFeeder](
             key="battery_state",
@@ -281,7 +283,9 @@ DEVICE_SENSOR_MAP: dict[type[Device], list[PetLibroSensorEntityDescription]] = {
             translation_key="wifi_rssi",
             icon="mdi:wifi",
             native_unit_of_measurement="dBm",
-            name="Wi-Fi Signal Strength"
+            name="Wi-Fi Signal Strength",
+            device_class=SensorDeviceClass.SIGNAL_STRENGTH,
+            state_class=SensorStateClass.MEASUREMENT
         ),
         PetLibroSensorEntityDescription[GranarySmartFeeder](
             key="remaining_desiccant",
@@ -358,7 +362,9 @@ DEVICE_SENSOR_MAP: dict[type[Device], list[PetLibroSensorEntityDescription]] = {
             translation_key="wifi_rssi",
             icon="mdi:wifi",
             native_unit_of_measurement="dBm",
-            name="Wi-Fi Signal Strength"
+            name="Wi-Fi Signal Strength",
+            device_class=SensorDeviceClass.SIGNAL_STRENGTH,
+            state_class=SensorStateClass.MEASUREMENT
         ),
         PetLibroSensorEntityDescription[GranarySmartCameraFeeder](
             key="remaining_desiccant",
@@ -471,7 +477,9 @@ DEVICE_SENSOR_MAP: dict[type[Device], list[PetLibroSensorEntityDescription]] = {
             translation_key="wifi_rssi",
             icon="mdi:wifi",
             native_unit_of_measurement="dBm",
-            name="Wi-Fi Signal Strength"
+            name="Wi-Fi Signal Strength",
+            device_class=SensorDeviceClass.SIGNAL_STRENGTH,
+            state_class=SensorStateClass.MEASUREMENT
         ),
         PetLibroSensorEntityDescription[OneRFIDSmartFeeder](
             key="remaining_desiccant",
@@ -551,7 +559,9 @@ DEVICE_SENSOR_MAP: dict[type[Device], list[PetLibroSensorEntityDescription]] = {
             translation_key="wifi_rssi",
             icon="mdi:wifi",
             native_unit_of_measurement="dBm",
-            name="Wi-Fi Signal Strength"
+            name="Wi-Fi Signal Strength",
+            device_class=SensorDeviceClass.SIGNAL_STRENGTH,
+            state_class=SensorStateClass.MEASUREMENT
         ),
         PetLibroSensorEntityDescription[PolarWetFoodFeeder](
             key="wifi_ssid",
@@ -585,7 +595,8 @@ DEVICE_SENSOR_MAP: dict[type[Device], list[PetLibroSensorEntityDescription]] = {
             key="next_feeding_day",
             translation_key="next_feeding_day",
             icon="mdi:calendar-clock",
-            name="Feeding Schedule"
+            name="Feeding Schedule",
+            device_class=SensorDeviceClass.DATE
         ),
         PetLibroSensorEntityDescription[PolarWetFoodFeeder](
             key="next_feeding_time",
@@ -631,7 +642,9 @@ DEVICE_SENSOR_MAP: dict[type[Device], list[PetLibroSensorEntityDescription]] = {
             translation_key="wifi_rssi",
             icon="mdi:wifi",
             native_unit_of_measurement="dBm",
-            name="Wi-Fi Signal Strength"
+            name="Wi-Fi Signal Strength",
+            device_class=SensorDeviceClass.SIGNAL_STRENGTH,
+            state_class=SensorStateClass.MEASUREMENT
         ),
         PetLibroSensorEntityDescription[DockstreamSmartFountain](
             key="remaining_cleaning_days",
@@ -645,7 +658,8 @@ DEVICE_SENSOR_MAP: dict[type[Device], list[PetLibroSensorEntityDescription]] = {
             icon="mdi:scale",
             native_unit_of_measurement="oz",
             state_class=SensorStateClass.MEASUREMENT,
-            name="Current Weight"
+            name="Current Weight",
+            device_class=SensorDeviceClass.WEIGHT
         ),
         PetLibroSensorEntityDescription[DockstreamSmartFountain](
             key="weight_percent",
@@ -701,7 +715,9 @@ DEVICE_SENSOR_MAP: dict[type[Device], list[PetLibroSensorEntityDescription]] = {
             translation_key="wifi_rssi",
             icon="mdi:wifi",
             native_unit_of_measurement="dBm",
-            name="Wi-Fi Signal Strength"
+            name="Wi-Fi Signal Strength",
+            device_class=SensorDeviceClass.SIGNAL_STRENGTH,
+            state_class=SensorStateClass.MEASUREMENT
         ),
         PetLibroSensorEntityDescription[DockstreamSmartRFIDFountain](
             key="remaining_cleaning_days",
@@ -715,7 +731,8 @@ DEVICE_SENSOR_MAP: dict[type[Device], list[PetLibroSensorEntityDescription]] = {
             icon="mdi:scale",
             native_unit_of_measurement="oz",
             state_class=SensorStateClass.MEASUREMENT,
-            name="Current Weight"
+            name="Current Weight",
+            device_class=SensorDeviceClass.WEIGHT
         ),
         PetLibroSensorEntityDescription[DockstreamSmartRFIDFountain](
             key="weight_percent",

--- a/custom_components/petlibro/sensor.py
+++ b/custom_components/petlibro/sensor.py
@@ -543,7 +543,7 @@ DEVICE_SENSOR_MAP: dict[type[Device], list[PetLibroSensorEntityDescription]] = {
     ],
     PolarWetFoodFeeder: [
         PetLibroSensorEntityDescription[PolarWetFoodFeeder](
-            key="device_sn",
+            key="serial",
             translation_key="device_sn",
             icon="mdi:identifier",
             name="Device SN"
@@ -592,23 +592,18 @@ DEVICE_SENSOR_MAP: dict[type[Device], list[PetLibroSensorEntityDescription]] = {
             should_report=lambda device: device.feeding_plan_state is not None,
         ),
         PetLibroSensorEntityDescription[PolarWetFoodFeeder](
-            key="next_feeding_day",
-            translation_key="next_feeding_day",
-            icon="mdi:calendar-clock",
-            name="Feeding Schedule",
-            device_class=SensorDeviceClass.DATE
-        ),
-        PetLibroSensorEntityDescription[PolarWetFoodFeeder](
             key="next_feeding_time",
             translation_key="next_feeding_time",
             icon="mdi:clock-outline",
-            name="Feeding Begins"
+            name="Feeding Begins",
+            device_class=SensorDeviceClass.TIMESTAMP
         ),
         PetLibroSensorEntityDescription[PolarWetFoodFeeder](
             key="next_feeding_end_time",
             translation_key="next_feeding_end_time",
             icon="mdi:clock-end",
-            name="Feeding Ends"
+            name="Feeding Ends",
+            device_class=SensorDeviceClass.TIMESTAMP
         ),
         PetLibroSensorEntityDescription[PolarWetFoodFeeder](
             key="plate_position",
@@ -616,6 +611,12 @@ DEVICE_SENSOR_MAP: dict[type[Device], list[PetLibroSensorEntityDescription]] = {
             icon="mdi:rotate-3d-variant",
             name="Plate Position",
             should_report=lambda device: device.plate_position is not None,
+        ),
+        PetLibroSensorEntityDescription[PolarWetFoodFeeder](
+            key="active_feeding_plan_name",
+            translation_key="active_feeding_plan_name",
+            icon="mdi:notebook",
+            name="Active feeding plan"
         ),
     ],
     DockstreamSmartFountain: [

--- a/custom_components/petlibro/sensor.py
+++ b/custom_components/petlibro/sensor.py
@@ -543,7 +543,7 @@ DEVICE_SENSOR_MAP: dict[type[Device], list[PetLibroSensorEntityDescription]] = {
     ],
     PolarWetFoodFeeder: [
         PetLibroSensorEntityDescription[PolarWetFoodFeeder](
-            key="serial",
+            key="device_sn",
             translation_key="device_sn",
             icon="mdi:identifier",
             name="Device SN"

--- a/custom_components/petlibro/translations/en.json
+++ b/custom_components/petlibro/translations/en.json
@@ -116,6 +116,9 @@
             },
             "plate_position": {
                 "name": "Plate position"
+            },
+            "active_feeding_plan_name": {
+                "name": "Active feeding plan"
             }
         },
         "switch": {


### PR DESCRIPTION
This PR cleans up some (most?) sensors for the Polar unit and adds one sensor for the currently active feeding plan. I want to add more sensors, but that will have to wait for another PR - I don't want to push too many changes at once :D

The PR is already pretty large because it covers the following things: 

# Changes
## Remove sensors not available in Polar units

While the API does return values for these sensors, the device does not actually support these:

- food_low - Polar units only have a plate and don't measure how much food is in them
- whether_in_sleep_mode - The devices (to my knowledge) do not have any sleep mode
- temperature - Polar units actually *do* support temperatures (visible when spying on the MQTT communication) but the API does not report it (value is always 0°C). It only supports a "snowflake" symbol in the app, but I'm not even sure what it means.

I wanted to remove the battery data as well because my unit always reports that it's empty :thinking: But I'll spend some time investigating this because it's supposed to support this.

## Add missing device/state classes

This isn't just for the Polar unit but for all sensors I could find that can have a "proper" device class. 

## Clean up properties in the Polar device class

Some properties were not used/duplicate:

- `available` was not used and was wrong - the property device does not exist
- `device_sn` is a duplicate of `serial` from the Device class
- `mac_address` is a duplicate of `mac` from Device. Also wasn't used
- `temperature` was already removed as a sensor because the API does not report the temperature
- `food_low` and `whether_in_sleep_mode` also have no sensor any more

Most properties were updated to return `None` if they have no value. This allows HomeAssistant to signal that the value is not available instead of hardcoding something.

The feeding times were updated to return proper datetimes and the sensors now show as timestamps. This unifies the date and time fields into one and allow users to have their own locale for the fields. It also knows about the proper timezone now (so far, the time was always off for me because the timezone was wrong). This could also allow users to properly use the date/times in automations or scripts.

# More notes

I did some clean up for what I feel is "better" like sensor properties returning `None` instead of a hardcoded default value. I also updated logging to not use f-strings because I guess it's ["better practice"](https://pylint.readthedocs.io/en/stable/user_guide/messages/warning/logging-fstring-interpolation.html). I can totally understand if you're not happy with these changes though and can revert this.

If you're happy with what I did in this PR, I'm more than happy to do the same clean up for other devices as well, just to keep everything in a common format. But I only have a Polar unit, so that's the first thing I worked on.

This PR obviously has some changes to some sensors (removing some, consolidating multiple into one, changing the device types and possible values). So if there are any existing automations based on these sensors, the changes will probably break something:

- device_sn
- next_feeding_day
- next_feeding_time
- next_feeding_end_time
- food_low
- whether_in_sleep_mode
- temperature