### PR TITLE
Add 'Feed now', 'Rotate food bowl', and 'Ring bell' manual controls for PLAF109

### DIFF
--- a/custom_components/petlibro/api.py
+++ b/custom_components/petlibro/api.py
@@ -335,6 +335,9 @@ class PetLibroAPI:
 
     async def device_feeding_plan_today_new(self, serial: str) -> Dict[str, Any]:
         return await self.session.post_serial("/device/feedingPlan/todayNew", serial)
+    
+    async def device_wet_feeding_plan_wet_list(self, serial: str) -> Dict[str, Any]:
+        return await self.session.post_serial("/device/wetFeedingPlan/wetListV3", serial)
 
     # Support for new switch functions
     async def set_feeding_plan(self, serial: str, enable: bool):
@@ -465,6 +468,70 @@ class PetLibroAPI:
             _LOGGER.error(f"Failed to trigger manual feeding for device {serial}: {err}")
             raise PetLibroAPIError(f"Error triggering manual feeding: {err}")
 
+    async def set_manual_feed_now(self, serial: str):
+        """Trigger manual feed now for a specific device. This opens the food bowl door."""
+        _LOGGER.debug(f"Triggering manual feed now for device with serial: {serial}")
+        
+        try:
+            # Send the POST request to trigger manual feeding
+            await self.session.post("/device/wetFeedingPlan/manualFeedNow", json={
+                "deviceSn": serial,
+                # The plate ID doesn't matter here - the device will always feed from the current bowl regardless of what the plate ID is.
+                # The app also always uses 1 for the plate ID.
+                "plate": 1 
+            })
+
+        except aiohttp.ClientError as err:
+            _LOGGER.error(f"Failed to trigger manual feed now for device {serial}: {err}")
+            raise PetLibroAPIError(f"Error triggering manual feed now: {err}")
+        
+    async def set_stop_feed_now(self, serial: str, manual_feed_id: int):
+        """Trigger stop feed now for a specific device. This closes the food bowl door."""
+        _LOGGER.debug(f"Triggering stop feed now for device with serial: {serial}")
+        
+        try:
+            # Send the POST request to trigger stop feeding
+            await self.session.post("/device/wetFeedingPlan/stopFeedNow", json={
+                "deviceSn": serial,
+                "feedId": manual_feed_id
+            })
+
+        except aiohttp.ClientError as err:
+            _LOGGER.error(f"Failed to trigger stop feed now for device {serial}: {err}")
+            raise PetLibroAPIError(f"Error triggering stop feed now: {err}")
+        
+    async def set_rotate_food_bowl(self, serial: str) -> int:
+        """Trigger rotate food bowl for a specific device. This rotates the bowls counter-clockwise by one bowl."""
+        _LOGGER.debug(f"Triggering rotate food bowl for device with serial: {serial}")
+        
+        try:
+            # Send the POST request to trigger plate position change
+            response = await self.session.post("/device/wetFeedingPlan/platePositionChange", json={
+                "deviceSn": serial,
+                # The plate ID doesn't matter here - the device will always rotate one bowl counter-clockwise regardless of what the plate ID is.
+                "plate": 1
+            })
+
+            _LOGGER.debug(f"Rotate food bowl successful, new plate position: {response}")
+            return response
+
+        except aiohttp.ClientError as err:
+            _LOGGER.error(f"Failed to trigger rotate food bowl for device {serial}: {err}")
+            raise PetLibroAPIError(f"Error triggering rotate food bowl: {err}")
+        
+    async def set_feed_audio(self, serial: str):
+        """Trigger feed audio for a specific device."""
+        _LOGGER.debug(f"Triggering feed audio for device with serial: {serial}")
+        
+        try:
+            # Send the POST request to trigger feed audio
+            await self.session.post("/device/wetFeedingPlan/feedAudio", json={
+                "deviceSn": serial
+            })
+
+        except aiohttp.ClientError as err:
+            _LOGGER.error(f"Failed to trigger feed audio for device {serial}: {err}")
+            raise PetLibroAPIError(f"Error triggering feed audio: {err}")
 
     async def set_desiccant_reset(self, serial: str) -> JSON:
         """Trigger desiccant reset for a specific device."""

--- a/custom_components/petlibro/api.py
+++ b/custom_components/petlibro/api.py
@@ -336,7 +336,7 @@ class PetLibroAPI:
     async def device_feeding_plan_today_new(self, serial: str) -> Dict[str, Any]:
         return await self.session.post_serial("/device/feedingPlan/todayNew", serial)
     
-    async def device_wet_feeding_plan_wet_list(self, serial: str) -> Dict[str, Any]:
+    async def device_wet_feeding_plan(self, serial: str) -> Dict[str, Any]:
         return await self.session.post_serial("/device/wetFeedingPlan/wetListV3", serial)
 
     # Support for new switch functions

--- a/custom_components/petlibro/button.py
+++ b/custom_components/petlibro/button.py
@@ -163,6 +163,18 @@ DEVICE_BUTTON_MAP: dict[type[Device], list[PetLibroButtonEntityDescription]] = {
 
     ],
     PolarWetFoodFeeder: [
+        PetLibroButtonEntityDescription[PolarWetFoodFeeder](
+            key="ring_bell",
+            translation_key="ring_bell",
+            set_fn=lambda device: device.feed_audio(),
+            name="Ring bell"
+        ),
+        PetLibroButtonEntityDescription[PolarWetFoodFeeder](
+            key="rotate_food_bowl",
+            translation_key="rotate_food_bowl",
+            set_fn=lambda device: device.rotate_food_bowl(),
+            name="Rotate food bowl"
+        )
     ],
     DockstreamSmartFountain: [
     ],

--- a/custom_components/petlibro/button.py
+++ b/custom_components/petlibro/button.py
@@ -167,13 +167,13 @@ DEVICE_BUTTON_MAP: dict[type[Device], list[PetLibroButtonEntityDescription]] = {
             key="ring_bell",
             translation_key="ring_bell",
             set_fn=lambda device: device.feed_audio(),
-            name="Ring bell"
+            name="Ring Bell"
         ),
         PetLibroButtonEntityDescription[PolarWetFoodFeeder](
             key="rotate_food_bowl",
             translation_key="rotate_food_bowl",
             set_fn=lambda device: device.rotate_food_bowl(),
-            name="Rotate food bowl"
+            name="Rotate Food Bowl"
         )
     ],
     DockstreamSmartFountain: [

--- a/custom_components/petlibro/devices/feeders/polar_wet_food_feeder.py
+++ b/custom_components/petlibro/devices/feeders/polar_wet_food_feeder.py
@@ -19,13 +19,13 @@ class PolarWetFoodFeeder(Device):
             # Fetch specific data for this device
             grain_status = await self.api.device_grain_status(self.serial)
             real_info = await self.api.device_real_info(self.serial)
-            wet_list = await self.api.device_wet_feeding_plan_wet_list(self.serial)
+            wet_feeding_plan = await self.api.device_wet_feeding_plan(self.serial)
     
             # Update internal data with fetched API data
             self.update_data({
                 "grainStatus": grain_status or {},
                 "realInfo": real_info or {},
-                "wetList": wet_list or {},
+                "wetFeedingPlan": wet_feeding_plan or {},
             })
         except PetLibroAPIError as err:
             _LOGGER.error(f"Error refreshing data for PolarWetFoodFeeder: {err}")
@@ -112,7 +112,7 @@ class PolarWetFoodFeeder(Device):
     @property
     def manual_feed_id(self) -> int:
         """Returns the manual feed ID."""
-        return self._data.get("wetList", {}).get("manualFeedId", None)
+        return self._data.get("wetFeedingPlan", {}).get("manualFeedId", None)
         
     @property
     def manual_feed_now(self) -> bool:

--- a/custom_components/petlibro/devices/feeders/polar_wet_food_feeder.py
+++ b/custom_components/petlibro/devices/feeders/polar_wet_food_feeder.py
@@ -19,11 +19,13 @@ class PolarWetFoodFeeder(Device):
             # Fetch specific data for this device
             grain_status = await self.api.device_grain_status(self.serial)
             real_info = await self.api.device_real_info(self.serial)
+            wet_list = await self.api.device_wet_feeding_plan_wet_list(self.serial)
     
             # Update internal data with fetched API data
             self.update_data({
                 "grainStatus": grain_status or {},
-                "realInfo": real_info or {}
+                "realInfo": real_info or {},
+                "wetList": wet_list or {},
             })
         except PetLibroAPIError as err:
             _LOGGER.error(f"Error refreshing data for PolarWetFoodFeeder: {err}")
@@ -106,6 +108,16 @@ class PolarWetFoodFeeder(Device):
             return time_obj.strftime("%I:%M %p")  # "08:00 AM" or "11:00 PM"
         except ValueError:
             return "Invalid time"
+        
+    @property
+    def manual_feed_id(self) -> int:
+        """Returns the manual feed ID."""
+        return self._data.get("wetList", {}).get("manualFeedId", None)
+        
+    @property
+    def manual_feed_now(self) -> bool:
+        """Returns whether the feeder is set to feed now or not."""
+        return self.manual_feed_id is not None
 
     @property
     def online(self) -> bool:
@@ -148,3 +160,37 @@ class PolarWetFoodFeeder(Device):
     @property
     def wifi_ssid(self) -> str:
         return self._data.get("realInfo", {}).get("wifiSsid", "unknown")
+
+    async def set_manual_feed_now(self, start: bool) -> None:
+        try:
+            if start:
+                _LOGGER.debug(f"Triggering manual feed now for {self.serial}")
+                await self.api.set_manual_feed_now(self.serial)
+            else:
+                _LOGGER.debug(f"Triggering stop feed now for {self.serial}")
+                await self.api.set_stop_feed_now(self.serial, self.manual_feed_id)
+            
+            await self.refresh()  # Refresh the state after the action
+        except aiohttp.ClientError as err:
+            _LOGGER.error(f"Failed to trigger manual feed now for {self.serial}: {err}")
+            raise PetLibroAPIError(f"Error triggering manual feed now: {err}")
+
+    async def rotate_food_bowl(self) -> None:
+        _LOGGER.debug(f"Triggering rotate food bowl for {self.serial}")
+
+        try:
+            await self.api.set_rotate_food_bowl(self.serial)
+            await self.refresh()  # Refresh the state after the action
+        except aiohttp.ClientError as err:
+            _LOGGER.error(f"Failed to trigger rotate food bowl for {self.serial}: {err}")
+            raise PetLibroAPIError(f"Error triggering rotate food bowl: {err}")
+
+    async def feed_audio(self) -> None:
+        _LOGGER.debug(f"Triggering feed audio for {self.serial}")
+
+        try:
+            await self.api.set_feed_audio(self.serial)
+            await self.refresh()  # Refresh the state after the action
+        except aiohttp.ClientError as err:
+            _LOGGER.error(f"Failed to trigger feed audio for {self.serial}: {err}")
+            raise PetLibroAPIError(f"Error triggering feed audio: {err}")

--- a/custom_components/petlibro/switch.py
+++ b/custom_components/petlibro/switch.py
@@ -58,7 +58,7 @@ DEVICE_SWITCH_MAP: dict[type[Device], list[PetLibroSwitchEntityDescription]] = {
             key="manual_feed_now",
             translation_key="manual_feed_now",
             set_fn=lambda device, value: device.set_manual_feed_now(value),
-            name="Feed now"
+            name="Manually Open/Close Lid"
         ),
     ],
     DockstreamSmartFountain: [

--- a/custom_components/petlibro/switch.py
+++ b/custom_components/petlibro/switch.py
@@ -54,6 +54,12 @@ DEVICE_SWITCH_MAP: dict[type[Device], list[PetLibroSwitchEntityDescription]] = {
     OneRFIDSmartFeeder: [
     ],
     PolarWetFoodFeeder: [
+        PetLibroSwitchEntityDescription[PolarWetFoodFeeder](
+            key="manual_feed_now",
+            translation_key="manual_feed_now",
+            set_fn=lambda device, value: device.set_manual_feed_now(value),
+            name="Feed now"
+        ),
     ],
     DockstreamSmartFountain: [
     ],
@@ -66,7 +72,7 @@ class PetLibroSwitchEntity(PetLibroEntity[_DeviceT], SwitchEntity):
 
     entity_description: PetLibroSwitchEntityDescription[_DeviceT]  # type: ignore [reportIncompatibleVariableOverride]
 
-    @cached_property
+    @property
     def is_on(self) -> bool | None:
         """Return true if switch is on."""
         return bool(getattr(self.device, self.entity_description.key))

--- a/custom_components/petlibro/translations/en.json
+++ b/custom_components/petlibro/translations/en.json
@@ -129,7 +129,7 @@
                 "name": "Enable Sound"
             },
             "manual_feed_now": {
-                "name": "Feed now"
+                "name": "Manually Open/Close Lid"
             }
         },
         "button": {
@@ -164,10 +164,10 @@
                 "name": "Desiccant Replaced"
             },
             "ring_bell": {
-                "name": "Ring bell"
+                "name": "Ring Bell"
             },
             "rotate_food_bowl": {
-                "name": "Rotate food bowl"
+                "name": "Rotate Food Bowl"
             }
         },
         "binary_sensor": {

--- a/custom_components/petlibro/translations/en.json
+++ b/custom_components/petlibro/translations/en.json
@@ -127,6 +127,9 @@
             },
             "enable_sound": {
                 "name": "Enable Sound"
+            },
+            "manual_feed_now": {
+                "name": "Feed now"
             }
         },
         "button": {
@@ -159,6 +162,12 @@
             },
             "desiccant_reset": {
                 "name": "Desiccant Replaced"
+            },
+            "ring_bell": {
+                "name": "Ring bell"
+            },
+            "rotate_food_bowl": {
+                "name": "Rotate food bowl"
             }
         },
         "binary_sensor": {


### PR DESCRIPTION
This implements the 'manual controls' available for the Polar Wet Food Feeder when no feeding schedules are set. In particular, it adds:

- A switch for opening and closing the food door.
- A button to rotate the food bowl.
- A button to ring the bell.

![image](https://github.com/user-attachments/assets/ea7bf297-daef-47fd-9b27-5b621f5d17c4)