### PR TITLE
Add Support for Setting the Manual Feed Amount for Air Smart Feeders

### DIFF
--- a/custom_components/petlibro/api.py
+++ b/custom_components/petlibro/api.py
@@ -483,11 +483,10 @@ class PetLibroAPI:
             _LOGGER.error(f"Failed to set lid mode for device {serial}: {e}")
             raise
 
-    async def set_manual_feed(self, serial: str) -> JSON:
-    async def set_manual_feed(self, serial: str, feed_value: int) -> JSON:
+
+    async def set_manual_feed(self, serial: str, feed_value=1) -> JSON: # Provide a default argument for the feed value just in case this works differently with other feeders
         """Trigger manual feeding for a specific device."""
         _LOGGER.debug(f"Triggering manual feeding for device with serial: {serial}")
-
         try:
             # Generate a dynamic request ID for the manual feeding
             request_id = str(uuid.uuid4()).replace("-", "")
@@ -495,7 +494,7 @@ class PetLibroAPI:
             # Send the POST request to trigger manual feeding
             response = await self.session.post("/device/device/manualFeeding", json={
                 "deviceSn": serial,
-                "grainNum": feed_value,  # Number of grains dispensed
+                "grainNum": int(feed_value),  # Number of grains dispensed, make sure it's an integer and not a float
                 "requestId": request_id  # Use dynamic request ID
             })
 

--- a/custom_components/petlibro/api.py
+++ b/custom_components/petlibro/api.py
@@ -434,10 +434,10 @@ class PetLibroAPI:
             _LOGGER.error(f"Failed to set sound level for device {serial}: {e}")
             raise
 
-    async def set_manual_feed(self, serial: str, grainNum: int) -> JSON:
+    async def set_manual_feed(self, serial: str, feed_value: int) -> JSON:
         """Trigger manual feeding for a specific device."""
         _LOGGER.debug(f"Triggering manual feeding for device with serial: {serial}")
-        
+
         try:
             # Generate a dynamic request ID for the manual feeding
             request_id = str(uuid.uuid4()).replace("-", "")
@@ -445,7 +445,7 @@ class PetLibroAPI:
             # Send the POST request to trigger manual feeding
             response = await self.session.post("/device/device/manualFeeding", json={
                 "deviceSn": serial,
-                "grainNum": grainNum,  # Number of grains dispensed
+                "grainNum": feed_value,  # Number of grains dispensed
                 "requestId": request_id  # Use dynamic request ID
             })
 

--- a/custom_components/petlibro/api.py
+++ b/custom_components/petlibro/api.py
@@ -387,7 +387,7 @@ class PetLibroAPI:
             _LOGGER.error(f"Failed to set sound level for device {serial}: {e}")
             raise
 
-    async def set_manual_feed(self, serial: str) -> JSON:
+    async def set_manual_feed(self, serial: str, grainNum: int) -> JSON:
         """Trigger manual feeding for a specific device."""
         _LOGGER.debug(f"Triggering manual feeding for device with serial: {serial}")
         
@@ -398,7 +398,7 @@ class PetLibroAPI:
             # Send the POST request to trigger manual feeding
             response = await self.session.post("/device/device/manualFeeding", json={
                 "deviceSn": serial,
-                "grainNum": 1,  # Number of grains dispensed
+                "grainNum": grainNum,  # Number of grains dispensed
                 "requestId": request_id  # Use dynamic request ID
             })
 

--- a/custom_components/petlibro/button.py
+++ b/custom_components/petlibro/button.py
@@ -274,3 +274,4 @@ async def async_setup_entry(
 
 
 
+

--- a/custom_components/petlibro/button.py
+++ b/custom_components/petlibro/button.py
@@ -51,7 +51,7 @@ DEVICE_BUTTON_MAP: dict[type[Device], list[PetLibroButtonEntityDescription]] = {
             key="manual_feed",
             translation_key="manual_feed",
             set_fn=lambda device: device.set_manual_feed(),
-            name = "Manual Feed"
+            name="Manual Feed"
         ),
         PetLibroButtonEntityDescription[AirSmartFeeder](
             key="enable_feeding_plan",

--- a/custom_components/petlibro/button.py
+++ b/custom_components/petlibro/button.py
@@ -47,7 +47,7 @@ DEVICE_BUTTON_MAP: dict[type[Device], list[PetLibroButtonEntityDescription]] = {
     Feeder: [
     ],
     AirSmartFeeder: [
-         PetLibroButtonEntityDescription[AirSmartFeeder](
+        PetLibroButtonEntityDescription[AirSmartFeeder](
             key="manual_feed",
             translation_key="manual_feed",
             set_fn=lambda device: device.set_manual_feed(),

--- a/custom_components/petlibro/button.py
+++ b/custom_components/petlibro/button.py
@@ -46,6 +46,12 @@ DEVICE_BUTTON_MAP: dict[type[Device], list[PetLibroButtonEntityDescription]] = {
     Feeder: [
     ],
     AirSmartFeeder: [
+         PetLibroButtonEntityDescription[AirSmartFeeder](
+            key="manual_feed",
+            translation_key="manual_feed",
+            set_fn=lambda device: device.set_manual_feed(),
+            name = "Manual Feed"
+        ),
         PetLibroButtonEntityDescription[AirSmartFeeder](
             key="enable_feeding_plan",
             translation_key="enable_feeding_plan",

--- a/custom_components/petlibro/button.py
+++ b/custom_components/petlibro/button.py
@@ -47,12 +47,6 @@ DEVICE_BUTTON_MAP: dict[type[Device], list[PetLibroButtonEntityDescription]] = {
     ],
     AirSmartFeeder: [
         PetLibroButtonEntityDescription[AirSmartFeeder](
-            key="manual_feed",
-            translation_key="manual_feed",
-            set_fn=lambda device: device.set_manual_feed(),
-            name="Manual Feed"
-        ),
-        PetLibroButtonEntityDescription[AirSmartFeeder](
             key="enable_feeding_plan",
             translation_key="enable_feeding_plan",
             set_fn=lambda device: device.set_feeding_plan(True),

--- a/custom_components/petlibro/button.py
+++ b/custom_components/petlibro/button.py
@@ -274,4 +274,3 @@ async def async_setup_entry(
 
 
 
-

--- a/custom_components/petlibro/devices/feeders/air_smart_feeder.py
+++ b/custom_components/petlibro/devices/feeders/air_smart_feeder.py
@@ -242,20 +242,19 @@ class AirSmartFeeder(Device):  # Inherit directly from Device
         return self.manual_feed_quantity
     '''
 
-    async def set_manual_feed_quantity(self, value: int):
+    async def set_manual_feed_quantity(self, value: float):
         """Set the manual feed quantity"""
         _LOGGER.debug(f"Setting manual feed quantity: serial={self.serial}, value={value}")
         self.manual_feed_quantity = value
-        return self.manual_feed_quantity
+        await self.refresh()
 
     # Method for manual feeding
     async def set_manual_feed(self) -> None:
         _LOGGER.debug(f"Triggering manual feed for {self.serial}")
         try:
             if hasattr(self, "manual_feed_quantity"):
-                manual_feed_quantity = self.manual_feed_quantity
-            await self.api.set_manual_feed(self.serial, feed_value = manual_feed_quantity)
-            await self.refresh()  # Refresh the state after the action
+                await self.api.set_manual_feed(self.serial, self.manual_feed_quantity)
+                await self.refresh()  # Refresh the state after the action
         except aiohttp.ClientError as err:
             _LOGGER.error(f"Failed to trigger manual feed for {self.serial}: {err}")
             raise PetLibroAPIError(f"Error triggering manual feed: {err}")

--- a/custom_components/petlibro/devices/feeders/air_smart_feeder.py
+++ b/custom_components/petlibro/devices/feeders/air_smart_feeder.py
@@ -242,19 +242,19 @@ class AirSmartFeeder(Device):  # Inherit directly from Device
         return self.manual_feed_quantity
     '''
 
-    async def set_manual_feed_quantity(self, serial: str, value: int):
+    async def set_manual_feed_quantity(self, value: int):
         """Set the manual feed quantity"""
-        _LOGGER.debug(f"Setting manual feed quantity: serial={serial}, value={value}")
+        _LOGGER.debug(f"Setting manual feed quantity: serial={self.serial}, value={value}")
         self.manual_feed_quantity = value
         return self.manual_feed_quantity
 
     # Method for manual feeding
-    async def set_manual_feed(self, value: int) -> None:
+    async def set_manual_feed(self) -> None:
         _LOGGER.debug(f"Triggering manual feed for {self.serial}")
         try:
-            if hasattr(self.device, "manual_feed_quantity"):
+            if hasattr(self, "manual_feed_quantity"):
                 manual_feed_quantity = self.manual_feed_quantity
-            await self.api.set_manual_feed(self.serial, manual_feed_quantity)
+            await self.api.set_manual_feed(self.serial, feed_value = manual_feed_quantity)
             await self.refresh()  # Refresh the state after the action
         except aiohttp.ClientError as err:
             _LOGGER.error(f"Failed to trigger manual feed for {self.serial}: {err}")

--- a/custom_components/petlibro/devices/feeders/air_smart_feeder.py
+++ b/custom_components/petlibro/devices/feeders/air_smart_feeder.py
@@ -229,10 +229,10 @@ class AirSmartFeeder(Device):  # Inherit directly from Device
             raise PetLibroAPIError(f"Error setting sound switch: {err}")
 
     # Method for manual feeding
-    async def set_manual_feed(self) -> None:
+    async def set_manual_feed(self, value: int) -> None:
         _LOGGER.debug(f"Triggering manual feed for {self.serial}")
         try:
-            await self.api.set_manual_feed(self.serial)
+            await self.api.set_manual_feed(self.serial, value)
             await self.refresh()  # Refresh the state after the action
         except aiohttp.ClientError as err:
             _LOGGER.error(f"Failed to trigger manual feed for {self.serial}: {err}")

--- a/custom_components/petlibro/devices/feeders/granary_smart_camera_feeder.py
+++ b/custom_components/petlibro/devices/feeders/granary_smart_camera_feeder.py
@@ -8,6 +8,11 @@ from ..device import Device
 _LOGGER = getLogger(__name__)
 
 class GranarySmartCameraFeeder(Device):  # Inherit directly from Device
+    def __init__(self, *args, **kwargs):
+        """Initialize the feeder with default values."""
+        super().__init__(*args, **kwargs)
+        self._manual_feed_quantity = None  # Default to None initially
+
     async def refresh(self):
         """Refresh the device data from the API."""
         try:
@@ -188,6 +193,13 @@ class GranarySmartCameraFeeder(Device):  # Inherit directly from Device
         """Get the remaining desiccant days."""
         return cast(str, self._data.get("remainingDesiccantDays", "unknown"))
     
+    @property
+    def manual_feed_quantity(self):
+        if self._manual_feed_quantity is None:
+            _LOGGER.warning(f"manual_feed_quantity is None for {self.serial}, setting default to 1.")
+            self._manual_feed_quantity = 1  # Default value
+        return self._manual_feed_quantity
+    
     # Error-handling updated for set_feeding_plan
     async def set_feeding_plan(self, value: bool) -> None:
         _LOGGER.debug(f"Setting feeding plan to {value} for {self.serial}")
@@ -248,11 +260,24 @@ class GranarySmartCameraFeeder(Device):  # Inherit directly from Device
             _LOGGER.error(f"Failed to set sound switch for {self.serial}: {err}")
             raise PetLibroAPIError(f"Error setting sound switch: {err}")
 
+    @manual_feed_quantity.setter
+    def manual_feed_quantity(self, value: float):
+        """Set the manual feed quantity."""
+        _LOGGER.debug(f"Setting manual feed quantity: serial={self.serial}, value={value}")
+        self._manual_feed_quantity = value
+    
+    async def set_manual_feed_quantity(self, value: float):
+        """Set the manual feed quantity with a default value handling"""
+        _LOGGER.debug(f"Setting manual feed quantity: serial={self.serial}, value={value}")
+        self.manual_feed_quantity = max(1, min(value, 12))  # Ensure value is within valid range
+        await self.refresh()
+
     # Method for manual feeding
     async def set_manual_feed(self) -> None:
         _LOGGER.debug(f"Triggering manual feed for {self.serial}")
         try:
-            await self.api.set_manual_feed(self.serial)
+            feed_quantity = getattr(self, "manual_feed_quantity", 1)  # Default to 1 if not set
+            await self.api.set_manual_feed(self.serial, feed_quantity)
             await self.refresh()  # Refresh the state after the action
         except aiohttp.ClientError as err:
             _LOGGER.error(f"Failed to trigger manual feed for {self.serial}: {err}")

--- a/custom_components/petlibro/devices/feeders/granary_smart_feeder.py
+++ b/custom_components/petlibro/devices/feeders/granary_smart_feeder.py
@@ -8,6 +8,11 @@ from ..device import Device
 _LOGGER = getLogger(__name__)
 
 class GranarySmartFeeder(Device):  # Inherit directly from Device
+    def __init__(self, *args, **kwargs):
+        """Initialize the feeder with default values."""
+        super().__init__(*args, **kwargs)
+        self._manual_feed_quantity = None  # Default to None initially
+
     async def refresh(self):
         """Refresh the device data from the API."""
         try:
@@ -163,6 +168,13 @@ class GranarySmartFeeder(Device):  # Inherit directly from Device
         """Get the remaining desiccant days."""
         return cast(str, self._data.get("remainingDesiccantDays", "unknown"))
     
+    @property
+    def manual_feed_quantity(self):
+        if self._manual_feed_quantity is None:
+            _LOGGER.warning(f"manual_feed_quantity is None for {self.serial}, setting default to 1.")
+            self._manual_feed_quantity = 1  # Default value
+        return self._manual_feed_quantity
+    
     # Error-handling updated for set_feeding_plan
     async def set_feeding_plan(self, value: bool) -> None:
         _LOGGER.debug(f"Setting feeding plan to {value} for {self.serial}")
@@ -223,16 +235,29 @@ class GranarySmartFeeder(Device):  # Inherit directly from Device
             _LOGGER.error(f"Failed to set sound switch for {self.serial}: {err}")
             raise PetLibroAPIError(f"Error setting sound switch: {err}")
 
+    @manual_feed_quantity.setter
+    def manual_feed_quantity(self, value: float):
+        """Set the manual feed quantity."""
+        _LOGGER.debug(f"Setting manual feed quantity: serial={self.serial}, value={value}")
+        self._manual_feed_quantity = value
+    
+    async def set_manual_feed_quantity(self, value: float):
+        """Set the manual feed quantity with a default value handling"""
+        _LOGGER.debug(f"Setting manual feed quantity: serial={self.serial}, value={value}")
+        self.manual_feed_quantity = max(1, min(value, 12))  # Ensure value is within valid range
+        await self.refresh()
+
     # Method for manual feeding
     async def set_manual_feed(self) -> None:
         _LOGGER.debug(f"Triggering manual feed for {self.serial}")
         try:
-            await self.api.set_manual_feed(self.serial)
+            feed_quantity = getattr(self, "manual_feed_quantity", 1)  # Default to 1 if not set
+            await self.api.set_manual_feed(self.serial, feed_quantity)
             await self.refresh()  # Refresh the state after the action
         except aiohttp.ClientError as err:
             _LOGGER.error(f"Failed to trigger manual feed for {self.serial}: {err}")
             raise PetLibroAPIError(f"Error triggering manual feed: {err}")
-
+        
     # Method for setting the feeding plan
     async def set_feeding_plan(self, value: bool) -> None:
         _LOGGER.debug(f"Setting feeding plan to {value} for {self.serial}")

--- a/custom_components/petlibro/devices/feeders/one_rfid_smart_feeder.py
+++ b/custom_components/petlibro/devices/feeders/one_rfid_smart_feeder.py
@@ -10,6 +10,11 @@ from logging import getLogger
 _LOGGER = getLogger(__name__)
 
 class OneRFIDSmartFeeder(Device):
+    def __init__(self, *args, **kwargs):
+        """Initialize the feeder with default values."""
+        super().__init__(*args, **kwargs)
+        self._manual_feed_quantity = None  # Default to None initially
+
     async def refresh(self):
         """Refresh the device data from the API."""
         try:
@@ -190,6 +195,13 @@ class OneRFIDSmartFeeder(Device):
     @property
     def desiccant_frequency(self) -> float:
         return self._data.get("realInfo", {}).get("changeDesiccantFrequency", 0)
+    
+    @property
+    def manual_feed_quantity(self):
+        if self._manual_feed_quantity is None:
+            _LOGGER.warning(f"manual_feed_quantity is None for {self.serial}, setting default to 1.")
+            self._manual_feed_quantity = 1  # Default value
+        return self._manual_feed_quantity
 
     async def set_desiccant_frequency(self, value: float) -> None:
         _LOGGER.debug(f"Setting desiccant frequency to {value} for {self.serial}")
@@ -275,11 +287,24 @@ class OneRFIDSmartFeeder(Device):
             _LOGGER.error(f"Failed to set sound switch for {self.serial}: {err}")
             raise PetLibroAPIError(f"Error setting sound switch: {err}")
 
+    @manual_feed_quantity.setter
+    def manual_feed_quantity(self, value: float):
+        """Set the manual feed quantity."""
+        _LOGGER.debug(f"Setting manual feed quantity: serial={self.serial}, value={value}")
+        self._manual_feed_quantity = value
+    
+    async def set_manual_feed_quantity(self, value: float):
+        """Set the manual feed quantity with a default value handling"""
+        _LOGGER.debug(f"Setting manual feed quantity: serial={self.serial}, value={value}")
+        self.manual_feed_quantity = max(1, min(value, 12))  # Ensure value is within valid range
+        await self.refresh()
+
     # Method for manual feeding
     async def set_manual_feed(self) -> None:
         _LOGGER.debug(f"Triggering manual feed for {self.serial}")
         try:
-            await self.api.set_manual_feed(self.serial)
+            feed_quantity = getattr(self, "manual_feed_quantity", 1)  # Default to 1 if not set
+            await self.api.set_manual_feed(self.serial, feed_quantity)
             await self.refresh()  # Refresh the state after the action
         except aiohttp.ClientError as err:
             _LOGGER.error(f"Failed to trigger manual feed for {self.serial}: {err}")

--- a/custom_components/petlibro/devices/feeders/space_smart_feeder.py
+++ b/custom_components/petlibro/devices/feeders/space_smart_feeder.py
@@ -8,6 +8,11 @@ from ..device import Device
 _LOGGER = getLogger(__name__)
 
 class SpaceSmartFeeder(Device):  # Inherit directly from Device
+    def __init__(self, *args, **kwargs):
+        """Initialize the feeder with default values."""
+        super().__init__(*args, **kwargs)
+        self._manual_feed_quantity = None  # Default to None initially
+
     async def refresh(self):
         """Refresh the device data from the API."""
         try:
@@ -163,6 +168,13 @@ class SpaceSmartFeeder(Device):  # Inherit directly from Device
         """Get the remaining desiccant days."""
         return cast(str, self._data.get("remainingDesiccantDays", "unknown"))
     
+    @property
+    def manual_feed_quantity(self):
+        if self._manual_feed_quantity is None:
+            _LOGGER.warning(f"manual_feed_quantity is None for {self.serial}, setting default to 1.")
+            self._manual_feed_quantity = 1  # Default value
+        return self._manual_feed_quantity
+    
     # Error-handling updated for set_feeding_plan
     async def set_feeding_plan(self, value: bool) -> None:
         _LOGGER.debug(f"Setting feeding plan to {value} for {self.serial}")
@@ -223,11 +235,24 @@ class SpaceSmartFeeder(Device):  # Inherit directly from Device
             _LOGGER.error(f"Failed to set sound switch for {self.serial}: {err}")
             raise PetLibroAPIError(f"Error setting sound switch: {err}")
 
+    @manual_feed_quantity.setter
+    def manual_feed_quantity(self, value: float):
+        """Set the manual feed quantity."""
+        _LOGGER.debug(f"Setting manual feed quantity: serial={self.serial}, value={value}")
+        self._manual_feed_quantity = value
+    
+    async def set_manual_feed_quantity(self, value: float):
+        """Set the manual feed quantity with a default value handling"""
+        _LOGGER.debug(f"Setting manual feed quantity: serial={self.serial}, value={value}")
+        self.manual_feed_quantity = max(1, min(value, 12))  # Ensure value is within valid range
+        await self.refresh()
+
     # Method for manual feeding
     async def set_manual_feed(self) -> None:
         _LOGGER.debug(f"Triggering manual feed for {self.serial}")
         try:
-            await self.api.set_manual_feed(self.serial)
+            feed_quantity = getattr(self, "manual_feed_quantity", 1)  # Default to 1 if not set
+            await self.api.set_manual_feed(self.serial, feed_quantity)
             await self.refresh()  # Refresh the state after the action
         except aiohttp.ClientError as err:
             _LOGGER.error(f"Failed to trigger manual feed for {self.serial}: {err}")

--- a/custom_components/petlibro/number.py
+++ b/custom_components/petlibro/number.py
@@ -95,8 +95,30 @@ DEVICE_NUMBER_MAP: dict[type[Device], list[PetLibroNumberEntityDescription]] = {
         ),
     ],
     GranarySmartFeeder: [
+        PetLibroNumberEntityDescription[GranarySmartFeeder](
+            key ="manual_feed_quantity",
+            translation_key ="manual_feed_quantity",
+            native_unit_of_measurement = "  / 12 cups",
+            native_max_value = 12,
+            native_min_value = 1,
+            native_step = 1,
+            value = lambda device: device.manual_feed_quantity,
+            method = lambda device, value: device.set_manual_feed_quantity(value),
+            name = "Manual Feed Quantity"
+        ), 
     ],
     GranarySmartCameraFeeder: [
+        PetLibroNumberEntityDescription[GranarySmartCameraFeeder](
+            key ="manual_feed_quantity",
+            translation_key ="manual_feed_quantity",
+            native_unit_of_measurement = "  / 12 cups",
+            native_max_value = 12,
+            native_min_value = 1,
+            native_step = 1,
+            value = lambda device: device.manual_feed_quantity,
+            method = lambda device, value: device.set_manual_feed_quantity(value),
+            name = "Manual Feed Quantity"
+        ),
     ],
     OneRFIDSmartFeeder: [
         PetLibroNumberEntityDescription[OneRFIDSmartFeeder](
@@ -135,11 +157,33 @@ DEVICE_NUMBER_MAP: dict[type[Device], list[PetLibroNumberEntityDescription]] = {
             value=lambda device: device.lid_close_time,
             method=lambda device, value: device.set_lid_close_time(value),
             name="Lid Close Time"
-        )
+        ),
+        PetLibroNumberEntityDescription[OneRFIDSmartFeeder](
+            key="manual_feed_quantity",
+            translation_key="manual_feed_quantity",
+            native_unit_of_measurement=" / 12 cups",
+            native_max_value=12,
+            native_min_value=1,
+            native_step=1,
+            value=lambda device: getattr(device, "manual_feed_quantity", 1),  # Default to 1 if not set
+            method=lambda device, value: device.set_manual_feed_quantity(value),
+            name="Manual Feed Quantity"
+        ),
     ],
     PolarWetFoodFeeder: [
     ],
     SpaceSmartFeeder: [
+        PetLibroNumberEntityDescription[SpaceSmartFeeder](
+            key ="manual_feed_quantity",
+            translation_key ="manual_feed_quantity",
+            native_unit_of_measurement = "  / 12 cups",
+            native_max_value = 12,
+            native_min_value = 1,
+            native_step = 1,
+            value = lambda device: device.manual_feed_quantity,
+            method = lambda device, value: device.set_manual_feed_quantity(value),
+            name = "Manual Feed Quantity"
+        ),
     ],
     DockstreamSmartFountain: [
     ],
@@ -190,4 +234,3 @@ async def async_setup_entry(
 
         # Add number entities to Home Assistant
         async_add_entities(entities)
-

--- a/custom_components/petlibro/number.py
+++ b/custom_components/petlibro/number.py
@@ -82,14 +82,15 @@ DEVICE_NUMBER_MAP: dict[type[Device], list[PetLibroNumberEntityDescription]] = {
     ],
     AirSmartFeeder: [
         PetLibroNumberEntityDescription[AirSmartFeeder](
-            key ="manual_feed",
-            translation_key ="manual_feed",
-            native_unit_of_measurement = "1/24 cups",
+            key ="manual_feed_quantity",
+            translation_key ="manual_feed_quantity",
+            native_unit_of_measurement = "  / 24 cups",
             native_max_value = 24,
             native_min_value = 1,
+            native_step = 1,
             value = lambda device: device.manual_feed_quantity,
-            method = lambda device, value: device.set_manual_feed(value),
-            name = "Manual Feed"
+            method = lambda device, value: device.set_manual_feed_quantity(value),
+            name = "Manual Feed Quantity"
         ),
     ],
     OneRFIDSmartFeeder: [

--- a/custom_components/petlibro/number.py
+++ b/custom_components/petlibro/number.py
@@ -79,6 +79,18 @@ class PetLibroNumberEntity(PetLibroEntity[_DeviceT], NumberEntity):
 DEVICE_NUMBER_MAP: dict[type[Device], list[PetLibroNumberEntityDescription]] = {
     Feeder: [
     ],
+    AirSmartFeeder: [
+        PetLibroNumberEntityDescription[AirSmartFeeder](
+            key ="manual_feed",
+            translation_key ="manual_feed",
+            native_unit_of_measurement = "1/24 cups",
+            native_max_value = 24,
+            native_min_value = 1,
+            value = lambda device: device.manual_feed_quantity,
+            method = lambda device, value: device.set_manual_feed(value),
+            name = "Manual Feed"
+        ),
+    ],
     OneRFIDSmartFeeder: [
         PetLibroNumberEntityDescription[OneRFIDSmartFeeder](
             key="sound_level",


### PR DESCRIPTION
<!--
Before opening this pull request please review the guidelines in the checklist below. If this PR does not meet those guidelines it will not be accepted, and everyone will be sad.

Please include a summary of the change. Screenshots and/or videos can also be helpful if appropriate. New devices or enhancements should include example(s) of relevant information.
-->

## Proposed change:

This PR adds the support for setting the manual feed/dispense amount for Petlibro Air Smart Feeders. 

Attached are the pictures of the button object and then a validation of the implementation. 

![firefox_Av905IpF8c](https://github.com/user-attachments/assets/abbcc59b-9d22-4c84-ba0c-c5ffd2751cf6)

![firefox_OoVjAWSrAg](https://github.com/user-attachments/assets/3d3504ca-f594-4a37-8439-e93762fc2ab9)

![firefox_If02bSog92](https://github.com/user-attachments/assets/72994c64-8e0a-4502-a081-8ff47e4646bf)

![IMG_2276](https://github.com/user-attachments/assets/30efb08c-53f3-4d69-a759-7717468c158f)

Closes #33 

## Type of change:

- [ ] New device.
- [ ] Bug fix (non-breaking change which fixes an issue).
- [X] New feature or enhancement (non-breaking change which adds functionality).
- [ ] Documentation only.
- [ ] Other (please explain).

## Checklist:

- [X] If applicable, I have added corresponding documentation changes.
- [X] If applicable, I have reviewed the [feature / enhancement](https://github.com/jjjonesjr33/petlibro/wiki/Feature-&-Enhancement-Guidelines) guidelines before submitting my request.
- [X] If applicable, I have tested my code for new features & regressions on the latest version of Home Assistant.

## Additional notes:
