### PR TITLE
PLAF109 | Add button to reposition the schedule

### DIFF
--- a/custom_components/petlibro/api.py
+++ b/custom_components/petlibro/api.py
@@ -39,7 +39,7 @@ class PetLibroSession:
         self.headers = {
             "source": "ANDROID",
             "language": "EN",
-            "timezone": "America/Chicago",
+            "timezone": time_zone or "America/Chicago",
             "version": "1.3.45",
         }
 
@@ -177,7 +177,7 @@ class PetLibroAPI:
 
     def __init__(self, session: ClientSession, time_zone: str, region: str, email: str, password: str, token: str | None = None, config_entry=None, hass=None):
         """Initialize."""
-        self.session = PetLibroSession(self.API_URLS[region], session, email, password, region, token)
+        self.session = PetLibroSession(self.API_URLS[region], session, email, password, region, token, time_zone)
         self.region = region
         self.time_zone = time_zone
         self.email = email  # Store email for login/re-login

--- a/custom_components/petlibro/api.py
+++ b/custom_components/petlibro/api.py
@@ -738,6 +738,15 @@ class PetLibroAPI:
             "soundEndTime": None
         })
 
+    async def set_reposition_schedule(self, serial: str, plan: dict, template_name: str):
+        """Reposition the schedule"""
+        _LOGGER.debug(f"Triggering reposition schedule for device with serial: {serial}")
+        await self.session.post("/device/wetFeedingPlan/reposition", json={
+            "deviceSn": serial,
+            "plan": plan,
+            "templateName": template_name,
+        })
+
 ## Added this to fix dupe logs
 class PetLibroDataCoordinator(DataUpdateCoordinator):
     def __init__(self, hass, api):

--- a/custom_components/petlibro/api.py
+++ b/custom_components/petlibro/api.py
@@ -29,7 +29,7 @@ _LOGGER = getLogger(__name__)
 class PetLibroSession:
     """PetLibro AIOHTTP session"""
     
-    def __init__(self, base_url: str, websession: ClientSession, email: str, password: str, region: str, token: str | None = None):
+    def __init__(self, base_url: str, websession: ClientSession, email: str, password: str, region: str, token: str | None = None, time_zone: str | None = None):
         self.base_url = base_url
         self.websession = websession
         self.token = token

--- a/custom_components/petlibro/button.py
+++ b/custom_components/petlibro/button.py
@@ -174,6 +174,12 @@ DEVICE_BUTTON_MAP: dict[type[Device], list[PetLibroButtonEntityDescription]] = {
             translation_key="rotate_food_bowl",
             set_fn=lambda device: device.rotate_food_bowl(),
             name="Rotate Food Bowl"
+        ),
+        PetLibroButtonEntityDescription[PolarWetFoodFeeder](
+            key="reposition_schedule",
+            translation_key="reposition_schedule",
+            set_fn=lambda device: device.reposition_schedule(),
+            name="Reposition the schedule"
         )
     ],
     SpaceSmartFeeder: [

--- a/custom_components/petlibro/devices/feeders/polar_wet_food_feeder.py
+++ b/custom_components/petlibro/devices/feeders/polar_wet_food_feeder.py
@@ -194,3 +194,35 @@ class PolarWetFoodFeeder(Device):
         except aiohttp.ClientError as err:
             _LOGGER.error(f"Failed to trigger feed audio for {self.serial}: {err}")
             raise PetLibroAPIError(f"Error triggering feed audio: {err}")
+
+    async def reposition_schedule(self) -> None:
+        _LOGGER.debug(f"Triggering reposition the schedule for {self.serial}")
+
+        if not self._data.get("wetFeedingPlan"):
+            _LOGGER.debug(f"Triggering device data refresh because wet feeding plan data is missing for {self.serial}")
+            # Refresh the state to ensure the wet feeding plan is already fetched
+            try:
+                await self.refresh()
+            except aiohttp.ClientError as err:
+                _LOGGER.error(f"Failed to refresh device data for triggering reposition the schedule for {self.serial}: {err}")
+                raise PetLibroAPIError(f"Error refresh device data for triggering reposition schedule: {err}")
+
+        current_feeding_plan = []
+        plan_name = self._data.get("wetFeedingPlan", {}).get("templateName")
+        current_feeding_plan = [
+            {
+                "id": plate.get("id"),
+                "plate": plate.get("plate"),
+                "label": plate.get("label"),
+                "executionStartTime": plate.get("executionStartTime"),
+                "executionEndTime": plate.get("executionEndTime"),
+            }
+            for plate in self._data.get("wetFeedingPlan", {}).get("plan", [])
+        ]
+
+        try:
+            await self.api.set_reposition_schedule(self.serial, current_feeding_plan, plan_name)
+            await self.refresh() # Refresh the state after the action
+        except aiohttp.ClientError as err:
+            _LOGGER.error(f"Failed to trigger reposition the schedule for {self.serial}: {err}")
+            raise PetLibroAPIError(f"Error triggering reposition schedule: {err}")

--- a/custom_components/petlibro/devices/feeders/polar_wet_food_feeder.py
+++ b/custom_components/petlibro/devices/feeders/polar_wet_food_feeder.py
@@ -207,8 +207,18 @@ class PolarWetFoodFeeder(Device):
                 _LOGGER.error(f"Failed to refresh device data for triggering reposition the schedule for {self.serial}: {err}")
                 raise PetLibroAPIError(f"Error refresh device data for triggering reposition schedule: {err}")
 
-        current_feeding_plan = []
-        plan_name = self._data.get("wetFeedingPlan", {}).get("templateName")
+        wet_plan = self._data.get("wetFeedingPlan", {})
+        plan_name = wet_plan.get("templateName")
+
+        if not plan_name:
+            _LOGGER.error(f"Missing template name in wetFeedingPlan for {self.serial}")
+            raise PetLibroAPIError("Missing template name in wetFeedingPlan")
+
+        plan_data = wet_plan.get("plan", [])
+        if not isinstance(plan_data, list):
+            _LOGGER.error(f"Unexpected format for wet feeding plan: {plan_data}")
+            raise PetLibroAPIError("Invalid wet feeding plan format")
+
         current_feeding_plan = [
             {
                 "id": plate.get("id"),

--- a/custom_components/petlibro/translations/de.json
+++ b/custom_components/petlibro/translations/de.json
@@ -162,6 +162,9 @@
             },
             "desiccant_reset": {
                 "name": "Trockenmittel gewechselt"
+            },
+            "reposition_schedule": {
+                "name": "Neupositionierung Futterplan"
             }
         },
         "binary_sensor": {

--- a/custom_components/petlibro/translations/en.json
+++ b/custom_components/petlibro/translations/en.json
@@ -171,6 +171,9 @@
             },
             "rotate_food_bowl": {
                 "name": "Rotate Food Bowl"
+            },
+            "reposition_schedule": {
+                "name": "Reposition Schedule"
             }
         },
         "binary_sensor": {


### PR DESCRIPTION
<!--
Before opening this pull request please review the guidelines in the checklist below. If this PR does not meet those guidelines it will not be accepted, and everyone will be sad.

Please include a summary of the change. Screenshots and/or videos can also be helpful if appropriate. New devices or enhancements should include example(s) of relevant information.
-->
## Proposed change:

Added a button to the Polar Wet Food Feeder (PLAF109) to reposition the schedule.  
The schedule repositioning is required after taking the food bowl out for cleaning/refilling and inserting it back. Without the schedule repositioning it can happen, that the feeder serves the wrong bowl for the configured feeding schedule.

The button *Reposition the schedule* uses the device method `reposition_schedule`.  
This method performs a data refresh if the wet feeding plan is not available, since the data is required for the API call. Furthermore, a part of the current wet feeding plan data must be submitted to the API.

The related API method is `set_reposition_schedule` and takes three arguments:

1. The device serial
2. The current feeding plan in the following format

    ```json
    {
        "plan": [
            {
                "id": 8942486
                "plate": 1,
                "label": "",
                "executionStartTime": "2025-05-17 12:00",
                "executionEndTime": "2025-05-17 14:00"
            },
            {
                "id": 8942487,
                "plate": 2,
                "label": "",
                "executionStartTime": "2025-05-17 19:00",
                "executionEndTime": "2025-05-17 22:00"
            }
        ],
        "templateName": "MEAL SCHEDULE 1",
        "deviceSn": "<DeviceSN>"
    }
    ```

4. The feeding plan name (`templateName` value)

Closes #87

## Type of change:

- [ ] New device.
- [ ] Bug fix (non-breaking change which fixes an issue).
- [X] New feature or enhancement (non-breaking change which adds functionality).
- [ ] Documentation only.
- [ ] Other (please explain).

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [X] If applicable, I have reviewed the [feature / enhancement](https://github.com/jjjonesjr33/petlibro/wiki/Feature-&-Enhancement-Guidelines) guidlines before submitting my request.
- [X] If applicable, I have tested my code for new features & regressions on the latest version of Home Assistant.

## Additional notes:

I've implemented a fix for `PetlibroSession` which either sets the header **timezone** to the provided value from the parameters during `__init__` or uses the default value.  

This was required during my testing of this feature, because the action `/device/wetFeedingPlan/reposition` requires the correct time zone to the submitted plan. If the wrong time zone is submitted, an error is returned which indicates that a modification of the feeding times are not allowed.