### PR TITLE
Feature/Fountains-Filter-Cleaning-Control

### DIFF
--- a/custom_components/petlibro/api.py
+++ b/custom_components/petlibro/api.py
@@ -434,16 +434,16 @@ class PetLibroAPI:
             _LOGGER.error(f"Failed to set sound enable for device {serial}: {err}")
             raise PetLibroAPIError(f"Error setting sound enable: {err}")
 
-    async def set_desiccant_frequency(self, serial: str, value: float) -> JSON:
+    async def set_desiccant_frequency(self, serial: str, value: float, key = str) -> JSON:
         """Set the desiccant frequency."""
-        _LOGGER.debug(f"Setting desiccant frequency: serial={serial}, value={value}")
+        _LOGGER.debug(f"Setting desiccant frequency: serial={serial}, value={value}, key={key}")
         try:
             # Generate a dynamic request ID for the manual feeding
             request_id = str(uuid.uuid4()).replace("-", "")
 
             response = await self.session.post("/device/device/maintenanceFrequencySetting", json={
                     "deviceSn": serial,
-                    "key": "DESICCANT",  # Try and find a way to make this dynamic as different devices may have a different key. if too difficult we could just duplicate this block for each key type.
+                    "key": key,
                     "frequency": value,
                     "requestId": request_id,
                     "timeout": 5000
@@ -545,6 +545,48 @@ class PetLibroAPI:
             return response
         except Exception as e:
             _LOGGER.error(f"Failed to set water dispensing duration for device {serial}: {e}")
+            raise
+
+    async def set_cleaning_frequency(self, serial: str, value: float, key = str) -> JSON:
+        """Set the machine cleaning frequency."""
+        _LOGGER.debug(f"Setting machine cleaning frequency: serial={serial}, value={value}, key={key}")
+        try:
+            # Generate a dynamic request ID for the manual feeding
+            request_id = str(uuid.uuid4()).replace("-", "")
+
+            response = await self.session.post("/device/device/maintenanceFrequencySetting", json={
+                    "deviceSn": serial,
+                    "key": key,
+                    "frequency": value,
+                    "requestId": request_id,
+                    "timeout": 5000
+                },
+            )
+            _LOGGER.debug(f"Machine cleaning frequency set successfully: {response}")
+            return response
+        except Exception as e:
+            _LOGGER.error(f"Failed to set machine cleaning frequency for device {serial}: {e}")
+            raise
+
+    async def set_filter_frequency(self, serial: str, value: float, key = str) -> JSON:
+        """Set the filter frequency."""
+        _LOGGER.debug(f"Setting filter frequency: serial={serial}, value={value}, key={key}")
+        try:
+            # Generate a dynamic request ID for the manual feeding
+            request_id = str(uuid.uuid4()).replace("-", "")
+
+            response = await self.session.post("/device/device/maintenanceFrequencySetting", json={
+                    "deviceSn": serial,
+                    "key": key,
+                    "frequency": value,
+                    "requestId": request_id,
+                    "timeout": 5000
+                },
+            )
+            _LOGGER.debug(f"Filter frequency set successfully: {response}")
+            return response
+        except Exception as e:
+            _LOGGER.error(f"Failed to set filter frequency for device {serial}: {e}")
             raise
 
     async def set_lid_mode(self, serial: str, value: str):
@@ -717,10 +759,10 @@ class PetLibroAPI:
         _LOGGER.debug(f"Triggering desiccant reset for device with serial: {serial}")
         
         try:
-            # Generate a dynamic request ID for the manual feeding
+            # Generate a dynamic request ID for the dessicant reset
             request_id = str(uuid.uuid4()).replace("-", "")
 
-            # Send the POST request to trigger manual feeding
+            # Send the POST request to trigger dessicant reset
             response = await self.session.post("/device/device/desiccantReset", json={
                 "deviceSn": serial,
                 "requestId": request_id,  # Use dynamic request ID
@@ -745,6 +787,74 @@ class PetLibroAPI:
         except aiohttp.ClientError as err:
             _LOGGER.error(f"Failed to trigger desiccant reset for device {serial}: {err}")
             raise PetLibroAPIError(f"Error triggering desiccant reset: {err}")
+
+    async def set_cleaning_reset(self, serial: str) -> JSON:
+        """Trigger machine cleaning reset for a specific device."""
+        _LOGGER.debug(f"Triggering machine cleaning reset for device with serial: {serial}")
+        
+        try:
+            # Generate a dynamic request ID for the machine cleaning reset
+            request_id = str(uuid.uuid4()).replace("-", "")
+
+            # Send the POST request to trigger machine cleaning reset
+            response = await self.session.post("/device/device/machineCleaningReset", json={
+                "deviceSn": serial,
+                "requestId": request_id,  # Use dynamic request ID
+                "timeout": 5000
+            })
+
+            # Check if response is already parsed (since response is an integer here)
+            if isinstance(response, int):
+                _LOGGER.debug(f"Machine cleaning reset set successfully, returned code: {response}")
+                return response
+            
+            # If response is a dictionary (JSON), handle it
+            response_data = await response.json()
+            _LOGGER.debug(f"Machine cleaning reset response data: {response_data}")
+            
+            # Check if the response indicates success
+            if response.status != 200 or response_data.get("code") != 0:
+                raise PetLibroAPIError(f"Failed to trigger machine cleaning reset: {response_data.get('msg')}")
+
+            return response_data
+
+        except aiohttp.ClientError as err:
+            _LOGGER.error(f"Failed to trigger machine cleaning reset for device {serial}: {err}")
+            raise PetLibroAPIError(f"Error triggering machine cleaning reset: {err}")
+
+    async def set_filter_reset(self, serial: str) -> JSON:
+        """Trigger machine cleaning reset for a specific device."""
+        _LOGGER.debug(f"Triggering filter reset for device with serial: {serial}")
+        
+        try:
+            # Generate a dynamic request ID for the machine cleaning reset
+            request_id = str(uuid.uuid4()).replace("-", "")
+
+            # Send the POST request to trigger machine cleaning reset
+            response = await self.session.post("/device/device/filterReset", json={
+                "deviceSn": serial,
+                "requestId": request_id,  # Use dynamic request ID
+                "timeout": 5000
+            })
+
+            # Check if response is already parsed (since response is an integer here)
+            if isinstance(response, int):
+                _LOGGER.debug(f"Filter reset set successfully, returned code: {response}")
+                return response
+            
+            # If response is a dictionary (JSON), handle it
+            response_data = await response.json()
+            _LOGGER.debug(f"Machine cleaning reset response data: {response_data}")
+            
+            # Check if the response indicates success
+            if response.status != 200 or response_data.get("code") != 0:
+                raise PetLibroAPIError(f"Failed to trigger machine cleaning reset: {response_data.get('msg')}")
+
+            return response_data
+
+        except aiohttp.ClientError as err:
+            _LOGGER.error(f"Failed to trigger machine cleaning reset for device {serial}: {err}")
+            raise PetLibroAPIError(f"Error triggering machine cleaning reset: {err}")
 
     async def set_manual_lid_open(self, serial: str):
         """Trigger manual lid opening for a specific device."""

--- a/custom_components/petlibro/button.py
+++ b/custom_components/petlibro/button.py
@@ -203,8 +203,32 @@ DEVICE_BUTTON_MAP: dict[type[Device], list[PetLibroButtonEntityDescription]] = {
         ),
     ],
     DockstreamSmartFountain: [
+        PetLibroButtonEntityDescription[DockstreamSmartFountain](
+            key="cleaning_reset",
+            translation_key="cleaning_reset",
+            set_fn=lambda device: device.set_cleaning_reset(),
+            name="Machine Cleaning Reset"
+        ),
+        PetLibroButtonEntityDescription[DockstreamSmartFountain](
+            key="filter_reset",
+            translation_key="filter_reset",
+            set_fn=lambda device: device.set_filter_reset(),
+            name="Filter Replaced"
+        )
     ],
     DockstreamSmartRFIDFountain: [
+        PetLibroButtonEntityDescription[DockstreamSmartRFIDFountain](
+            key="cleaning_reset",
+            translation_key="cleaning_reset",
+            set_fn=lambda device: device.set_cleaning_reset(),
+            name="Machine Cleaning Reset"
+        ),
+        PetLibroButtonEntityDescription[DockstreamSmartRFIDFountain](
+            key="filter_reset",
+            translation_key="filter_reset",
+            set_fn=lambda device: device.set_filter_reset(),
+            name="Filter Replaced"
+        )
     ],
 }
 

--- a/custom_components/petlibro/button.py
+++ b/custom_components/petlibro/button.py
@@ -159,7 +159,7 @@ DEVICE_BUTTON_MAP: dict[type[Device], list[PetLibroButtonEntityDescription]] = {
             key="desiccant_reset",
             translation_key="desiccant_reset",
             set_fn=lambda device: device.set_desiccant_reset(),
-            name="Desiccant Replaced"
+            name="Desiccant Reset"
         )
     ],
     PolarWetFoodFeeder: [
@@ -207,13 +207,13 @@ DEVICE_BUTTON_MAP: dict[type[Device], list[PetLibroButtonEntityDescription]] = {
             key="cleaning_reset",
             translation_key="cleaning_reset",
             set_fn=lambda device: device.set_cleaning_reset(),
-            name="Machine Cleaning Reset"
+            name="Cleaning Reset"
         ),
         PetLibroButtonEntityDescription[DockstreamSmartFountain](
             key="filter_reset",
             translation_key="filter_reset",
             set_fn=lambda device: device.set_filter_reset(),
-            name="Filter Replaced"
+            name="Filter Reset"
         )
     ],
     DockstreamSmartRFIDFountain: [
@@ -221,13 +221,13 @@ DEVICE_BUTTON_MAP: dict[type[Device], list[PetLibroButtonEntityDescription]] = {
             key="cleaning_reset",
             translation_key="cleaning_reset",
             set_fn=lambda device: device.set_cleaning_reset(),
-            name="Machine Cleaning Reset"
+            name="Cleaning Reset"
         ),
         PetLibroButtonEntityDescription[DockstreamSmartRFIDFountain](
             key="filter_reset",
             translation_key="filter_reset",
             set_fn=lambda device: device.set_filter_reset(),
-            name="Filter Replaced"
+            name="Filter Reset"
         )
     ],
 }

--- a/custom_components/petlibro/devices/feeders/one_rfid_smart_feeder.py
+++ b/custom_components/petlibro/devices/feeders/one_rfid_smart_feeder.py
@@ -200,7 +200,7 @@ class OneRFIDSmartFeeder(Device):
         return cast(str, self._data.get("remainingDesiccantDays", "unknown"))
     
     @property
-    def desiccant_frequency(self) -> float:
+    def desiccant_cycle(self) -> float:
         return self._data.get("realInfo", {}).get("changeDesiccantFrequency", 0)
     
     @property
@@ -239,15 +239,15 @@ class OneRFIDSmartFeeder(Device):
             self._manual_feed_quantity = 1  # Default value
         return self._manual_feed_quantity
 
-    async def set_desiccant_frequency(self, value: float) -> None:
-        _LOGGER.debug(f"Setting desiccant frequency to {value} for {self.serial}")
+    async def set_desiccant_cycle(self, value: float) -> None:
+        _LOGGER.debug(f"Setting desiccant cycle to {value} for {self.serial}")
         try:
             key = "DESSICANT"
-            await self.api.set_desiccant_frequency(self.serial, value, key)
+            await self.api.set_desiccant_cycle(self.serial, value, key)
             await self.refresh()  # Refresh the state after the action
         except aiohttp.ClientError as err:
-            _LOGGER.error(f"Failed to set desiccant frequency for {self.serial}: {err}")
-            raise PetLibroAPIError(f"Error setting desiccant frequency: {err}")
+            _LOGGER.error(f"Failed to set desiccant cycle for {self.serial}: {err}")
+            raise PetLibroAPIError(f"Error setting desiccant cycle: {err}")
     
     @property
     def sound_switch(self) -> bool:

--- a/custom_components/petlibro/devices/feeders/one_rfid_smart_feeder.py
+++ b/custom_components/petlibro/devices/feeders/one_rfid_smart_feeder.py
@@ -214,11 +214,14 @@ class OneRFIDSmartFeeder(Device):
     async def set_desiccant_frequency(self, value: float) -> None:
         _LOGGER.debug(f"Setting desiccant frequency to {value} for {self.serial}")
         try:
-            await self.api.set_desiccant_frequency(self.serial, value)
+            key = "DESSICANT"
+            await self.api.set_desiccant_frequency(self.serial, value, key)
             await self.refresh()  # Refresh the state after the action
         except aiohttp.ClientError as err:
             _LOGGER.error(f"Failed to set desiccant frequency for {self.serial}: {err}")
-            raise PetLibroAPIError(f"Error setting desiccantfrequency: {err}")
+            raise PetLibroAPIError(f"Error setting desiccant frequency: {err}")
+    
+    @property
     def sound_switch(self) -> bool:
         return self._data.get("realInfo", {}).get("soundSwitch", False)
 

--- a/custom_components/petlibro/devices/fountains/dockstream_smart_fountain.py
+++ b/custom_components/petlibro/devices/fountains/dockstream_smart_fountain.py
@@ -232,13 +232,3 @@ class DockstreamSmartFountain(Device):
     def use_water_duration(self) -> int:
         """Get the water usage duration."""
         return self._data.get("realInfo", {}).get("useWaterDuration", 0)
-    
-    @property
-    def filter_replacement_frequency(self) -> int:
-        """Get the filter replacement frequency."""
-        return self._data.get("realInfo", {}).get("filterReplacementFrequency", 0)
-    
-    @property
-    def machine_cleaning_frequency(self) -> int:
-        """Get the machine cleaning frequency."""
-        return self._data.get("realInfo", {}).get("machineCleaningFrequency", 0)

--- a/custom_components/petlibro/devices/fountains/dockstream_smart_fountain.py
+++ b/custom_components/petlibro/devices/fountains/dockstream_smart_fountain.py
@@ -173,32 +173,32 @@ class DockstreamSmartFountain(Device):
             raise PetLibroAPIError(f"Error setting water dispensing duration using {current_mode} & {current_interval}: {err}")
 
     @property
-    def cleaning_frequency(self) -> float:
+    def cleaning_cycle(self) -> float:
         return self._data.get("realInfo", {}).get("machineCleaningFrequency", 0)
 
-    async def set_cleaning_frequency(self, value: float) -> None:
-        _LOGGER.debug(f"Setting machine cleaning frequency to {value} for {self.serial}")
+    async def set_cleaning_cycle(self, value: float) -> None:
+        _LOGGER.debug(f"Setting cleaning cycle to {value} for {self.serial}")
         try:
             key = "MACHINE_CLEANING"
-            await self.api.set_filter_frequency(self.serial, value, key)
+            await self.api.set_filter_cycle(self.serial, value, key)
             await self.refresh()  # Refresh the state after the action
         except aiohttp.ClientError as err:
-            _LOGGER.error(f"Failed to set machine cleaning frequency using {key} for {self.serial}: {err}")
-            raise PetLibroAPIError(f"Error setting machine cleaning frequency using {key}: {err}")
+            _LOGGER.error(f"Failed to set cleaning cycle using {key} for {self.serial}: {err}")
+            raise PetLibroAPIError(f"Error setting cleaning cycle using {key}: {err}")
 
     @property
-    def filter_frequency(self) -> float:
+    def filter_cycle(self) -> float:
         return self._data.get("realInfo", {}).get("filterReplacementFrequency", 0)
 
-    async def set_filter_frequency(self, value: float) -> None:
-        _LOGGER.debug(f"Setting filter frequency to {value} for {self.serial}")
+    async def set_filter_cycle(self, value: float) -> None:
+        _LOGGER.debug(f"Setting filter cycle to {value} for {self.serial}")
         try:
             key = "FILTER_ELEMENT"
-            await self.api.set_filter_frequency(self.serial, value, key)
+            await self.api.set_filter_cycle(self.serial, value, key)
             await self.refresh()  # Refresh the state after the action
         except aiohttp.ClientError as err:
-            _LOGGER.error(f"Failed to set filter frequency using {key} for {self.serial}: {err}")
-            raise PetLibroAPIError(f"Error setting filter frequency using {key}: {err}")
+            _LOGGER.error(f"Failed to set filter cycle using {key} for {self.serial}: {err}")
+            raise PetLibroAPIError(f"Error setting filter cycle using {key}: {err}")
 
     async def set_cleaning_reset(self) -> None:
         _LOGGER.debug(f"Triggering machine cleaning reset for {self.serial}")

--- a/custom_components/petlibro/devices/fountains/dockstream_smart_fountain.py
+++ b/custom_components/petlibro/devices/fountains/dockstream_smart_fountain.py
@@ -119,11 +119,6 @@ class DockstreamSmartFountain(Device):
         """Enable or disable the sound."""
         await self.api.set_sound_switch(self.serial, value)
         await self.refresh()
-    
-    async def set_manual_cleaning(self):
-        """Trigger manual cleaning action."""
-        await self.api.set_manual_cleaning(self.serial)
-        await self.refresh()
 
     @property
     def water_dispensing_mode(self) -> int:
@@ -176,6 +171,52 @@ class DockstreamSmartFountain(Device):
         except aiohttp.ClientError as err:
             _LOGGER.error(f"Failed to set water dispensing duration using {current_mode} & {current_interval} for {self.serial}: {err}")
             raise PetLibroAPIError(f"Error setting water dispensing duration using {current_mode} & {current_interval}: {err}")
+
+    @property
+    def cleaning_frequency(self) -> float:
+        return self._data.get("realInfo", {}).get("machineCleaningFrequency", 0)
+
+    async def set_cleaning_frequency(self, value: float) -> None:
+        _LOGGER.debug(f"Setting machine cleaning frequency to {value} for {self.serial}")
+        try:
+            key = "MACHINE_CLEANING"
+            await self.api.set_filter_frequency(self.serial, value, key)
+            await self.refresh()  # Refresh the state after the action
+        except aiohttp.ClientError as err:
+            _LOGGER.error(f"Failed to set machine cleaning frequency using {key} for {self.serial}: {err}")
+            raise PetLibroAPIError(f"Error setting machine cleaning frequency using {key}: {err}")
+
+    @property
+    def filter_frequency(self) -> float:
+        return self._data.get("realInfo", {}).get("filterReplacementFrequency", 0)
+
+    async def set_filter_frequency(self, value: float) -> None:
+        _LOGGER.debug(f"Setting filter frequency to {value} for {self.serial}")
+        try:
+            key = "FILTER_ELEMENT"
+            await self.api.set_filter_frequency(self.serial, value, key)
+            await self.refresh()  # Refresh the state after the action
+        except aiohttp.ClientError as err:
+            _LOGGER.error(f"Failed to set filter frequency using {key} for {self.serial}: {err}")
+            raise PetLibroAPIError(f"Error setting filter frequency using {key}: {err}")
+
+    async def set_cleaning_reset(self) -> None:
+        _LOGGER.debug(f"Triggering machine cleaning reset for {self.serial}")
+        try:
+            await self.api.set_cleaning_reset(self.serial)
+            await self.refresh()  # Refresh the state after the action
+        except aiohttp.ClientError as err:
+            _LOGGER.error(f"Failed to trigger machine cleaning reset for {self.serial}: {err}")
+            raise PetLibroAPIError(f"Error triggering machine cleaning reset: {err}")
+
+    async def set_filter_reset(self) -> None:
+        _LOGGER.debug(f"Triggering filter reset for {self.serial}")
+        try:
+            await self.api.set_filter_reset(self.serial)
+            await self.refresh()  # Refresh the state after the action
+        except aiohttp.ClientError as err:
+            _LOGGER.error(f"Failed to trigger filter reset for {self.serial}: {err}")
+            raise PetLibroAPIError(f"Error triggering filter reset: {err}")
 
     @property
     def today_total_ml(self) -> int:

--- a/custom_components/petlibro/devices/fountains/dockstream_smart_rfid_fountain.py
+++ b/custom_components/petlibro/devices/fountains/dockstream_smart_rfid_fountain.py
@@ -173,32 +173,32 @@ class DockstreamSmartRFIDFountain(Device):
             raise PetLibroAPIError(f"Error setting water dispensing duration using {current_mode} & {current_interval}: {err}")
 
     @property
-    def cleaning_frequency(self) -> float:
+    def cleaning_cycle(self) -> float:
         return self._data.get("realInfo", {}).get("machineCleaningFrequency", 0)
 
-    async def set_cleaning_frequency(self, value: float) -> None:
-        _LOGGER.debug(f"Setting machine cleaning frequency to {value} for {self.serial}")
+    async def set_cleaning_cycle(self, value: float) -> None:
+        _LOGGER.debug(f"Setting machine cleaning cycle to {value} for {self.serial}")
         try:
             key = "MACHINE_CLEANING"
-            await self.api.set_filter_frequency(self.serial, value, key)
+            await self.api.set_filter_cycle(self.serial, value, key)
             await self.refresh()  # Refresh the state after the action
         except aiohttp.ClientError as err:
-            _LOGGER.error(f"Failed to set machine cleaning frequency using {key} for {self.serial}: {err}")
-            raise PetLibroAPIError(f"Error setting machine cleaning frequency using {key}: {err}")
+            _LOGGER.error(f"Failed to set cleaning cycle using {key} for {self.serial}: {err}")
+            raise PetLibroAPIError(f"Error setting cleaning cycle using {key}: {err}")
 
     @property
-    def filter_frequency(self) -> float:
+    def filter_cycle(self) -> float:
         return self._data.get("realInfo", {}).get("filterReplacementFrequency", 0)
 
-    async def set_filter_frequency(self, value: float) -> None:
-        _LOGGER.debug(f"Setting filter frequency to {value} for {self.serial}")
+    async def set_filter_cycle(self, value: float) -> None:
+        _LOGGER.debug(f"Setting filter cycle to {value} for {self.serial}")
         try:
             key = "FILTER_ELEMENT"
-            await self.api.set_filter_frequency(self.serial, value, key)
+            await self.api.set_filter_cycle(self.serial, value, key)
             await self.refresh()  # Refresh the state after the action
         except aiohttp.ClientError as err:
-            _LOGGER.error(f"Failed to set filter frequency using {key} for {self.serial}: {err}")
-            raise PetLibroAPIError(f"Error setting filter frequency using {key}: {err}")
+            _LOGGER.error(f"Failed to set filter cycle using {key} for {self.serial}: {err}")
+            raise PetLibroAPIError(f"Error setting filter cycle using {key}: {err}")
 
     async def set_cleaning_reset(self) -> None:
         _LOGGER.debug(f"Triggering machine cleaning reset for {self.serial}")

--- a/custom_components/petlibro/devices/fountains/dockstream_smart_rfid_fountain.py
+++ b/custom_components/petlibro/devices/fountains/dockstream_smart_rfid_fountain.py
@@ -120,11 +120,6 @@ class DockstreamSmartRFIDFountain(Device):
         await self.api.set_sound_switch(self.serial, value)
         await self.refresh()
     
-    async def set_manual_cleaning(self):
-        """Trigger manual cleaning action."""
-        await self.api.set_manual_cleaning(self.serial)
-        await self.refresh()
-    
     @property
     def water_dispensing_mode(self) -> int:
         """Return the user-friendly water dispensing mode (mapped directly from the API value)."""
@@ -177,6 +172,51 @@ class DockstreamSmartRFIDFountain(Device):
             _LOGGER.error(f"Failed to set water dispensing duration using {current_mode} & {current_interval} for {self.serial}: {err}")
             raise PetLibroAPIError(f"Error setting water dispensing duration using {current_mode} & {current_interval}: {err}")
 
+    @property
+    def cleaning_frequency(self) -> float:
+        return self._data.get("realInfo", {}).get("machineCleaningFrequency", 0)
+
+    async def set_cleaning_frequency(self, value: float) -> None:
+        _LOGGER.debug(f"Setting machine cleaning frequency to {value} for {self.serial}")
+        try:
+            key = "MACHINE_CLEANING"
+            await self.api.set_filter_frequency(self.serial, value, key)
+            await self.refresh()  # Refresh the state after the action
+        except aiohttp.ClientError as err:
+            _LOGGER.error(f"Failed to set machine cleaning frequency using {key} for {self.serial}: {err}")
+            raise PetLibroAPIError(f"Error setting machine cleaning frequency using {key}: {err}")
+
+    @property
+    def filter_frequency(self) -> float:
+        return self._data.get("realInfo", {}).get("filterReplacementFrequency", 0)
+
+    async def set_filter_frequency(self, value: float) -> None:
+        _LOGGER.debug(f"Setting filter frequency to {value} for {self.serial}")
+        try:
+            key = "FILTER_ELEMENT"
+            await self.api.set_filter_frequency(self.serial, value, key)
+            await self.refresh()  # Refresh the state after the action
+        except aiohttp.ClientError as err:
+            _LOGGER.error(f"Failed to set filter frequency using {key} for {self.serial}: {err}")
+            raise PetLibroAPIError(f"Error setting filter frequency using {key}: {err}")
+
+    async def set_cleaning_reset(self) -> None:
+        _LOGGER.debug(f"Triggering machine cleaning reset for {self.serial}")
+        try:
+            await self.api.set_cleaning_reset(self.serial)
+            await self.refresh()  # Refresh the state after the action
+        except aiohttp.ClientError as err:
+            _LOGGER.error(f"Failed to trigger machine cleaning reset for {self.serial}: {err}")
+            raise PetLibroAPIError(f"Error triggering machine cleaning reset: {err}")
+
+    async def set_filter_reset(self) -> None:
+        _LOGGER.debug(f"Triggering filter reset for {self.serial}")
+        try:
+            await self.api.set_filter_reset(self.serial)
+            await self.refresh()  # Refresh the state after the action
+        except aiohttp.ClientError as err:
+            _LOGGER.error(f"Failed to trigger filter reset for {self.serial}: {err}")
+            raise PetLibroAPIError(f"Error triggering filter reset: {err}")
 
     @property
     def today_total_ml(self) -> int:

--- a/custom_components/petlibro/number.py
+++ b/custom_components/petlibro/number.py
@@ -210,6 +210,32 @@ DEVICE_NUMBER_MAP: dict[type[Device], list[PetLibroNumberEntityDescription]] = {
             method=lambda device, value: device.set_water_dispensing_duration(value),
             name="Water Dispensing Duration"
         ),
+        PetLibroNumberEntityDescription[DockstreamSmartFountain](
+            key="cleaning_frequency",
+            translation_key="cleaning_frequency",
+            icon="mdi:calendar-alert",
+            native_unit_of_measurement="Days",
+            mode="box",
+            native_max_value=60,
+            native_min_value=1,
+            native_step=1,
+            value=lambda device: device.cleaning_frequency,
+            method=lambda device, value: device.set_cleaning_frequency(value),
+            name="Machine Cleaning Frequency"
+        ),
+        PetLibroNumberEntityDescription[DockstreamSmartFountain](
+            key="filter_frequency",
+            translation_key="filter_frequency",
+            icon="mdi:calendar-alert",
+            native_unit_of_measurement="Days",
+            mode="box",
+            native_max_value=60,
+            native_min_value=1,
+            native_step=1,
+            value=lambda device: device.filter_frequency,
+            method=lambda device, value: device.set_filter_frequency(value),
+            name="Filter Frequency"
+        ),
     ],
     DockstreamSmartRFIDFountain: [
         PetLibroNumberEntityDescription[DockstreamSmartRFIDFountain](
@@ -235,6 +261,32 @@ DEVICE_NUMBER_MAP: dict[type[Device], list[PetLibroNumberEntityDescription]] = {
             value=lambda device: device.water_dispensing_duration,
             method=lambda device, value: device.set_water_dispensing_duration(value),
             name="Water Dispensing Duration"
+        ),
+        PetLibroNumberEntityDescription[DockstreamSmartRFIDFountain](
+            key="cleaning_frequency",
+            translation_key="cleaning_frequency",
+            icon="mdi:calendar-alert",
+            native_unit_of_measurement="Days",
+            mode="box",
+            native_max_value=60,
+            native_min_value=1,
+            native_step=1,
+            value=lambda device: device.cleaning_frequency,
+            method=lambda device, value: device.set_cleaning_frequency(value),
+            name="Machine Cleaning Frequency"
+        ),
+        PetLibroNumberEntityDescription[DockstreamSmartRFIDFountain](
+            key="filter_frequency",
+            translation_key="filter_frequency",
+            icon="mdi:calendar-alert",
+            native_unit_of_measurement="Days",
+            mode="box",
+            native_max_value=60,
+            native_min_value=1,
+            native_step=1,
+            value=lambda device: device.filter_frequency,
+            method=lambda device, value: device.set_filter_frequency(value),
+            name="Filter Frequency"
         ),
     ],
 }

--- a/custom_components/petlibro/number.py
+++ b/custom_components/petlibro/number.py
@@ -122,17 +122,17 @@ DEVICE_NUMBER_MAP: dict[type[Device], list[PetLibroNumberEntityDescription]] = {
     ],
     OneRFIDSmartFeeder: [
         PetLibroNumberEntityDescription[OneRFIDSmartFeeder](
-            key="desiccant_frequency",
-            translation_key="desiccant_frequency",
+            key="desiccant_cycle",
+            translation_key="desiccant_cycle",
             icon="mdi:calendar-alert",
             native_unit_of_measurement="Days",
             mode="box",
             native_max_value=60,
             native_min_value=1,
             native_step=1,
-            value=lambda device: device.desiccant_frequency,
-            method=lambda device, value: device.set_desiccant_frequency(value),
-            name="Desiccant Frequency"
+            value=lambda device: device.desiccant_cycle,
+            method=lambda device, value: device.set_desiccant_cycle(value),
+            name="Desiccant Cycle"
         ),
         PetLibroNumberEntityDescription[OneRFIDSmartFeeder](
             key="sound_level",
@@ -211,30 +211,30 @@ DEVICE_NUMBER_MAP: dict[type[Device], list[PetLibroNumberEntityDescription]] = {
             name="Water Dispensing Duration"
         ),
         PetLibroNumberEntityDescription[DockstreamSmartFountain](
-            key="cleaning_frequency",
-            translation_key="cleaning_frequency",
+            key="cleaning_cycle",
+            translation_key="cleaning_cycle",
             icon="mdi:calendar-alert",
             native_unit_of_measurement="Days",
             mode="box",
             native_max_value=60,
             native_min_value=1,
             native_step=1,
-            value=lambda device: device.cleaning_frequency,
-            method=lambda device, value: device.set_cleaning_frequency(value),
-            name="Machine Cleaning Frequency"
+            value=lambda device: device.cleaning_cycle,
+            method=lambda device, value: device.set_cleaning_cycle(value),
+            name="Machine Cleaning Cycle"
         ),
         PetLibroNumberEntityDescription[DockstreamSmartFountain](
-            key="filter_frequency",
-            translation_key="filter_frequency",
+            key="filter_cycle",
+            translation_key="filter_cycle",
             icon="mdi:calendar-alert",
             native_unit_of_measurement="Days",
             mode="box",
             native_max_value=60,
             native_min_value=1,
             native_step=1,
-            value=lambda device: device.filter_frequency,
-            method=lambda device, value: device.set_filter_frequency(value),
-            name="Filter Frequency"
+            value=lambda device: device.filter_cycle,
+            method=lambda device, value: device.set_filter_cycle(value),
+            name="Filter Cycle"
         ),
     ],
     DockstreamSmartRFIDFountain: [
@@ -263,30 +263,30 @@ DEVICE_NUMBER_MAP: dict[type[Device], list[PetLibroNumberEntityDescription]] = {
             name="Water Dispensing Duration"
         ),
         PetLibroNumberEntityDescription[DockstreamSmartRFIDFountain](
-            key="cleaning_frequency",
-            translation_key="cleaning_frequency",
+            key="cleaning_cycle",
+            translation_key="cleaning_cycle",
             icon="mdi:calendar-alert",
             native_unit_of_measurement="Days",
             mode="box",
             native_max_value=60,
             native_min_value=1,
             native_step=1,
-            value=lambda device: device.cleaning_frequency,
-            method=lambda device, value: device.set_cleaning_frequency(value),
-            name="Machine Cleaning Frequency"
+            value=lambda device: device.cleaning_cycle,
+            method=lambda device, value: device.set_cleaning_cycle(value),
+            name="Machine Cleaning Cycle"
         ),
         PetLibroNumberEntityDescription[DockstreamSmartRFIDFountain](
-            key="filter_frequency",
-            translation_key="filter_frequency",
+            key="filter_cycle",
+            translation_key="filter_cycle",
             icon="mdi:calendar-alert",
             native_unit_of_measurement="Days",
             mode="box",
             native_max_value=60,
             native_min_value=1,
             native_step=1,
-            value=lambda device: device.filter_frequency,
-            method=lambda device, value: device.set_filter_frequency(value),
-            name="Filter Frequency"
+            value=lambda device: device.filter_cycle,
+            method=lambda device, value: device.set_filter_cycle(value),
+            name="Filter Cycle"
         ),
     ],
 }

--- a/custom_components/petlibro/translations/ar.json
+++ b/custom_components/petlibro/translations/ar.json
@@ -209,7 +209,7 @@
             "sound_level": {
                 "name": "مستوى الحجم"
             },
-            "desiccant_frequency": {
+            "desiccant_cycle": {
                 "name": "تردد الجفاف"
             },
             "lid_close_time": {

--- a/custom_components/petlibro/translations/bn.json
+++ b/custom_components/petlibro/translations/bn.json
@@ -209,7 +209,7 @@
             "sound_level": {
                 "name": "ভলিউম স্তর"
             },
-            "desiccant_frequency": {
+            "desiccant_cycle": {
                 "name": "ডেসিক্যান্ট ফ্রিকোয়েন্সি"
             },
             "lid_close_time": {

--- a/custom_components/petlibro/translations/de.json
+++ b/custom_components/petlibro/translations/de.json
@@ -203,7 +203,7 @@
             "sound_level": {
                 "name": "Lautstärke"
             },
-            "desiccant_frequency": {
+            "desiccant_cycle": {
                 "name": "Trockenmittel Häufigkeit"
             },
             "lid_close_time": {

--- a/custom_components/petlibro/translations/dk.json
+++ b/custom_components/petlibro/translations/dk.json
@@ -212,7 +212,7 @@
             "sound_level": {
                 "name": "Lydstyrkeniveau"
             },
-            "desiccant_frequency": {
+            "desiccant_cycle": {
                 "name": "Tørremiddelfrekvens"
             },
             "lid_close_time": {

--- a/custom_components/petlibro/translations/en.json
+++ b/custom_components/petlibro/translations/en.json
@@ -174,6 +174,12 @@
             },
             "reposition_schedule": {
                 "name": "Reposition Schedule"
+            },
+            "machine_cleaning_reset": {
+                "name": "Machine Cleaning Reset"
+            },
+            "filter_reset": {
+                "name": "Filter Replaced"
             }
         },
         "binary_sensor": {
@@ -223,6 +229,12 @@
             },
             "water_dispensing_duration": {
                 "name": "Water Dispensing Duration"
+            },
+            "cleaning_frequency": {
+                "name": "Machine Cleanining Frequency"
+            },
+            "filter_frequency": {
+                "name": "Filter Frequency"
             }
         },
         "select": {

--- a/custom_components/petlibro/translations/en.json
+++ b/custom_components/petlibro/translations/en.json
@@ -60,9 +60,6 @@
             "today_eating_time": {
                 "name": "Today's Total Eating Time"
             },
-            "last_feed_time": {
-                "name": "Last Feed Time"
-            },
             "feeding_plan_state": {
                 "name": "Today's Feeding Plan"
             },
@@ -167,7 +164,7 @@
                 "name": "Turn Off Sound"
             },
             "desiccant_reset": {
-                "name": "Desiccant Replaced"
+                "name": "Desiccant Reset"
             },
             "ring_bell": {
                 "name": "Ring Bell"
@@ -178,11 +175,11 @@
             "reposition_schedule": {
                 "name": "Reposition Schedule"
             },
-            "machine_cleaning_reset": {
-                "name": "Machine Cleaning Reset"
+            "cleaning_reset": {
+                "name": "Cleaning Reset"
             },
             "filter_reset": {
-                "name": "Filter Replaced"
+                "name": "Filter Reset"
             }
         },
         "binary_sensor": {
@@ -221,8 +218,8 @@
             "sound_level": {
                 "name": "Volume Level"
             },
-            "desiccant_frequency": {
-                "name": "Desiccant Frequency"
+            "desiccant_cycle": {
+                "name": "Desiccant Cycle"
             },
             "lid_close_time": {
                 "name": "Lid Close Time"
@@ -233,11 +230,11 @@
             "water_dispensing_duration": {
                 "name": "Water Dispensing Duration"
             },
-            "cleaning_frequency": {
-                "name": "Machine Cleanining Frequency"
+            "cleaning_cycle": {
+                "name": "Cleanining Cycle"
             },
-            "filter_frequency": {
-                "name": "Filter Frequency"
+            "filter_cycle": {
+                "name": "Filter Cycle"
             }
         },
         "select": {

--- a/custom_components/petlibro/translations/en.json
+++ b/custom_components/petlibro/translations/en.json
@@ -60,6 +60,9 @@
             "today_eating_time": {
                 "name": "Today's Total Eating Time"
             },
+            "last_feed_time": {
+                "name": "Last Feed Time"
+            },
             "feeding_plan_state": {
                 "name": "Today's Feeding Plan"
             },
@@ -169,6 +172,7 @@
             "ring_bell": {
                 "name": "Ring Bell"
             },
+
             "rotate_food_bowl": {
                 "name": "Rotate Food Bowl"
             },

--- a/custom_components/petlibro/translations/es.json
+++ b/custom_components/petlibro/translations/es.json
@@ -209,7 +209,7 @@
             "sound_level": {
                 "name": "Nivel de volumen"
             },
-            "desiccant_frequency": {
+            "desiccant_cycle": {
                 "name": "Frecuencia desecante"
             },
             "lid_close_time": {

--- a/custom_components/petlibro/translations/fr.json
+++ b/custom_components/petlibro/translations/fr.json
@@ -40,7 +40,7 @@
                 "name": "Force du signal Wi-Fi"
             },
             "remaining_desiccant": {
-                "name": "Dessicant Days restants"
+                "name": "Dessiccant Days restants"
             },
             "battery_state": {
                 "name": "Niveau de la batterie"
@@ -164,7 +164,7 @@
                 "name": "Éteindre le son"
             },
             "desiccant_reset": {
-                "name": "Desiccant remplacé"
+                "name": "Dessicant remplacé"
             },
             "ring_bell": {
                 "name": "Sonnerie"

--- a/custom_components/petlibro/translations/fr.json
+++ b/custom_components/petlibro/translations/fr.json
@@ -40,7 +40,7 @@
                 "name": "Force du signal Wi-Fi"
             },
             "remaining_desiccant": {
-                "name": "Dessiccant Days restants"
+                "name": "Dessicant Days restants"
             },
             "battery_state": {
                 "name": "Niveau de la batterie"
@@ -164,7 +164,7 @@
                 "name": "Éteindre le son"
             },
             "desiccant_reset": {
-                "name": "Dessicant remplacé"
+                "name": "Desiccant remplacé"
             },
             "ring_bell": {
                 "name": "Sonnerie"
@@ -209,7 +209,7 @@
             "sound_level": {
                 "name": "Niveau de volume"
             },
-            "desiccant_frequency": {
+            "desiccant_cycle": {
                 "name": "Fréquence dessicante"
             },
             "lid_close_time": {

--- a/custom_components/petlibro/translations/hi.json
+++ b/custom_components/petlibro/translations/hi.json
@@ -209,7 +209,7 @@
             "sound_level": {
                 "name": "खंड स्तर"
             },
-            "desiccant_frequency": {
+            "desiccant_cycle": {
                 "name": "डेसिकेंट आवृत्ति"
             },
             "lid_close_time": {

--- a/custom_components/petlibro/translations/ja.json
+++ b/custom_components/petlibro/translations/ja.json
@@ -209,7 +209,7 @@
             "sound_level": {
                 "name": "ボリュームレベル"
             },
-            "desiccant_frequency": {
+            "desiccant_cycle": {
                 "name": "乾燥剤周波数"
             },
             "lid_close_time": {

--- a/custom_components/petlibro/translations/nl-be.json
+++ b/custom_components/petlibro/translations/nl-be.json
@@ -212,7 +212,7 @@
             "sound_level": {
                 "name": "Geluidsniveau"
             },
-            "desiccant_frequency": {
+            "desiccant_cycle": {
                 "name": "Droogmiddelfrequentie"
             },
             "lid_close_time": {

--- a/custom_components/petlibro/translations/pt.json
+++ b/custom_components/petlibro/translations/pt.json
@@ -209,7 +209,7 @@
             "sound_level": {
                 "name": "Nível de volume"
             },
-            "desiccant_frequency": {
+            "desiccant_cycle": {
                 "name": "Frequência dessecante"
             },
             "lid_close_time": {

--- a/custom_components/petlibro/translations/ru.json
+++ b/custom_components/petlibro/translations/ru.json
@@ -209,7 +209,7 @@
             "sound_level": {
                 "name": "Уровень объема"
             },
-            "desiccant_frequency": {
+            "desiccant_cycle": {
                 "name": "Исчезающая частота"
             },
             "lid_close_time": {

--- a/custom_components/petlibro/translations/zh-cn.json
+++ b/custom_components/petlibro/translations/zh-cn.json
@@ -209,7 +209,7 @@
             "sound_level": {
                 "name": "音量水平"
             },
-            "desiccant_frequency": {
+            "desiccant_cycle": {
                 "name": "干燥频率"
             },
             "lid_close_time": {


### PR DESCRIPTION
<!--
Before opening this pull request please review the guidelines in the checklist below. If this PR does not meet those guidelines it will not be accepted, and everyone will be sad.

Please include a summary of the change. Screenshots and/or videos can also be helpful if appropriate. New devices or enhancements should include example(s) of relevant information.
-->
## Proposed change:
Add support for controlling the machine cleaning and filter replacement frequency and resetting the counters, for both Docstream RFID + Non-RFID fountains.
![image](https://github.com/user-attachments/assets/9671f937-ec31-463c-9a81-301e0155a946)
![image](https://github.com/user-attachments/assets/5346dc5e-22a5-438b-85b5-84e4b7ffa3fa)

Closes #94 & Closes #95 

## Type of change:

- [ ] New device.
- [ ] Bug fix (non-breaking change which fixes an issue).
- [X] New feature or enhancement (non-breaking change which adds functionality).
- [ ] Documentation only.
- [ ] Other (please explain).

## Checklist:

- [X] If applicable, I have added corresponding documentation changes.
- [X] If applicable, I have reviewed the [feature / enhancement](https://github.com/jjjonesjr33/petlibro/wiki/Feature-&-Enhancement-Guidelines) guidlines before submitting my request.
- [X] If applicable, I have tested my code for new features & regressions on the latest version of Home Assistant.

## Additional notes:
We could likely combine the frequency updating into 1 in apy.py, as we pass the key for the cleaning type from the feeder/fountain itself now.
