### PR TITLE
Feature/polar-wet-food-feeder-enhanced-plate-control

### DIFF
--- a/custom_components/petlibro/__init__.py
+++ b/custom_components/petlibro/__init__.py
@@ -59,6 +59,7 @@ PLATFORMS_BY_TYPE = {
         Platform.SENSOR,
         Platform.BINARY_SENSOR,
         Platform.SWITCH,
+        Platform.SELECT,
         Platform.BUTTON,
     ),
     SpaceSmartFeeder: (

--- a/custom_components/petlibro/api.py
+++ b/custom_components/petlibro/api.py
@@ -684,7 +684,7 @@ class PetLibroAPI:
             _LOGGER.error(f"Failed to trigger manual feeding for device {serial}: {err}")
             raise PetLibroAPIError(f"Error triggering manual feeding: {err}")
 
-    async def set_manual_feed_now(self, serial: str):
+    async def set_manual_feed_now(self, serial: str, plate: int):
         """Trigger manual feed now for a specific device. This opens the food bowl door."""
         _LOGGER.debug(f"Triggering manual feed now for device with serial: {serial}")
         
@@ -692,9 +692,7 @@ class PetLibroAPI:
             # Send the POST request to trigger manual feeding
             await self.session.post("/device/wetFeedingPlan/manualFeedNow", json={
                 "deviceSn": serial,
-                # The plate ID doesn't matter here - the device will always feed from the current bowl regardless of what the plate ID is.
-                # The app also always uses 1 for the plate ID.
-                "plate": 1 
+                "plate": plate 
             })
 
         except aiohttp.ClientError as err:

--- a/custom_components/petlibro/devices/feeders/polar_wet_food_feeder.py
+++ b/custom_components/petlibro/devices/feeders/polar_wet_food_feeder.py
@@ -2,6 +2,7 @@ import aiohttp
 
 from ...api import make_api_call
 from aiohttp import ClientSession, ClientError
+import asyncio
 from datetime import datetime
 from ...exceptions import PetLibroAPIError
 from ..device import Device
@@ -167,19 +168,48 @@ class PolarWetFoodFeeder(Device):
     def feeding_plan_today_data(self) -> str:
         return self._data.get("getfeedingplantoday", {})
 
-    async def set_manual_feed_now(self, start: bool) -> None:
+    async def set_manual_feed_now(self, start: bool, plate: int) -> None:
+        plate = plate if plate is not None else self.plate_position
         try:
             if start:
-                _LOGGER.debug(f"Triggering manual feed now for {self.serial}")
-                await self.api.set_manual_feed_now(self.serial)
+                _LOGGER.debug(f"Triggering manual feed now for {self.serial} with plate no.{plate}")
+                await self.api.set_manual_feed_now(self.serial, plate)
             else:
                 _LOGGER.debug(f"Triggering stop feed now for {self.serial}")
                 await self.api.set_stop_feed_now(self.serial, self.manual_feed_id)
             
             await self.refresh()  # Refresh the state after the action
         except aiohttp.ClientError as err:
-            _LOGGER.error(f"Failed to trigger manual feed now for {self.serial}: {err}")
+            _LOGGER.error(f"Failed to trigger manual feed now for {self.serial} with plate no.{plate}: {err}")
             raise PetLibroAPIError(f"Error triggering manual feed now: {err}")
+    
+    async def set_plate_position(self, value: str | int) -> None:
+        """Rotate bowl to requested plate (1-3)"""
+        try:
+            target = int(value)
+        except (TypeError, ValueError):
+            raise PetLibroAPIError(f"Invalid plate value: {value!r}")
+        if target not in (1, 2, 3):
+            # Raise an error if plate count somehow became less than 1 or more than 3.
+            raise PetLibroAPIError(f"Plate must be 1, 2, or 3, got {target}")
+
+        # Ensure we know current position
+        if not self.plate_position:
+            await self.refresh()
+        curr = self.plate_position or 1
+
+        steps = (target - curr) % 3
+        _LOGGER.debug("Rotate-to-plate: curr=%s target=%s steps=%s for %s", curr, target, steps, self.serial)
+
+        # didnt test other cooldowns, may be able reduce.
+        ROTATE_COOLDOWN = 0.6
+        for _ in range(steps):
+            await self.api.set_rotate_food_bowl(self.serial)
+            await asyncio.sleep(ROTATE_COOLDOWN)
+            await self.refresh()
+
+        # Final refresh so sensor/current_option show the target
+        await self.refresh()
 
     async def rotate_food_bowl(self) -> None:
         _LOGGER.debug(f"Triggering rotate food bowl for {self.serial}")

--- a/custom_components/petlibro/switch.py
+++ b/custom_components/petlibro/switch.py
@@ -58,7 +58,7 @@ DEVICE_SWITCH_MAP: dict[type[Device], list[PetLibroSwitchEntityDescription]] = {
         PetLibroSwitchEntityDescription[PolarWetFoodFeeder](
             key="manual_feed_now",
             translation_key="manual_feed_now",
-            set_fn=lambda device, value: device.set_manual_feed_now(value),
+            set_fn=lambda device, value: device.set_manual_feed_now(value, device.plate_position),
             name="Manually Open/Close Lid"
         ),
     ],

--- a/custom_components/petlibro/translations/en.json
+++ b/custom_components/petlibro/translations/en.json
@@ -118,7 +118,7 @@
                 "name": "Temperature"
             },
             "plate_position": {
-                "name": "Plate position"
+                "name": "Plate Position"
             },
             "display_selection": {
                 "name": "Display Value"
@@ -240,6 +240,9 @@
             },
             "water_dispensing_mode": {
                 "name": "Water Dispensing Mode"
+            },
+            "plate_position": {
+                "name": "Plate Position"
             }
         },
         "text": {


### PR DESCRIPTION
<!--
Before opening this pull request please review the guidelines in the checklist below. If this PR does not meet those guidelines it will not be accepted, and everyone will be sad.

Please include a summary of the change. Screenshots and/or videos can also be helpful if appropriate. New devices or enhancements should include example(s) of relevant information.
-->
## Proposed change:
Add plate selector option. this will rotate the plate inside the feeder, without affecting the lid.
<img width="312" height="80" alt="image" src="https://github.com/user-attachments/assets/c5ebb0c6-1ddb-4010-86af-bb62d5e33bd8" />

Fix that manual opening of the lid would rotate plate to plate 1 in all instances. manual opening now respects the currently selected plate option, from the plate_position sensor. we can probably remove the sensor entity since the selector will always be updated to the same state as the sensor. but i am leaving it in for now, in case someone has used the sensor in automation or something.

Closes #103 

## Type of change:

- [ ] New device.
- [X] Bug fix (non-breaking change which fixes an issue).
- [X] New feature or enhancement (non-breaking change which adds functionality).
- [ ] Documentation only.
- [ ] Other (please explain).

## Checklist:

- [X] If applicable, I have added corresponding documentation changes.
- [X] If applicable, I have reviewed the [feature / enhancement](https://github.com/jjjonesjr33/petlibro/wiki/Feature-&-Enhancement-Guidelines) guidlines before submitting my request.
- [X] If applicable, I have tested my code for new features & regressions on the latest version of Home Assistant.

## Additional notes:
