### PR TITLE
Add Support for Lid Mode, Lid Speed, and Lid Close Time for OneRFIDSmartFeeder PLAF301

### DIFF
--- a/custom_components/petlibro/__init__.py
+++ b/custom_components/petlibro/__init__.py
@@ -51,6 +51,7 @@ PLATFORMS_BY_TYPE = {
         Platform.SWITCH,
         Platform.BUTTON,
         Platform.NUMBER,
+        Platform.SELECT,
     ),
     PolarWetFoodFeeder: (
         Platform.SENSOR,

--- a/custom_components/petlibro/api.py
+++ b/custom_components/petlibro/api.py
@@ -434,15 +434,32 @@ class PetLibroAPI:
             _LOGGER.error(f"Failed to set sound level for device {serial}: {e}")
             raise
 
+    async def set_lid_close_time(self, serial: str, value: float):
+        """Set the lid close time."""
+        _LOGGER.debug(f"Setting sound level: serial={serial}, value={value}")
+        try:
+            response = await self.session.post("/device/setting/updateCoverSetting", json={
+                "deviceSn": serial,
+                "coverOpenMode": None,
+                "coverCloseSpeed": None,
+                "closeDoorTimeSec": value
+            })
+            _LOGGER.debug(f"Lid close time set successfully: {response}")
+            return response
+        except Exception as e:
+            _LOGGER.error(f"Failed to set lid close time for device {serial}: {e}")
+            raise
+
+
     async def set_lid_speed(self, serial: str, value: str):
         """Set the lid speed."""
         _LOGGER.debug(f"Setting lid speed: serial={serial}, value={value}")
         try:
             response = await self.session.post("/device/setting/updateCoverSetting", json={
                 "deviceSn": serial,
-                "coverOpenMode": 0,
+                "coverOpenMode": None,
                 "coverCloseSpeed": value,
-                "closeDoorTimeSec": 0
+                "closeDoorTimeSec": None
             })
             _LOGGER.debug(f"Lid speed set successfully: {response}")
             return response
@@ -457,8 +474,8 @@ class PetLibroAPI:
             response = await self.session.post("/device/setting/updateCoverSetting", json={
                 "deviceSn": serial,
                 "coverOpenMode": value,
-                "coverCloseSpeed": 0,
-                "closeDoorTimeSec": 0
+                "coverCloseSpeed": None,
+                "closeDoorTimeSec": None
             })
             _LOGGER.debug(f"Lid mode set successfully: {response}")
             return response

--- a/custom_components/petlibro/api.py
+++ b/custom_components/petlibro/api.py
@@ -382,8 +382,8 @@ class PetLibroAPI:
         """Trigger manual lid opening for a specific device."""
         await self.session.post("/device/device/doorStateChange", json={
             "deviceSn": serial,
-            "barnDoorState": 'true',
-            "timeout": 8000 # Can make this dynamic in the future?
+            "barnDoorState": True,
+            "timeout": 8000
         })
 
 ## Added this to fix dupe logs

--- a/custom_components/petlibro/api.py
+++ b/custom_components/petlibro/api.py
@@ -386,8 +386,8 @@ class PetLibroAPI:
             "timeout": 8000
         })
     
-    async def set_display_matrix_on(self, serial: str):
-        """Trigger turn display matrix on"""
+    async def set_display_on(self, serial: str):
+        """Trigger turn display on"""
         await self.session.post("/device/setting/updateDisplayMatrixSetting", json={
             "deviceSn": serial,
             "screenDisplayAgingType": 1,
@@ -396,14 +396,34 @@ class PetLibroAPI:
             "screenDisplaySwitch": True
         })
     
-    async def set_display_matrix_off(self, serial: str):
-        """Trigger turn display matrix off"""
+    async def set_display_off(self, serial: str):
+        """Trigger turn display off"""
         await self.session.post("/device/setting/updateDisplayMatrixSetting", json={
             "deviceSn": serial,
             "screenDisplayAgingType": 1,
             "screenDisplayStartTime": None,
             "screenDisplayEndTime": None,
             "screenDisplaySwitch": False
+        })
+
+    async def set_sound_on(self, serial: str):
+        """Trigger turn sound on"""
+        await self.session.post("/device/setting/updateDisplayMatrixSetting", json={
+            "deviceSn": serial,
+            "soundAgingType": 1,
+            "soundStartTime": None,
+            "soundStartTime": None,
+            "soundSwitch": True
+        })
+    
+    async def set_sound_off(self, serial: str):
+        """Trigger turn sound off"""
+        await self.session.post("/device/setting/updateDisplayMatrixSetting", json={
+            "deviceSn": serial,
+            "soundAgingType": 1,
+            "soundStartTime": None,
+            "soundStartTime": None,
+            "soundSwitch": False
         })
 
 ## Added this to fix dupe logs

--- a/custom_components/petlibro/api.py
+++ b/custom_components/petlibro/api.py
@@ -408,7 +408,7 @@ class PetLibroAPI:
 
     async def set_sound_on(self, serial: str):
         """Trigger turn sound on"""
-        await self.session.post("/device/setting/updateDisplayMatrixSetting", json={
+        await self.session.post("/device/setting/updateSoundSetting", json={
             "deviceSn": serial,
             "soundSwitch": True,
             "soundAgingType": 1,
@@ -418,7 +418,7 @@ class PetLibroAPI:
     
     async def set_sound_off(self, serial: str):
         """Trigger turn sound off"""
-        await self.session.post("/device/setting/updateDisplayMatrixSetting", json={
+        await self.session.post("/device/setting/updateSoundSetting", json={
             "deviceSn": serial,
             "soundSwitch": False,
             "soundAgingType": 1,

--- a/custom_components/petlibro/api.py
+++ b/custom_components/petlibro/api.py
@@ -385,6 +385,26 @@ class PetLibroAPI:
             "barnDoorState": True,
             "timeout": 8000
         })
+    
+    async def set_display_matrix_on(self, serial: str):
+        """Trigger turn display matrix on"""
+        await self.session.post("/device/setting/updateDisplayMatrixSetting", json={
+            "deviceSn": serial,
+            "screenDisplayAgingType": 1,
+            "screenDisplayStartTime": None,
+            "screenDisplayEndTime": None,
+            "screenDisplaySwitch": True
+        })
+    
+    async def set_display_matrix_off(self, serial: str):
+        """Trigger turn display matrix off"""
+        await self.session.post("/device/setting/updateDisplayMatrixSetting", json={
+            "deviceSn": serial,
+            "screenDisplayAgingType": 1,
+            "screenDisplayStartTime": None,
+            "screenDisplayEndTime": None,
+            "screenDisplaySwitch": False
+        })
 
 ## Added this to fix dupe logs
 class PetLibroDataCoordinator(DataUpdateCoordinator):

--- a/custom_components/petlibro/api.py
+++ b/custom_components/petlibro/api.py
@@ -434,6 +434,38 @@ class PetLibroAPI:
             _LOGGER.error(f"Failed to set sound level for device {serial}: {e}")
             raise
 
+    async def set_lid_speed(self, serial: str, value: str):
+        """Set the lid speed."""
+        _LOGGER.debug(f"Setting lid speed: serial={serial}, value={value}")
+        try:
+            response = await self.session.post("/device/setting/updateCoverSetting", json={
+                "deviceSn": serial,
+                "coverOpenMode": 0,
+                "coverCloseSpeed": value,
+                "closeDoorTimeSec": 0
+            })
+            _LOGGER.debug(f"Lid speed set successfully: {response}")
+            return response
+        except Exception as e:
+            _LOGGER.error(f"Failed to set lid speed for device {serial}: {e}")
+            raise
+
+    async def set_lid_mode(self, serial: str, value: str):
+        """Set the lid mode."""
+        _LOGGER.debug(f"Setting lid mode: serial={serial}, value={value}")
+        try:
+            response = await self.session.post("/device/setting/updateCoverSetting", json={
+                "deviceSn": serial,
+                "coverOpenMode": value,
+                "coverCloseSpeed": 0,
+                "closeDoorTimeSec": 0
+            })
+            _LOGGER.debug(f"Lid mode set successfully: {response}")
+            return response
+        except Exception as e:
+            _LOGGER.error(f"Failed to set lid mode for device {serial}: {e}")
+            raise
+
     async def set_manual_feed(self, serial: str) -> JSON:
         """Trigger manual feeding for a specific device."""
         _LOGGER.debug(f"Triggering manual feeding for device with serial: {serial}")

--- a/custom_components/petlibro/api.py
+++ b/custom_components/petlibro/api.py
@@ -378,6 +378,14 @@ class PetLibroAPI:
             _LOGGER.error(f"Failed to trigger manual feeding for device {serial}: {err}")
             raise PetLibroAPIError(f"Error triggering manual feeding: {err}")
 
+    async def set_manual_lid_open(self, serial: str):
+        """Turn the sound on or off."""
+        await self.session.post("/device/device/doorStateChange", json={
+            "deviceSn": serial,
+            "barnDoorState": 'true'
+            "timeout": 8000 # Can make this dynamic in the future?
+        })
+
 ## Added this to fix dupe logs
 class PetLibroDataCoordinator(DataUpdateCoordinator):
     def __init__(self, hass, api):

--- a/custom_components/petlibro/api.py
+++ b/custom_components/petlibro/api.py
@@ -410,20 +410,20 @@ class PetLibroAPI:
         """Trigger turn sound on"""
         await self.session.post("/device/setting/updateDisplayMatrixSetting", json={
             "deviceSn": serial,
+            "soundSwitch": True,
             "soundAgingType": 1,
             "soundStartTime": None,
-            "soundStartTime": None,
-            "soundSwitch": True
+            "soundEndTime": None
         })
     
     async def set_sound_off(self, serial: str):
         """Trigger turn sound off"""
         await self.session.post("/device/setting/updateDisplayMatrixSetting", json={
             "deviceSn": serial,
+            "soundSwitch": False,
             "soundAgingType": 1,
             "soundStartTime": None,
-            "soundStartTime": None,
-            "soundSwitch": False
+            "soundEndTime": None
         })
 
 ## Added this to fix dupe logs

--- a/custom_components/petlibro/api.py
+++ b/custom_components/petlibro/api.py
@@ -379,10 +379,10 @@ class PetLibroAPI:
             raise PetLibroAPIError(f"Error triggering manual feeding: {err}")
 
     async def set_manual_lid_open(self, serial: str):
-        """Turn the sound on or off."""
+        """Trigger manual lid opening for a specific device."""
         await self.session.post("/device/device/doorStateChange", json={
             "deviceSn": serial,
-            "barnDoorState": 'true'
+            "barnDoorState": 'true',
             "timeout": 8000 # Can make this dynamic in the future?
         })
 

--- a/custom_components/petlibro/button.py
+++ b/custom_components/petlibro/button.py
@@ -123,6 +123,12 @@ DEVICE_BUTTON_MAP: dict[type[Device], list[PetLibroButtonEntityDescription]] = {
             translation_key="disable_feeding_plan",
             set_fn=lambda device: device.set_feeding_plan(False),
             name="Disable Feeding Plan"
+        ),
+        PetLibroButtonEntityDescription[OneRFIDSmartFeeder](
+            key="manual_lid_open",
+            translation_key="manual_lid_open",
+            set_fn=lambda device: device.set_manual_lid_open(),
+            name="Manually Open Lid"
         )
     ],
     PolarWetFoodFeeder: [

--- a/custom_components/petlibro/button.py
+++ b/custom_components/petlibro/button.py
@@ -131,17 +131,30 @@ DEVICE_BUTTON_MAP: dict[type[Device], list[PetLibroButtonEntityDescription]] = {
             name="Manually Open Lid"
         ),
         PetLibroButtonEntityDescription[OneRFIDSmartFeeder](
-            key="display_matrix_on",
-            translation_key="display_matrix_on",
-            set_fn=lambda device: device.set_display_matrix_on(),
-            name="Turn On Display Matrix"
+            key="display_on",
+            translation_key="display_on",
+            set_fn=lambda device: device.set_display_on(),
+            name="Turn On Display"
         ),
         PetLibroButtonEntityDescription[OneRFIDSmartFeeder](
-            key="display_matrix_off",
-            translation_key="display_matrix_off",
-            set_fn=lambda device: device.set_display_matrix_off(),
-            name="Turn Off Display Matrix"
+            key="display_off",
+            translation_key="display_off",
+            set_fn=lambda device: device.set_display_off(),
+            name="Turn Off Display"
+        ),
+        PetLibroButtonEntityDescription[OneRFIDSmartFeeder](
+            key="sound_on",
+            translation_key="sound_on",
+            set_fn=lambda device: device.set_sound_on(),
+            name="Turn On Sound"
+        ),
+        PetLibroButtonEntityDescription[OneRFIDSmartFeeder](
+            key="sound_off",
+            translation_key="sound_off",
+            set_fn=lambda device: device.set_sound_off(),
+            name="Turn Off Sound"
         )
+
     ],
     PolarWetFoodFeeder: [
     ],

--- a/custom_components/petlibro/button.py
+++ b/custom_components/petlibro/button.py
@@ -129,6 +129,18 @@ DEVICE_BUTTON_MAP: dict[type[Device], list[PetLibroButtonEntityDescription]] = {
             translation_key="manual_lid_open",
             set_fn=lambda device: device.set_manual_lid_open(),
             name="Manually Open Lid"
+        ),
+        PetLibroButtonEntityDescription[OneRFIDSmartFeeder](
+            key="display_matrix_on",
+            translation_key="display_matrix_on",
+            set_fn=lambda device: device.set_display_matrix_on(),
+            name="Turn On Display Matrix"
+        ),
+        PetLibroButtonEntityDescription[OneRFIDSmartFeeder](
+            key="display_matrix_off",
+            translation_key="display_matrix_off",
+            set_fn=lambda device: device.set_display_matrix_off(),
+            name="Turn Off Display Matrix"
         )
     ],
     PolarWetFoodFeeder: [

--- a/custom_components/petlibro/const.py
+++ b/custom_components/petlibro/const.py
@@ -9,7 +9,7 @@ CONF_API_TOKEN = "api_token"
 CONF_REGION = "region"
 
 # Supported platforms
-PLATFORMS = ["sensor", "switch", "button", "binary_sensor", "number"]  # Add any other platforms as needed
+PLATFORMS = ["sensor", "switch", "button", "binary_sensor", "number", "select"]  # Add any other platforms as needed
 
 # Update interval for device data in seconds
 UPDATE_INTERVAL_SECONDS = 60  # You can adjust this value based on your needs

--- a/custom_components/petlibro/devices/feeders/one_rfid_smart_feeder.py
+++ b/custom_components/petlibro/devices/feeders/one_rfid_smart_feeder.py
@@ -353,3 +353,29 @@ class OneRFIDSmartFeeder(Device):
         except aiohttp.ClientError as err:
             _LOGGER.error(f"Failed to trigger desiccant reset for {self.serial}: {err}")
             raise PetLibroAPIError(f"Error triggering desiccant reset: {err}")
+
+    @property
+    def lid_speed(self) -> str:
+        return self._data.get("getAttributeSetting", {}).get("coverCloseSpeed", "FAST")
+
+    async def set_lid_speed(self, value: str) -> None:
+        _LOGGER.debug(f"Setting lid speed to {value} for {self.serial}")
+        try:
+            await self.api.set_lid_speed(self.serial, value)
+            await self.refresh()  # Refresh the state after the action
+        except aiohttp.ClientError as err:
+            _LOGGER.error(f"Failed to set lid speed for {self.serial}: {err}")
+            raise PetLibroAPIError(f"Error setting lid speed: {err}")
+
+    @property
+    def lid_mode(self) -> str:
+        return self._data.get("getAttributeSetting", {}).get("coverOpenMode", "CUSTOM")
+
+    async def set_lid_mode(self, value: str) -> None:
+        _LOGGER.debug(f"Setting lid mode to {value} for {self.serial}")
+        try:
+            await self.api.set_lid_mode(self.serial, value)
+            await self.refresh()  # Refresh the state after the action
+        except aiohttp.ClientError as err:
+            _LOGGER.error(f"Failed to set lid mode for {self.serial}: {err}")
+            raise PetLibroAPIError(f"Error setting lid mode: {err}")

--- a/custom_components/petlibro/devices/feeders/one_rfid_smart_feeder.py
+++ b/custom_components/petlibro/devices/feeders/one_rfid_smart_feeder.py
@@ -355,8 +355,19 @@ class OneRFIDSmartFeeder(Device):
             raise PetLibroAPIError(f"Error triggering desiccant reset: {err}")
 
     @property
-    def lid_speed(self) -> str:
-        return self._data.get("getAttributeSetting", {}).get("coverCloseSpeed", "FAST")
+    def lid_mode(self) -> str:
+        """Return the user-friendly lid mode (mapped directly from the API value)."""
+        api_value = self._data.get("getAttributeSetting", {}).get("coverCloseSpeed", "FAST")
+        
+        # Direct mapping inside the property
+        if api_value == "FAST":
+            return "Fast"
+        elif api_value == "MEDIUM":
+            return "Medium"
+        elif api_value == "SLOW":
+            return "Slow"
+        else:
+            return "Unknown"
 
     async def set_lid_speed(self, value: str) -> None:
         _LOGGER.debug(f"Setting lid speed to {value} for {self.serial}")
@@ -369,7 +380,16 @@ class OneRFIDSmartFeeder(Device):
 
     @property
     def lid_mode(self) -> str:
-        return self._data.get("getAttributeSetting", {}).get("coverOpenMode", "CUSTOM")
+        """Return the user-friendly lid mode (mapped directly from the API value)."""
+        api_value = self._data.get("getAttributeSetting", {}).get("coverOpenMode", "CUSTOM")
+        
+        # Direct mapping inside the property
+        if api_value == "KEEP_OPEN":
+            return "Stay Open"
+        elif api_value == "CUSTOM":
+            return "Open On Detection"
+        else:
+            return "Unknown"
 
     async def set_lid_mode(self, value: str) -> None:
         _LOGGER.debug(f"Setting lid mode to {value} for {self.serial}")
@@ -379,3 +399,4 @@ class OneRFIDSmartFeeder(Device):
         except aiohttp.ClientError as err:
             _LOGGER.error(f"Failed to set lid mode for {self.serial}: {err}")
             raise PetLibroAPIError(f"Error setting lid mode: {err}")
+        

--- a/custom_components/petlibro/devices/feeders/one_rfid_smart_feeder.py
+++ b/custom_components/petlibro/devices/feeders/one_rfid_smart_feeder.py
@@ -402,7 +402,7 @@ class OneRFIDSmartFeeder(Device):
 
     @property
     def lid_close_time(self) -> float:
-        return self._data.get("getAttributeSetting", {}).get("volume", 0)
+        return self._data.get("getAttributeSetting", {}).get("closeDoorTimeSec", 0)
 
     async def set_lid_close_time(self, value: float) -> None:
         _LOGGER.debug(f"Setting lid close time to {value} for {self.serial}")

--- a/custom_components/petlibro/devices/feeders/one_rfid_smart_feeder.py
+++ b/custom_components/petlibro/devices/feeders/one_rfid_smart_feeder.py
@@ -50,15 +50,7 @@ class OneRFIDSmartFeeder(Device):
 
     @property
     def today_eating_time(self) -> int:
-        eating_time_str = self._data.get("grainStatus", {}).get("eatingTime", "0'0''")
-        if not eating_time_str:
-            return 0
-        try:
-            minutes, seconds = map(int, eating_time_str.replace("''", "").split("'"))
-            total_seconds = minutes * 60 + seconds
-        except ValueError:
-            return 0
-        return total_seconds
+        return self._data.get("grainStatus", {}).get("petEatingTime", 0)
 
     @property
     def feeding_plan_state(self) -> bool:

--- a/custom_components/petlibro/devices/feeders/one_rfid_smart_feeder.py
+++ b/custom_components/petlibro/devices/feeders/one_rfid_smart_feeder.py
@@ -279,3 +279,22 @@ class OneRFIDSmartFeeder(Device):
             _LOGGER.error(f"Failed to trigger manual lid opening for {self.serial}: {err}")
             raise PetLibroAPIError(f"Error triggering manual lid opening: {err}")
 
+    # Method for display matrix turn on
+    async def set_display_matrix_on(self) -> None:
+        _LOGGER.debug(f"Turning on the display matrix for {self.serial}")
+        try:
+            await self.api.set_display_matrix_on(self.serial)
+            await self.refresh()  # Refresh the state after the action
+        except aiohttp.ClientError as err:
+            _LOGGER.error(f"Failed to turn on the display matrix for {self.serial}: {err}")
+            raise PetLibroAPIError(f"Error turning on the display matrix: {err}")
+
+    # Method for display matrix turn off
+    async def set_display_matrix_off(self) -> None:
+        _LOGGER.debug(f"Turning off the display matrix for {self.serial}")
+        try:
+            await self.api.set_display_matrix_off(self.serial)
+            await self.refresh()  # Refresh the state after the action
+        except aiohttp.ClientError as err:
+            _LOGGER.error(f"Failed to turn off the display matrix for {self.serial}: {err}")
+            raise PetLibroAPIError(f"Error turning off the display matrix: {err}")

--- a/custom_components/petlibro/devices/feeders/one_rfid_smart_feeder.py
+++ b/custom_components/petlibro/devices/feeders/one_rfid_smart_feeder.py
@@ -385,9 +385,9 @@ class OneRFIDSmartFeeder(Device):
         
         # Direct mapping inside the property
         if api_value == "KEEP_OPEN":
-            return "Stay Open"
+            return "Open Mode (Stays Open Until Closed)"
         elif api_value == "CUSTOM":
-            return "Open On Detection"
+            return "Personal Mode (Opens on Detection)"
         else:
             return "Unknown"
 

--- a/custom_components/petlibro/devices/feeders/one_rfid_smart_feeder.py
+++ b/custom_components/petlibro/devices/feeders/one_rfid_smart_feeder.py
@@ -271,22 +271,42 @@ class OneRFIDSmartFeeder(Device):
             _LOGGER.error(f"Failed to trigger manual lid opening for {self.serial}: {err}")
             raise PetLibroAPIError(f"Error triggering manual lid opening: {err}")
 
-    # Method for display matrix turn on
-    async def set_display_matrix_on(self) -> None:
+    # Method for display turn on
+    async def set_display_on(self) -> None:
         _LOGGER.debug(f"Turning on the display matrix for {self.serial}")
         try:
-            await self.api.set_display_matrix_on(self.serial)
+            await self.api.set_display_on(self.serial)
             await self.refresh()  # Refresh the state after the action
         except aiohttp.ClientError as err:
-            _LOGGER.error(f"Failed to turn on the display matrix for {self.serial}: {err}")
-            raise PetLibroAPIError(f"Error turning on the display matrix: {err}")
+            _LOGGER.error(f"Failed to turn on the display for {self.serial}: {err}")
+            raise PetLibroAPIError(f"Error turning on the display: {err}")
 
     # Method for display matrix turn off
-    async def set_display_matrix_off(self) -> None:
-        _LOGGER.debug(f"Turning off the display matrix for {self.serial}")
+    async def set_display_off(self) -> None:
+        _LOGGER.debug(f"Turning off the display for {self.serial}")
         try:
-            await self.api.set_display_matrix_off(self.serial)
+            await self.api.set_display_off(self.serial)
             await self.refresh()  # Refresh the state after the action
         except aiohttp.ClientError as err:
-            _LOGGER.error(f"Failed to turn off the display matrix for {self.serial}: {err}")
-            raise PetLibroAPIError(f"Error turning off the display matrix: {err}")
+            _LOGGER.error(f"Failed to turn off the display for {self.serial}: {err}")
+            raise PetLibroAPIError(f"Error turning off the display: {err}")
+
+    # Method for sound turn on
+    async def set_sound_on(self) -> None:
+        _LOGGER.debug(f"Turning on the sound for {self.serial}")
+        try:
+            await self.api.set_sound_on(self.serial)
+            await self.refresh()  # Refresh the state after the action
+        except aiohttp.ClientError as err:
+            _LOGGER.error(f"Failed to turn on the sound for {self.serial}: {err}")
+            raise PetLibroAPIError(f"Error turning on the sound: {err}")
+
+    # Method for sound turn off
+    async def set_sound_off(self) -> None:
+        _LOGGER.debug(f"Turning off the sound for {self.serial}")
+        try:
+            await self.api.set_sound_off(self.serial)
+            await self.refresh()  # Refresh the state after the action
+        except aiohttp.ClientError as err:
+            _LOGGER.error(f"Failed to turn off the sound for {self.serial}: {err}")
+            raise PetLibroAPIError(f"Error turning off the sound: {err}")

--- a/custom_components/petlibro/devices/feeders/one_rfid_smart_feeder.py
+++ b/custom_components/petlibro/devices/feeders/one_rfid_smart_feeder.py
@@ -269,3 +269,13 @@ class OneRFIDSmartFeeder(Device):
             _LOGGER.error(f"Failed to set feeding plan for {self.serial}: {err}")
             raise PetLibroAPIError(f"Error setting feeding plan: {err}")
 
+    # Method for manual lid opening
+    async def set_manual_lid_open(self) -> None:
+        _LOGGER.debug(f"Triggering manual lid opening for {self.serial}")
+        try:
+            await self.api.set_manual_lid_open(self.serial)
+            await self.refresh()  # Refresh the state after the action
+        except aiohttp.ClientError as err:
+            _LOGGER.error(f"Failed to trigger manual lid opening for {self.serial}: {err}")
+            raise PetLibroAPIError(f"Error triggering manual lid opening: {err}")
+

--- a/custom_components/petlibro/devices/feeders/one_rfid_smart_feeder.py
+++ b/custom_components/petlibro/devices/feeders/one_rfid_smart_feeder.py
@@ -399,4 +399,16 @@ class OneRFIDSmartFeeder(Device):
         except aiohttp.ClientError as err:
             _LOGGER.error(f"Failed to set lid mode for {self.serial}: {err}")
             raise PetLibroAPIError(f"Error setting lid mode: {err}")
-        
+
+    @property
+    def lid_close_time(self) -> float:
+        return self._data.get("getAttributeSetting", {}).get("volume", 0)
+
+    async def set_lid_close_time(self, value: float) -> None:
+        _LOGGER.debug(f"Setting lid close time to {value} for {self.serial}")
+        try:
+            await self.api.set_lid_close_time(self.serial, value)
+            await self.refresh()  # Refresh the state after the action
+        except aiohttp.ClientError as err:
+            _LOGGER.error(f"Failed to set lid close time for {self.serial}: {err}")
+            raise PetLibroAPIError(f"Error setting lid close time: {err}")

--- a/custom_components/petlibro/devices/feeders/one_rfid_smart_feeder.py
+++ b/custom_components/petlibro/devices/feeders/one_rfid_smart_feeder.py
@@ -355,8 +355,8 @@ class OneRFIDSmartFeeder(Device):
             raise PetLibroAPIError(f"Error triggering desiccant reset: {err}")
 
     @property
-    def lid_mode(self) -> str:
-        """Return the user-friendly lid mode (mapped directly from the API value)."""
+    def lid_speed(self) -> str:
+        """Return the user-friendly lid speed (mapped directly from the API value)."""
         api_value = self._data.get("getAttributeSetting", {}).get("coverCloseSpeed", "FAST")
         
         # Direct mapping inside the property

--- a/custom_components/petlibro/number.py
+++ b/custom_components/petlibro/number.py
@@ -105,6 +105,18 @@ DEVICE_NUMBER_MAP: dict[type[Device], list[PetLibroNumberEntityDescription]] = {
             value=lambda device: device.sound_level,
             method=lambda device, value: device.set_sound_level(value),
             name="Sound Level"
+        ),
+        PetLibroNumberEntityDescription[OneRFIDSmartFeeder](
+            key="lid_close_time",
+            translation_key="lid_close_time",
+            icon="mdi:timer",
+            native_unit_of_measurement="s",
+            native_max_value=10,
+            native_min_value=1,
+            native_step=1,
+            value=lambda device: device.lid_close_time,
+            method=lambda device, value: device.set_lid_close_time(value),
+            name="Lid Close Time"
         )
     ]
 }

--- a/custom_components/petlibro/select.py
+++ b/custom_components/petlibro/select.py
@@ -40,8 +40,8 @@ from .entity import PetLibroEntity, _DeviceT, PetLibroEntityDescription
 class PetLibroSelectEntityDescription(SelectEntityDescription, PetLibroEntityDescription[_DeviceT]):
     """A class that describes device select entities."""
 
-    options: List[str]
     method: Callable[[_DeviceT, str], Awaitable[None]]
+    options: List[str]
     current_option: Callable[[_DeviceT], str] = lambda _: True
 
 class PetLibroSelectEntity(PetLibroEntity[_DeviceT], SelectEntity):

--- a/custom_components/petlibro/select.py
+++ b/custom_components/petlibro/select.py
@@ -104,7 +104,7 @@ DEVICE_SELECT_MAP: dict[type[Device], list[PetLibroSelectEntityDescription]] = {
         PetLibroSelectEntityDescription[OneRFIDSmartFeeder](
             key="lid_speed",
             translation_key="lid_speed",
-            icon="mdi:volume-high",
+            icon="mdi:speedometer",
             current_selection=lambda device: device.lid_speed,
             method=lambda device, current_selection: device.set_lid_speed(PetLibroSelectEntity.map_value_to_api(key="lid_speed", current_selection=current_selection)),
             options_list=['Slow','Medium','Fast'],
@@ -113,7 +113,7 @@ DEVICE_SELECT_MAP: dict[type[Device], list[PetLibroSelectEntityDescription]] = {
         PetLibroSelectEntityDescription[OneRFIDSmartFeeder](
             key="lid_mode",
             translation_key="lid_mode",
-            icon="mdi:volume-high",
+            icon="mdi:arrow-oscillating",
             current_selection=lambda device: device.lid_mode,
             method=lambda device, current_selection: device.set_lid_mode(PetLibroSelectEntity.map_value_to_api(key="lid_mode", current_selection=current_selection)),
             options_list=['Stay Open','Open On Detection'],

--- a/custom_components/petlibro/select.py
+++ b/custom_components/petlibro/select.py
@@ -42,7 +42,7 @@ class PetLibroSelectEntityDescription(SelectEntityDescription, PetLibroEntityDes
 
     method: Callable[[_DeviceT, str],  Any]
     options_list: list[str]
-    current_option: Callable[[_DeviceT], str] | None = None
+    current_selection: Callable[[_DeviceT], str] | None = None
 
 class PetLibroSelectEntity(PetLibroEntity[_DeviceT], SelectEntity):
     """PETLIBRO sensor entity."""
@@ -59,15 +59,15 @@ class PetLibroSelectEntity(PetLibroEntity[_DeviceT], SelectEntity):
         _LOGGER.debug(f"Retrieved current option for '{self.entity_description.key}', {self.device.name}: {state}")
         return str(state)
     
-    async def async_select_option(self, current_option: str) -> None:
+    async def async_select_option(self, current_selection: str) -> None:
         """Set the current_option of the select."""
-        _LOGGER.debug(f"Setting current option {current_option} for {self.device.name}")
+        _LOGGER.debug(f"Setting current option {current_selection} for {self.device.name}")
         try:
-            _LOGGER.debug(f"Calling method with current option={current_option} for {self.device.name}")
-            await self.entity_description.method(self.device, current_option)
-            _LOGGER.debug(f"Current option {current_option} set successfully for {self.device.name}")
+            _LOGGER.debug(f"Calling method with current option={current_selection} for {self.device.name}")
+            await self.entity_description.method(self.device, current_selection)
+            _LOGGER.debug(f"Current option {current_selection} set successfully for {self.device.name}")
         except Exception as e:
-            _LOGGER.error(f"Error setting current option {current_option} for {self.device.name}: {e}")
+            _LOGGER.error(f"Error setting current option {current_selection} for {self.device.name}: {e}")
 
     @staticmethod
     def map_value_to_api(*, key: str, value: str) -> str:
@@ -93,18 +93,18 @@ DEVICE_SELECT_MAP: dict[type[Device], list[PetLibroSelectEntityDescription]] = {
             key="lid_speed",
             translation_key="lid_speed",
             icon="mdi:volume-high",
-            method=lambda device, current_option: device.set_lid_speed(PetLibroSelectEntity.map_value_to_api("lid_speed",current_option)),
+            method=lambda device, current_selection: device.set_lid_speed(PetLibroSelectEntity.map_value_to_api("lid_speed",current_selection)),
             options_list=['Slow','Medium','Fast'],
-            current_option=lambda device: device.lid_speed,
+            current_selection=lambda device: device.lid_speed,
             name="Lid Speed"
         ),
         PetLibroSelectEntityDescription[OneRFIDSmartFeeder](
             key="lid_mode",
             translation_key="lid_mode",
             icon="mdi:volume-high",
-            method=lambda device, current_option: device.set_lid_speed(PetLibroSelectEntity.map_value_to_api("lid_mode",current_option)),
+            method=lambda device, current_selection: device.set_lid_speed(PetLibroSelectEntity.map_value_to_api("lid_mode",current_selection)),
             options_list=['Stay Open','Open On Detection'],
-            current_option=lambda device: device.lid_mode,
+            current_selection=lambda device: device.lid_mode,
             name="Lid Mode"
         )
     ]

--- a/custom_components/petlibro/select.py
+++ b/custom_components/petlibro/select.py
@@ -40,9 +40,9 @@ from .entity import PetLibroEntity, _DeviceT, PetLibroEntityDescription
 class PetLibroSelectEntityDescription(SelectEntityDescription, PetLibroEntityDescription[_DeviceT]):
     """A class that describes device select entities."""
 
-    options_list: list[str] = field(default_factory=list)
-    method: Callable[[_DeviceT, str], Any] = lambda _: True
-    current_selection: Callable[[_DeviceT], str] | None = None
+    options_list: list[str] = field(default_factory=list)  # Default to empty list
+    method: Callable[[_DeviceT, str], Any] = field(default=lambda _: True)  # Default lambda function
+    current_selection: Callable[[_DeviceT], str] | None = None  # Default to None
 
 class PetLibroSelectEntity(PetLibroEntity[_DeviceT], SelectEntity):
     """PETLIBRO sensor entity."""

--- a/custom_components/petlibro/select.py
+++ b/custom_components/petlibro/select.py
@@ -41,8 +41,8 @@ class PetLibroSelectEntityDescription(SelectEntityDescription, PetLibroEntityDes
     """A class that describes device select entities."""
 
     method: Callable[[_DeviceT, str], Awaitable[None]]
-    options: List[str] = field(default_factory=list)
-    current_option: Optional[Callable[[_DeviceT], str]] = None
+    options: list[str]
+    current_option: Optional[Callable[[_DeviceT], str]]
 class PetLibroSelectEntity(PetLibroEntity[_DeviceT], SelectEntity):
     """PETLIBRO sensor entity."""
 

--- a/custom_components/petlibro/select.py
+++ b/custom_components/petlibro/select.py
@@ -41,8 +41,9 @@ class PetLibroSelectEntityDescription(SelectEntityDescription, PetLibroEntityDes
     """A class that describes device select entities."""
 
     method: Callable[[_DeviceT, str],  Any]
-    options: list[str]
+    options_list: list[str]
     current_option: Callable[[_DeviceT], str] | None = None
+
 class PetLibroSelectEntity(PetLibroEntity[_DeviceT], SelectEntity):
     """PETLIBRO sensor entity."""
 
@@ -93,7 +94,7 @@ DEVICE_SELECT_MAP: dict[type[Device], list[PetLibroSelectEntityDescription]] = {
             translation_key="lid_speed",
             icon="mdi:volume-high",
             method=lambda device, current_option: device.set_lid_speed(PetLibroSelectEntity.map_value_to_api("lid_speed",current_option)),
-            options=['Slow','Medium','Fast'],
+            options_list=['Slow','Medium','Fast'],
             current_option=lambda device: device.lid_speed,
             name="Lid Speed"
         ),
@@ -102,7 +103,7 @@ DEVICE_SELECT_MAP: dict[type[Device], list[PetLibroSelectEntityDescription]] = {
             translation_key="lid_mode",
             icon="mdi:volume-high",
             method=lambda device, current_option: device.set_lid_speed(PetLibroSelectEntity.map_value_to_api("lid_mode",current_option)),
-            options=['Stay Open','Open On Detection'],
+            options_list=['Stay Open','Open On Detection'],
             current_option=lambda device: device.lid_mode,
             name="Lid Mode"
         )

--- a/custom_components/petlibro/select.py
+++ b/custom_components/petlibro/select.py
@@ -40,9 +40,9 @@ from .entity import PetLibroEntity, _DeviceT, PetLibroEntityDescription
 class PetLibroSelectEntityDescription(SelectEntityDescription, PetLibroEntityDescription[_DeviceT]):
     """A class that describes device select entities."""
 
-    method: Callable[[_DeviceT, str], Awaitable[None]]
+    method: Callable[[_DeviceT, str],  Any]
     options: list[str]
-    current_option: Optional[Callable[[_DeviceT], str]]
+    current_option: Callable[[_DeviceT], str] | None = None
 class PetLibroSelectEntity(PetLibroEntity[_DeviceT], SelectEntity):
     """PETLIBRO sensor entity."""
 

--- a/custom_components/petlibro/select.py
+++ b/custom_components/petlibro/select.py
@@ -70,7 +70,7 @@ class PetLibroSelectEntity(PetLibroEntity[_DeviceT], SelectEntity):
             _LOGGER.error(f"Error setting current option {current_selection} for {self.device.name}: {e}")
 
     @staticmethod
-    def map_value_to_api(*, key: str, value: str) -> str:
+    def map_value_to_api(*, key: str, current_selection: str) -> str:
         """Map user-friendly values to API-compatible values."""
         mappings = {
             "lid_speed": {
@@ -83,7 +83,7 @@ class PetLibroSelectEntity(PetLibroEntity[_DeviceT], SelectEntity):
                 "Open On Detection": "CUSTOM"
             }
         }
-        return mappings.get(key, {}).get(value, "unknown")
+        return mappings.get(key, {}).get(current_selection, "unknown")
 
 DEVICE_SELECT_MAP: dict[type[Device], list[PetLibroSelectEntityDescription]] = {
     Feeder: [

--- a/custom_components/petlibro/select.py
+++ b/custom_components/petlibro/select.py
@@ -106,9 +106,7 @@ DEVICE_SELECT_MAP: dict[type[Device], list[PetLibroSelectEntityDescription]] = {
             translation_key="lid_speed",
             icon="mdi:volume-high",
             current_selection=lambda device: device.lid_speed,
-            method=lambda device, current_selection: device.set_lid_speed(
-                PetLibroSelectEntity.map_value_to_api(key="lid_speed", current_selection=current_selection)
-            ),
+            method=lambda device, current_selection: device.set_lid_speed(PetLibroSelectEntity.map_value_to_api(key="lid_speed", current_selection=current_selection)),
             options_list=['Slow','Medium','Fast'],
             name="Lid Speed"
         ),
@@ -117,9 +115,7 @@ DEVICE_SELECT_MAP: dict[type[Device], list[PetLibroSelectEntityDescription]] = {
             translation_key="lid_mode",
             icon="mdi:volume-high",
             current_selection=lambda device: device.lid_mode,
-            method=lambda device, current_selection: device.set_lid_mode(
-                PetLibroSelectEntity.map_value_to_api(key="lid_mode", current_selection=current_selection)
-            ),
+            method=lambda device, current_selection: device.set_lid_mode(PetLibroSelectEntity.map_value_to_api(key="lid_mode", current_selection=current_selection)),
             options_list=['Stay Open','Open On Detection'],
             name="Lid Mode"
         )

--- a/custom_components/petlibro/select.py
+++ b/custom_components/petlibro/select.py
@@ -40,9 +40,9 @@ from .entity import PetLibroEntity, _DeviceT, PetLibroEntityDescription
 class PetLibroSelectEntityDescription(SelectEntityDescription, PetLibroEntityDescription[_DeviceT]):
     """A class that describes device select entities."""
 
-    current_selection: Callable[[_DeviceT], str] | None = None
-    method: Callable[[_DeviceT, str],  Any] = lambda _: True
     options_list: list[str]
+    method: Callable[[_DeviceT, str],  Any] = lambda _: True
+    current_selection: Callable[[_DeviceT], str] | None = None
 
 class PetLibroSelectEntity(PetLibroEntity[_DeviceT], SelectEntity):
     """PETLIBRO sensor entity."""

--- a/custom_components/petlibro/select.py
+++ b/custom_components/petlibro/select.py
@@ -15,8 +15,6 @@ from .const import DOMAIN
 from homeassistant.components.select import (
     SelectEntity,
     SelectEntityDescription,
-    SelectDeviceClass,
-
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -45,17 +43,11 @@ class PetLibroSelectEntityDescription(SelectEntityDescription, PetLibroEntityDes
     current_option: Callable[[_DeviceT], str] = lambda _: True
     options: List[str]
     method: Callable[[_DeviceT, str], Awaitable[None]]
-    device_class: Optional[SelectDeviceClass] = None
 
 class PetLibroSelectEntity(PetLibroEntity[_DeviceT], SelectEntity):
     """PETLIBRO sensor entity."""
 
     entity_description: PetLibroSelectEntityDescription[_DeviceT]
-
-    @cached_property
-    def device_class(self) -> SelectDeviceClass | None:
-        """Return the device class to use in the frontend, if any."""
-        return self.entity_description.device_class
 
     @property
     def current_option(self) -> str:

--- a/custom_components/petlibro/select.py
+++ b/custom_components/petlibro/select.py
@@ -40,8 +40,8 @@ from .entity import PetLibroEntity, _DeviceT, PetLibroEntityDescription
 class PetLibroSelectEntityDescription(SelectEntityDescription, PetLibroEntityDescription[_DeviceT]):
     """A class that describes device select entities."""
 
-    options_list: list[str]
-    method: Callable[[_DeviceT, str],  Any] = lambda _: True
+    options_list: list[str] = field(default_factory=list)
+    method: Callable[[_DeviceT, str], Any] = lambda _: True
     current_selection: Callable[[_DeviceT], str] | None = None
 
 class PetLibroSelectEntity(PetLibroEntity[_DeviceT], SelectEntity):

--- a/custom_components/petlibro/select.py
+++ b/custom_components/petlibro/select.py
@@ -40,9 +40,9 @@ from .entity import PetLibroEntity, _DeviceT, PetLibroEntityDescription
 class PetLibroSelectEntityDescription(SelectEntityDescription, PetLibroEntityDescription[_DeviceT]):
     """A class that describes device select entities."""
 
-    method: Callable[[_DeviceT, str],  Any]
-    options_list: list[str]
     current_selection: Callable[[_DeviceT], str] | None = None
+    method: Callable[[_DeviceT, str],  Any] = lambda _: True
+    options_list: list[str]
 
 class PetLibroSelectEntity(PetLibroEntity[_DeviceT], SelectEntity):
     """PETLIBRO sensor entity."""
@@ -93,18 +93,18 @@ DEVICE_SELECT_MAP: dict[type[Device], list[PetLibroSelectEntityDescription]] = {
             key="lid_speed",
             translation_key="lid_speed",
             icon="mdi:volume-high",
+            current_selection=lambda device: device.lid_speed,
             method=lambda device, current_selection: device.set_lid_speed(PetLibroSelectEntity.map_value_to_api("lid_speed",current_selection)),
             options_list=['Slow','Medium','Fast'],
-            current_selection=lambda device: device.lid_speed,
             name="Lid Speed"
         ),
         PetLibroSelectEntityDescription[OneRFIDSmartFeeder](
             key="lid_mode",
             translation_key="lid_mode",
             icon="mdi:volume-high",
+            current_selection=lambda device: device.lid_mode,
             method=lambda device, current_selection: device.set_lid_speed(PetLibroSelectEntity.map_value_to_api("lid_mode",current_selection)),
             options_list=['Stay Open','Open On Detection'],
-            current_selection=lambda device: device.lid_mode,
             name="Lid Mode"
         )
     ]

--- a/custom_components/petlibro/select.py
+++ b/custom_components/petlibro/select.py
@@ -108,7 +108,7 @@ DEVICE_SELECT_MAP: dict[type[Device], list[PetLibroSelectEntityDescription]] = {
             current_selection=lambda device: device.lid_speed,
             method=lambda device, current_selection: device.set_lid_speed(
                 PetLibroSelectEntity.map_value_to_api(key="lid_speed", current_selection=current_selection)
-            )
+            ),
             options_list=['Slow','Medium','Fast'],
             name="Lid Speed"
         ),
@@ -119,7 +119,7 @@ DEVICE_SELECT_MAP: dict[type[Device], list[PetLibroSelectEntityDescription]] = {
             current_selection=lambda device: device.lid_mode,
             method=lambda device, current_selection: device.set_lid_mode(
                 PetLibroSelectEntity.map_value_to_api(key="lid_mode", current_selection=current_selection)
-            )
+            ),
             options_list=['Stay Open','Open On Detection'],
             name="Lid Mode"
         )

--- a/custom_components/petlibro/select.py
+++ b/custom_components/petlibro/select.py
@@ -1,0 +1,164 @@
+"""Support for PETLIBRO selects."""
+from __future__ import annotations
+from .api import make_api_call
+import aiohttp
+from aiohttp import ClientSession, ClientError
+from dataclasses import dataclass
+from dataclasses import dataclass, field
+from collections.abc import Callable
+from functools import cached_property
+from typing import Optional
+from typing import Any
+from typing import List, Awaitable
+import logging
+from .const import DOMAIN
+from homeassistant.components.select import (
+    SelectEntity,
+    SelectEntityDescription,
+    SelectDeviceClass,
+
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.config_entries import ConfigEntry  # Added ConfigEntry import
+from .hub import PetLibroHub  # Adjust the import path as necessary
+
+
+_LOGGER = logging.getLogger(__name__)
+
+from .devices import Device
+from .devices.device import Device
+from .devices.feeders.feeder import Feeder
+from .devices.feeders.air_smart_feeder import AirSmartFeeder
+from .devices.feeders.granary_smart_feeder import GranarySmartFeeder
+from .devices.feeders.granary_smart_camera_feeder import GranarySmartCameraFeeder
+from .devices.feeders.one_rfid_smart_feeder import OneRFIDSmartFeeder
+from .devices.feeders.polar_wet_food_feeder import PolarWetFoodFeeder
+from .devices.fountains.dockstream_smart_fountain import DockstreamSmartFountain
+from .devices.fountains.dockstream_smart_rfid_fountain import DockstreamSmartRFIDFountain
+from .entity import PetLibroEntity, _DeviceT, PetLibroEntityDescription
+
+@dataclass(frozen=True)
+class PetLibroSelectEntityDescription(SelectEntityDescription, PetLibroEntityDescription[_DeviceT]):
+    """A class that describes device select entities."""
+
+    current_option: Callable[[_DeviceT], str] = lambda _: True
+    options: List[str]
+    method: Callable[[_DeviceT, str], Awaitable[None]]
+    device_class: Optional[SelectDeviceClass] = None
+
+class PetLibroSelectEntity(PetLibroEntity[_DeviceT], SelectEntity):
+    """PETLIBRO sensor entity."""
+
+    entity_description: PetLibroSelectEntityDescription[_DeviceT]
+
+    @cached_property
+    def device_class(self) -> SelectDeviceClass | None:
+        """Return the device class to use in the frontend, if any."""
+        return self.entity_description.device_class
+
+    @property
+    def current_option(self) -> str:
+        """Return the current current_option."""
+        state = getattr(self.device, self.entity_description.key, None)
+        if state is None:
+            _LOGGER.warning(f"Current option '{self.entity_description.key}' is None for device {self.device.name}")
+            return None
+        _LOGGER.debug(f"Retrieved current option for '{self.entity_description.key}', {self.device.name}: {state}")
+        return str(state)
+    
+    async def async_select_option(self, current_option: str) -> None:
+        """Set the current_option of the select."""
+        _LOGGER.debug(f"Setting current option {current_option} for {self.device.name}")
+        try:
+            _LOGGER.debug(f"Calling method with current option={current_option} for {self.device.name}")
+            await self.entity_description.method(self.device, current_option)
+            _LOGGER.debug(f"Current option {current_option} set successfully for {self.device.name}")
+        except Exception as e:
+            _LOGGER.error(f"Error setting current option {current_option} for {self.device.name}: {e}")
+
+    @staticmethod
+    def map_value_to_api(key: str, value: str) -> str:
+        """Map user-friendly values to API-compatible values."""
+        mappings = {
+            "lid_speed": {
+                "Slow": "SLOW",
+                "Medium": "MEDIUM",
+                "Fast": "FAST"
+            },
+            "lid_mode": {
+                "Stay Open": "KEEP_OPEN",
+                "Open On Detection": "CUSTOM"
+            }
+        }
+        return mappings.get(key, {}).get(value, "unknown")
+
+DEVICE_SELECT_MAP: dict[type[Device], list[PetLibroSelectEntityDescription]] = {
+    Feeder: [
+    ],
+    OneRFIDSmartFeeder: [
+        PetLibroSelectEntityDescription[OneRFIDSmartFeeder](
+            key="lid_speed",
+            translation_key="lid_speed",
+            icon="mdi:volume-high",
+            current_option=lambda device: device.lid_speed,
+            options=['Slow','Medium','Fast'],
+            method=lambda device, current_option: device.set_lid_speed(PetLibroSelectEntity.map_value_to_api("lid_speed",current_option)),
+            name="Lid Speed"
+        ),
+        PetLibroSelectEntityDescription[OneRFIDSmartFeeder](
+            key="lid_mode",
+            translation_key="lid_mode",
+            icon="mdi:volume-high",
+            current_option=lambda device: device.lid_mode,
+            options=['Stay Open','Open On Detection'],
+            method=lambda device, current_option: device.set_lid_speed(PetLibroSelectEntity.map_value_to_api("lid_mode",current_option)),
+            name="Lid Mode"
+        )
+    ]
+}
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,  # Use ConfigEntry
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up PETLIBRO select using config entry."""
+    # Retrieve the hub from hass.data that was set up in __init__.py
+    hub = hass.data[DOMAIN].get(entry.entry_id)
+
+    if not hub:
+        _LOGGER.error("Hub not found for entry: %s", entry.entry_id)
+        return
+
+    # Ensure that the devices are loaded (if load_devices is not already called elsewhere)
+    if not hub.devices:
+        _LOGGER.warning("No devices found in hub during select setup.")
+        return
+
+    # Log the contents of the hub data for debugging
+    _LOGGER.debug("Hub data: %s", hub)
+
+    devices = hub.devices  # Devices should already be loaded in the hub
+    _LOGGER.debug("Devices in hub: %s", devices)
+
+    # Create select entities for each device based on the select map
+    entities = [
+        PetLibroSelectEntity(device, hub, description)
+        for device in devices  # Iterate through devices from the hub
+        for device_type, entity_descriptions in DEVICE_SELECT_MAP.items()
+        if isinstance(device, device_type)
+        for description in entity_descriptions
+    ]
+
+    if not entities:
+        _LOGGER.warning("No select entities added, entities list is empty!")
+    else:
+        # Log the select of entities and their details
+        _LOGGER.debug("Adding %d PetLibro select entities", len(entities))
+        for entity in entities:
+            _LOGGER.debug("Adding select entity: %s for device %s", entity.entity_description.name, entity.device.name)
+
+        # Add select entities to Home Assistant
+        async_add_entities(entities)
+

--- a/custom_components/petlibro/select.py
+++ b/custom_components/petlibro/select.py
@@ -91,8 +91,8 @@ class PetLibroSelectEntity(PetLibroEntity[_DeviceT], SelectEntity):
                 "Fast": "FAST"
             },
             "lid_mode": {
-                "Stay Open": "KEEP_OPEN",
-                "Open On Detection": "CUSTOM"
+                "Open Mode (Stays Open Until Closed)": "KEEP_OPEN",
+                "Personal Mode (Opens on Detection)": "CUSTOM"
             }
         }
         return mappings.get(key, {}).get(current_selection, "unknown")
@@ -116,7 +116,7 @@ DEVICE_SELECT_MAP: dict[type[Device], list[PetLibroSelectEntityDescription]] = {
             icon="mdi:arrow-oscillating",
             current_selection=lambda device: device.lid_mode,
             method=lambda device, current_selection: device.set_lid_mode(PetLibroSelectEntity.map_value_to_api(key="lid_mode", current_selection=current_selection)),
-            options_list=['Stay Open','Open On Detection'],
+            options_list=['Open Mode (Stays Open Until Closed)','Personal Mode (Opens on Detection)'],
             name="Lid Mode"
         )
     ]

--- a/custom_components/petlibro/select.py
+++ b/custom_components/petlibro/select.py
@@ -50,7 +50,7 @@ class PetLibroSelectEntity(PetLibroEntity[_DeviceT], SelectEntity):
     entity_description: PetLibroSelectEntityDescription[_DeviceT]
 
     @property
-    def current_option(self) -> str:
+    def current_option(self) -> str | None:
         """Return the current current_option."""
         state = getattr(self.device, self.entity_description.key, None)
         if state is None:

--- a/custom_components/petlibro/select.py
+++ b/custom_components/petlibro/select.py
@@ -42,8 +42,7 @@ class PetLibroSelectEntityDescription(SelectEntityDescription, PetLibroEntityDes
 
     method: Callable[[_DeviceT, str], Awaitable[None]]
     options: List[str]
-    current_option: Callable[[_DeviceT], str] = lambda _: True
-
+    current_option: Optional[Callable[[_DeviceT], str]]
 class PetLibroSelectEntity(PetLibroEntity[_DeviceT], SelectEntity):
     """PETLIBRO sensor entity."""
 
@@ -93,18 +92,18 @@ DEVICE_SELECT_MAP: dict[type[Device], list[PetLibroSelectEntityDescription]] = {
             key="lid_speed",
             translation_key="lid_speed",
             icon="mdi:volume-high",
-            current_option=lambda device: device.lid_speed,
-            options=['Slow','Medium','Fast'],
             method=lambda device, current_option: device.set_lid_speed(PetLibroSelectEntity.map_value_to_api("lid_speed",current_option)),
+            options=['Slow','Medium','Fast'],
+            current_option=lambda device: device.lid_speed,
             name="Lid Speed"
         ),
         PetLibroSelectEntityDescription[OneRFIDSmartFeeder](
             key="lid_mode",
             translation_key="lid_mode",
             icon="mdi:volume-high",
-            current_option=lambda device: device.lid_mode,
-            options=['Stay Open','Open On Detection'],
             method=lambda device, current_option: device.set_lid_speed(PetLibroSelectEntity.map_value_to_api("lid_mode",current_option)),
+            options=['Stay Open','Open On Detection'],
+            current_option=lambda device: device.lid_mode,
             name="Lid Mode"
         )
     ]

--- a/custom_components/petlibro/select.py
+++ b/custom_components/petlibro/select.py
@@ -40,9 +40,9 @@ from .entity import PetLibroEntity, _DeviceT, PetLibroEntityDescription
 class PetLibroSelectEntityDescription(SelectEntityDescription, PetLibroEntityDescription[_DeviceT]):
     """A class that describes device select entities."""
 
-    current_option: Callable[[_DeviceT], str] = lambda _: True
     options: List[str]
     method: Callable[[_DeviceT, str], Awaitable[None]]
+    current_option: Callable[[_DeviceT], str] = lambda _: True
 
 class PetLibroSelectEntity(PetLibroEntity[_DeviceT], SelectEntity):
     """PETLIBRO sensor entity."""
@@ -70,7 +70,7 @@ class PetLibroSelectEntity(PetLibroEntity[_DeviceT], SelectEntity):
             _LOGGER.error(f"Error setting current option {current_option} for {self.device.name}: {e}")
 
     @staticmethod
-    def map_value_to_api(key: str, value: str) -> str:
+    def map_value_to_api(*, key: str, value: str) -> str:
         """Map user-friendly values to API-compatible values."""
         mappings = {
             "lid_speed": {

--- a/custom_components/petlibro/select.py
+++ b/custom_components/petlibro/select.py
@@ -50,6 +50,18 @@ class PetLibroSelectEntity(PetLibroEntity[_DeviceT], SelectEntity):
     entity_description: PetLibroSelectEntityDescription[_DeviceT]
 
     @property
+    def options(self) -> list[str]:
+        """Return the list of available options for the select."""
+        # This should return the options that are available for selection.
+        # Use the options_list field from the entity_description.
+        if self.entity_description.options_list:
+            return self.entity_description.options_list
+        else:
+            # If there are no options, return an empty list or log an error.
+            _LOGGER.error(f"No options available for select entity {self.name}")
+            return []
+
+    @property
     def current_option(self) -> str | None:
         """Return the current current_option."""
         state = getattr(self.device, self.entity_description.key, None)

--- a/custom_components/petlibro/select.py
+++ b/custom_components/petlibro/select.py
@@ -41,8 +41,8 @@ class PetLibroSelectEntityDescription(SelectEntityDescription, PetLibroEntityDes
     """A class that describes device select entities."""
 
     method: Callable[[_DeviceT, str], Awaitable[None]]
-    options: List[str]
-    current_option: Optional[Callable[[_DeviceT], str]]
+    options: List[str] = field(default_factory=list)
+    current_option: Optional[Callable[[_DeviceT], str]] = None
 class PetLibroSelectEntity(PetLibroEntity[_DeviceT], SelectEntity):
     """PETLIBRO sensor entity."""
 

--- a/custom_components/petlibro/select.py
+++ b/custom_components/petlibro/select.py
@@ -106,7 +106,9 @@ DEVICE_SELECT_MAP: dict[type[Device], list[PetLibroSelectEntityDescription]] = {
             translation_key="lid_speed",
             icon="mdi:volume-high",
             current_selection=lambda device: device.lid_speed,
-            method=lambda device, current_selection: device.set_lid_speed(PetLibroSelectEntity.map_value_to_api("lid_speed",current_selection)),
+            method=lambda device, current_selection: device.set_lid_speed(
+                PetLibroSelectEntity.map_value_to_api(key="lid_speed", current_selection=current_selection)
+            )
             options_list=['Slow','Medium','Fast'],
             name="Lid Speed"
         ),
@@ -115,7 +117,9 @@ DEVICE_SELECT_MAP: dict[type[Device], list[PetLibroSelectEntityDescription]] = {
             translation_key="lid_mode",
             icon="mdi:volume-high",
             current_selection=lambda device: device.lid_mode,
-            method=lambda device, current_selection: device.set_lid_speed(PetLibroSelectEntity.map_value_to_api("lid_mode",current_selection)),
+            method=lambda device, current_selection: device.set_lid_mode(
+                PetLibroSelectEntity.map_value_to_api(key="lid_mode", current_selection=current_selection)
+            )
             options_list=['Stay Open','Open On Detection'],
             name="Lid Mode"
         )

--- a/custom_components/petlibro/translations/de.json
+++ b/custom_components/petlibro/translations/de.json
@@ -200,6 +200,14 @@
             "desiccant_frequency": {
                 "name": "Trockenmittel Häufigkeit"
             }
+        },
+        "select": {
+            "lid_speed": {
+                "name": "Deckelgeschwindigkeit"
+            },
+            "lid_mode": {
+                "name": "Deckelmodus"
+            }
         }
     }
 }

--- a/custom_components/petlibro/translations/de.json
+++ b/custom_components/petlibro/translations/de.json
@@ -206,19 +206,10 @@
         },
         "select": {
             "lid_speed": {
-                "name": "Deckelgeschwindigkeit",
-                "options": {
-                    "Slow": "Langsam",
-                    "Medium": "Mittel",
-                    "Fast": "Schnell"
-                }
+                "name": "Deckelgeschwindigkeit"
             },
             "lid_mode": {
-                "name": "Deckelmodus",
-                "options": {
-                    "Open Mode (Stays Open Until Closed)": "Offener Modus (Bleibt offen, bis er geschlossen wird)",
-                    "Personal Mode (Opens on Detection)": "Persönlicher Modus (Öffnet sich bei Erkennung)"
-                }
+                "name": "Deckelmodus"
             }
         }
     }

--- a/custom_components/petlibro/translations/de.json
+++ b/custom_components/petlibro/translations/de.json
@@ -199,6 +199,9 @@
             },
             "desiccant_frequency": {
                 "name": "Trockenmittel Häufigkeit"
+            },
+            "lid_close_time": {
+                "name": "Deckelschließzeit"
             }
         },
         "select": {

--- a/custom_components/petlibro/translations/de.json
+++ b/custom_components/petlibro/translations/de.json
@@ -206,10 +206,19 @@
         },
         "select": {
             "lid_speed": {
-                "name": "Deckelgeschwindigkeit"
+                "name": "Deckelgeschwindigkeit",
+                "options": {
+                    "Slow": "Langsam",
+                    "Medium": "Mittel",
+                    "Fast": "Schnell"
+                }
             },
             "lid_mode": {
-                "name": "Deckelmodus"
+                "name": "Deckelmodus",
+                "options": {
+                    "Open Mode (Stays Open Until Closed)": "Offener Modus (Bleibt offen, bis er geschlossen wird)",
+                    "Personal Mode (Opens on Detection)": "Persönlicher Modus (Öffnet sich bei Erkennung)"
+                }
             }
         }
     }

--- a/custom_components/petlibro/translations/en.json
+++ b/custom_components/petlibro/translations/en.json
@@ -214,21 +214,21 @@
             }
         },
         "select": {
-        "lid_speed": {
-            "name": "Lid Speed",
-            "options": {
-                "Slow": "Slow",
-                "Medium": "Medium",
-                "Fast": "Fast"
+            "lid_speed": {
+                "name": "Lid Speed",
+                "options": {
+                    "Slow": "Slow",
+                    "Medium": "Medium",
+                    "Fast": "Fast"
+                }
+            },
+            "lid_mode": {
+                "name": "Lid Mode",
+                "options": {
+                    "Open Mode (Stays Open Until Closed)": "Open Mode (Stays Open Until Closed)",
+                    "Personal Mode (Opens on Detection)": "Personal Mode (Opens on Detection)"
+                }
             }
-        },
-        "lid_mode": {
-            "name": "Lid Mode",
-            "options": {
-                "Open Mode (Stays Open Until Closed)": "Open Mode (Stays Open Until Closed)",
-                "Personal Mode (Opens on Detection)": "Personal Mode (Opens on Detection)"
-            }
-        }
         }
     }
 }

--- a/custom_components/petlibro/translations/en.json
+++ b/custom_components/petlibro/translations/en.json
@@ -215,19 +215,10 @@
         },
         "select": {
             "lid_speed": {
-                "name": "Lid Speed",
-                "options": {
-                    "Slow": "Slow",
-                    "Medium": "Medium",
-                    "Fast": "Fast"
-                }
+                "name": "Lid Speed"
             },
             "lid_mode": {
-                "name": "Lid Mode",
-                "options": {
-                    "Open Mode (Stays Open Until Closed)": "Open Mode (Stays Open Until Closed)",
-                    "Personal Mode (Opens on Detection)": "Personal Mode (Opens on Detection)"
-                }
+                "name": "Lid Mode"
             }
         }
     }

--- a/custom_components/petlibro/translations/en.json
+++ b/custom_components/petlibro/translations/en.json
@@ -135,6 +135,9 @@
             },
             "disable_feeding_plan": {
                 "name": "Disable Feeding Plan"
+            },
+            "manual_lid_open": {
+                "name": "Manually Open Lid"
             }
         },
         "binary_sensor": {

--- a/custom_components/petlibro/translations/en.json
+++ b/custom_components/petlibro/translations/en.json
@@ -209,6 +209,14 @@
             "desiccant_frequency": {
                 "name": "Desiccant Frequency"
             }
+        },
+        "select": {
+            "lid_speed": {
+                "name": "Lid Speed"
+            },
+            "lid_mode": {
+                "name": "Lid Mode"
+            }
         }
     }
 }

--- a/custom_components/petlibro/translations/en.json
+++ b/custom_components/petlibro/translations/en.json
@@ -208,6 +208,9 @@
             },
             "desiccant_frequency": {
                 "name": "Desiccant Frequency"
+            },
+            "lid_close_time": {
+                "name": "Lid Close Time"
             }
         },
         "select": {

--- a/custom_components/petlibro/translations/en.json
+++ b/custom_components/petlibro/translations/en.json
@@ -139,11 +139,17 @@
             "manual_lid_open": {
                 "name": "Manually Open Lid"
             },
-            "display_matrix_on": {
-                "name": "Turn On Display Matrix"
+            "display_on": {
+                "name": "Turn On Display"
             },
-            "display_matrix_off": {
-                "name": "Turn Off Display Matrix"
+            "display_off": {
+                "name": "Turn Off Display"
+            },
+            "sound_on": {
+                "name": "Turn On Sound"
+            },
+            "sound_off": {
+                "name": "Turn Off Sound"
             }
         },
         "binary_sensor": {

--- a/custom_components/petlibro/translations/en.json
+++ b/custom_components/petlibro/translations/en.json
@@ -138,6 +138,12 @@
             },
             "manual_lid_open": {
                 "name": "Manually Open Lid"
+            },
+            "display_matrix_on": {
+                "name": "Turn On Display Matrix"
+            },
+            "display_matrix_off": {
+                "name": "Turn Off Display Matrix"
             }
         },
         "binary_sensor": {

--- a/custom_components/petlibro/translations/en.json
+++ b/custom_components/petlibro/translations/en.json
@@ -214,12 +214,21 @@
             }
         },
         "select": {
-            "lid_speed": {
-                "name": "Lid Speed"
-            },
-            "lid_mode": {
-                "name": "Lid Mode"
+        "lid_speed": {
+            "name": "Lid Speed",
+            "options": {
+                "Slow": "Slow",
+                "Medium": "Medium",
+                "Fast": "Fast"
             }
+        },
+        "lid_mode": {
+            "name": "Lid Mode",
+            "options": {
+                "Open Mode (Stays Open Until Closed)": "Open Mode (Stays Open Until Closed)",
+                "Personal Mode (Opens on Detection)": "Personal Mode (Opens on Detection)"
+            }
+        }
         }
     }
 }


### PR DESCRIPTION
<!--
==== STOP ====================
======== STOP ================
============ STOP ============
================ STOP ========
==================== STOP ====

⚠️ Before opening this pull request please review the guidelines in the checklist below.

If this PR does not meet those guidelines it will not be accepted, and everyone will be sad.
-->

## Add Support for Lid Mode, Lid Speed, and Lid Close Time for OneRFIDSmartFeeder PLAF301


Support for changing devices lid mode, from Keep Open to Personal Mode or Vice Versa:
![image](https://github.com/user-attachments/assets/7aa8bcd9-dee5-40cc-831d-dc17cb7a1edf)
Support for changing devices lid speed (opening and closing speed, how fast the physical mechanism moves, not how long it takes to start moving):
![image](https://github.com/user-attachments/assets/dc34d91e-77ad-4b07-be43-b317cd5acf02)
Support for changing devices lid close time (how long before it starts closing after no longer detecting pet):
![image](https://github.com/user-attachments/assets/3d7885a0-8319-4cee-b2cb-e640301d1dcd)

Closes #51 Closes #28 

## Type of change

- [ X] New feature or enhancement (non-breaking change which adds functionality).

## Checklist:

- [ X] If applicable, I have added corresponding documentation changes.
- [ X] If applicable, I have reviewed the [feature / enhancement](https://github.com/jjjonesjr33/petlibro/wiki/Feature-&-Enhancement-Guidelines) guidlines before submitting my request.
- [ X] If applicable, I have tested my code for new features & regressions on the latest version of Home Assistant.
