### PR TITLE
Feature/Granary-Smart-Feeder-Reset-Desiccant

### DIFF
--- a/custom_components/petlibro/api.py
+++ b/custom_components/petlibro/api.py
@@ -430,7 +430,7 @@ class PetLibroAPI:
         """Enable or disable the child lock functionality."""
         try:
             response = await self.session.post(
-                "/device/setting/updateChildLockSwitch", 
+                "/device/setting/updateChildLockSwitch",
                 json={"deviceSn": serial, "enable": enable}
             )
 
@@ -694,7 +694,7 @@ class PetLibroAPI:
                 "deviceSn": serial,
                 # The plate ID doesn't matter here - the device will always feed from the current bowl regardless of what the plate ID is.
                 # The app also always uses 1 for the plate ID.
-                "plate": 1 
+                "plate": 1
             })
 
         except aiohttp.ClientError as err:
@@ -752,7 +752,7 @@ class PetLibroAPI:
     async def set_desiccant_reset(self, serial: str) -> JSON:
         """Trigger desiccant reset for a specific device."""
         _LOGGER.debug(f"Triggering desiccant reset for device with serial: {serial}")
-        
+
         try:
             # Generate a dynamic request ID for the manual feeding
             request_id = str(uuid.uuid4()).replace("-", "")
@@ -764,15 +764,20 @@ class PetLibroAPI:
                 "timeout": 5000
             })
 
+            # Granary smart feeder quirk: response can be None on success
+            if response is None:
+                _LOGGER.debug("Desiccant reset set successfully, got no extra data")
+                return
+
             # Check if response is already parsed (since response is an integer here)
             if isinstance(response, int):
                 _LOGGER.debug(f"Desiccant reset set successfully, returned code: {response}")
                 return response
-            
+
             # If response is a dictionary (JSON), handle it
             response_data = await response.json()
             _LOGGER.debug(f"Desiccant reset response data: {response_data}")
-            
+
             # Check if the response indicates success
             if response.status != 200 or response_data.get("code") != 0:
                 raise PetLibroAPIError(f"Failed to trigger desiccant reset: {response_data.get('msg')}")
@@ -848,4 +853,4 @@ class PetLibroDataCoordinator(DataUpdateCoordinator):
 
     async def _async_update_data(self):
         # Fetch data from the API once per update cycle
-        return await self.api.fetch_device_data()        
+        return await self.api.fetch_device_data()

--- a/custom_components/petlibro/button.py
+++ b/custom_components/petlibro/button.py
@@ -84,6 +84,12 @@ DEVICE_BUTTON_MAP: dict[type[Device], list[PetLibroButtonEntityDescription]] = {
             translation_key="disable_feeding_plan",
             set_fn=lambda device: device.set_feeding_plan(False),
             name="Disable Feeding Plan"
+        ),
+        PetLibroButtonEntityDescription[GranarySmartFeeder](
+            key="desiccant_reset",
+            translation_key="desiccant_reset",
+            set_fn=lambda device: device.set_desiccant_reset(),
+            name="Desiccant Replaced"
         )
     ],
     GranarySmartCameraFeeder: [
@@ -277,7 +283,3 @@ async def async_setup_entry(
 
         # Add button entities to Home Assistant
         async_add_entities(entities)
-
-
-
-

--- a/custom_components/petlibro/devices/feeders/granary_smart_feeder.py
+++ b/custom_components/petlibro/devices/feeders/granary_smart_feeder.py
@@ -309,13 +309,13 @@ class GranarySmartFeeder(Device):  # Inherit directly from Device
             raise PetLibroAPIError(f"Error setting feeding plan: {err}")
 
     async def set_desiccant_frequency(self, value: float) -> None:
-                _LOGGER.debug(f"Setting desiccant frequency to {value} for {self.serial}")
-                try:
-                    await self.api.set_desiccant_frequency(self.serial, value)
-                    await self.refresh()  # Refresh the state after the action
-                except aiohttp.ClientError as err:
-                    _LOGGER.error(f"Failed to set desiccant frequency for {self.serial}: {err}")
-                    raise PetLibroAPIError(f"Error setting desiccantfrequency: {err}")
+        _LOGGER.debug(f"Setting desiccant frequency to {value} for {self.serial}")
+        try:
+            await self.api.set_desiccant_frequency(self.serial, value)
+            await self.refresh()  # Refresh the state after the action
+        except aiohttp.ClientError as err:
+            _LOGGER.error(f"Failed to set desiccant frequency for {self.serial}: {err}")
+            raise PetLibroAPIError(f"Error setting desiccantfrequency: {err}")
 
     async def set_desiccant_reset(self) -> None:
         _LOGGER.debug(f"Triggering desiccant reset for {self.serial}")

--- a/custom_components/petlibro/devices/feeders/granary_smart_feeder.py
+++ b/custom_components/petlibro/devices/feeders/granary_smart_feeder.py
@@ -18,14 +18,14 @@ class GranarySmartFeeder(Device):  # Inherit directly from Device
         """Refresh the device data from the API."""
         try:
             await super().refresh()  # Call the refresh method from Device
-    
+
             # Fetch specific data for this device
             grain_status = await self.api.device_grain_status(self.serial)
             real_info = await self.api.device_real_info(self.serial)
             attribute_settings = await self.api.device_attribute_settings(self.serial)
             get_default_matrix = await self.api.get_default_matrix(self.serial)
             get_feeding_plan_today = await self.api.device_feeding_plan_today_new(self.serial)
-    
+
             # Update internal data with fetched API data
             self.update_data({
                 "grainStatus": grain_status or {},
@@ -174,7 +174,7 @@ class GranarySmartFeeder(Device):  # Inherit directly from Device
     def remaining_desiccant(self) -> str:
         """Get the remaining desiccant days."""
         return cast(str, self._data.get("remainingDesiccantDays", "unknown"))
-    
+
     @property
     def last_feed_time(self) -> str | None:
         """Return the recordTime of the last successful grain output as a formatted string."""
@@ -210,7 +210,11 @@ class GranarySmartFeeder(Device):  # Inherit directly from Device
             _LOGGER.warning(f"manual_feed_quantity is None for {self.serial}, setting default to 1.")
             self._manual_feed_quantity = 1  # Default value
         return self._manual_feed_quantity
-    
+
+    @property
+    def desiccant_frequency(self) -> float:
+        return self._data.get("realInfo", {}).get("changeDesiccantFrequency", 0)
+
     # Error-handling updated for set_feeding_plan
     async def set_feeding_plan(self, value: bool) -> None:
         _LOGGER.debug(f"Setting feeding plan to {value} for {self.serial}")
@@ -276,7 +280,7 @@ class GranarySmartFeeder(Device):  # Inherit directly from Device
         """Set the manual feed quantity."""
         _LOGGER.debug(f"Setting manual feed quantity: serial={self.serial}, value={value}")
         self._manual_feed_quantity = value
-    
+
     async def set_manual_feed_quantity(self, value: float):
         """Set the manual feed quantity with a default value handling"""
         _LOGGER.debug(f"Setting manual feed quantity: serial={self.serial}, value={value}")
@@ -293,7 +297,7 @@ class GranarySmartFeeder(Device):  # Inherit directly from Device
         except aiohttp.ClientError as err:
             _LOGGER.error(f"Failed to trigger manual feed for {self.serial}: {err}")
             raise PetLibroAPIError(f"Error triggering manual feed: {err}")
-        
+
     # Method for setting the feeding plan
     async def set_feeding_plan(self, value: bool) -> None:
         _LOGGER.debug(f"Setting feeding plan to {value} for {self.serial}")
@@ -303,3 +307,21 @@ class GranarySmartFeeder(Device):  # Inherit directly from Device
         except aiohttp.ClientError as err:
             _LOGGER.error(f"Failed to set feeding plan for {self.serial}: {err}")
             raise PetLibroAPIError(f"Error setting feeding plan: {err}")
+
+    async def set_desiccant_frequency(self, value: float) -> None:
+                _LOGGER.debug(f"Setting desiccant frequency to {value} for {self.serial}")
+                try:
+                    await self.api.set_desiccant_frequency(self.serial, value)
+                    await self.refresh()  # Refresh the state after the action
+                except aiohttp.ClientError as err:
+                    _LOGGER.error(f"Failed to set desiccant frequency for {self.serial}: {err}")
+                    raise PetLibroAPIError(f"Error setting desiccantfrequency: {err}")
+
+    async def set_desiccant_reset(self) -> None:
+        _LOGGER.debug(f"Triggering desiccant reset for {self.serial}")
+        try:
+            await self.api.set_desiccant_reset(self.serial)
+            await self.refresh()  # Refresh the state after the action
+        except aiohttp.ClientError as err:
+            _LOGGER.error(f"Failed to trigger desiccant reset for {self.serial}: {err}")
+            raise PetLibroAPIError(f"Error triggering desiccant reset: {err}")

--- a/custom_components/petlibro/number.py
+++ b/custom_components/petlibro/number.py
@@ -66,7 +66,7 @@ class PetLibroNumberEntity(PetLibroEntity[_DeviceT], NumberEntity):
             return None
         _LOGGER.debug(f"Retrieved value for '{self.entity_description.key}', {self.device.name}: {state}")
         return float(state)
-    
+
     async def async_set_native_value(self, value: float) -> None:
         """Set the value of the number."""
         _LOGGER.debug(f"Setting value {value} for {self.device.name}")
@@ -105,7 +105,20 @@ DEVICE_NUMBER_MAP: dict[type[Device], list[PetLibroNumberEntityDescription]] = {
             value = lambda device: device.manual_feed_quantity,
             method = lambda device, value: device.set_manual_feed_quantity(value),
             name = "Manual Feed Quantity"
-        ), 
+        ),
+        PetLibroNumberEntityDescription[GranarySmartFeeder](
+            key="desiccant_frequency",
+            translation_key="desiccant_frequency",
+            icon="mdi:calendar-alert",
+            native_unit_of_measurement="Days",
+            mode="box",
+            native_max_value=60,
+            native_min_value=1,
+            native_step=1,
+            value=lambda device: device.desiccant_frequency,
+            method=lambda device, value: device.set_desiccant_frequency(value),
+            name="Desiccant Frequency"
+        ),
     ],
     GranarySmartCameraFeeder: [
         PetLibroNumberEntityDescription[GranarySmartCameraFeeder](


### PR DESCRIPTION
<!--
Before opening this pull request please review the guidelines in the checklist below. If this PR does not meet those guidelines it will not be accepted, and everyone will be sad.

Please include a summary of the change. Screenshots and/or videos can also be helpful if appropriate. New devices or enhancements should include example(s) of relevant information.
-->
## Proposed change:

Adding desiccant reset and frequency settings for the Granary Smart Feeder, analogous to what's already been done for the One RFID feeder.
<img width="784" height="214" alt="image" src="https://github.com/user-attachments/assets/c652a2f7-b2b0-4462-90e7-0eb33eae5e5a" />
Tested with a real device, plus changes are reflected between the app and HA.

## Type of change:

- [ ] New device.
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature or enhancement (non-breaking change which adds functionality).
- [ ] Documentation only.
- [ ] Other (please explain).

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature / enhancement](https://github.com/jjjonesjr33/petlibro/wiki/Feature-&-Enhancement-Guidelines) guidlines before submitting my request.
- [x] If applicable, I have tested my code for new features & regressions on the latest version of Home Assistant.

## Additional notes:
Only difference in behaviour I've noticed during testing, is that the API returns null for extra `data`, hence [the added conditional in the method](https://github.com/mgren/petlibro/blob/a5d1ccd37c1a154ca28b344df8ac9d549ba7578b/custom_components/petlibro/api.py#L768). I'm heavily tempted to remove all the extra response handling `set_desiccant_reset` does since [request](https://github.com/jjjonesjr33/petlibro/blob/6ada8f845fd8a89def6661b674e17ba11a79268e/custom_components/petlibro/api.py#L62) already covers checking the encapsulating `status` and `code` and One RFID doesn't rely on the returned value. I'd rather not touch it without a device to test on, unless this is a regression from api refactoring that slipped in?
