### PR TITLE
Feature/sync measurement units

### DIFF
--- a/custom_components/petlibro/__init__.py
+++ b/custom_components/petlibro/__init__.py
@@ -162,7 +162,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     # Initialize PetLibroHub
     try:
-        hub = PetLibroHub(hass, entry.data)
+        hub = PetLibroHub(hass, entry)
 
         # Store the hub in hass.data
         hass.data.setdefault(DOMAIN, {})[entry.entry_id] = hub
@@ -172,6 +172,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
         # Load devices only once here
         await hub.load_devices()
+        
+        # Initialize Helpers
+        await hub._initialize_helpers()
 
         # Start the coordinator for periodic updates
         await hub.coordinator.async_config_entry_first_refresh()

--- a/custom_components/petlibro/config_flow.py
+++ b/custom_components/petlibro/config_flow.py
@@ -10,21 +10,23 @@ from typing import Any
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry, ConfigFlow, ConfigFlowResult, OptionsFlow
-from homeassistant.const import CONF_API_TOKEN, CONF_EMAIL, CONF_PASSWORD, CONF_REGION
+from homeassistant.const import CONF_API_TOKEN, CONF_EMAIL, CONF_PASSWORD, CONF_REGION, Platform
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import section
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.selector import selector
+from homeassistant.helpers.entity_registry import async_get as get_entity_registry
 
 from .api import PetLibroAPI
 from .const import (
     DEFAULT_FEED,
     DEFAULT_WATER,
     DEFAULT_WEIGHT,
+    ROUNDING_RULES,
     DOMAIN,
-    CommonAPIKeys as API,
+    APIKey as API,
     Gender,
-    UnitTypes,
+    Unit,
 )
 from .exceptions import PetLibroCannotConnect, PetLibroInvalidAuth
 from .hub import PetLibroHub
@@ -201,25 +203,54 @@ class PetlibroOptionsFlow(OptionsFlow):
             return self.async_abort(reason="account_update_nomember")
 
         user_input = user_input or {}
-        if user_input:
+        if user_input:            
+            update_setting_temp = user_input.pop("measurement_unit", {})
+            update_info_temp = user_input.copy()
+            user_input.update(**update_setting_temp)
+            update_all_units = update_setting_temp.pop("update_all_units", False)
+            
             update_setting = self.collect_updates(
                 fields=(API.FEED_UNIT, API.WATER_UNIT, API.WEIGHT_UNIT),
-                user_input=user_input.pop("measurement_unit", {}),
-                enum_cls=UnitTypes,
+                user_input=update_setting_temp,
+                enum_cls=Unit,
             )
 
             update_info = self.collect_updates(
                 fields=(API.NICKNAME, API.GENDER),
-                user_input=user_input,
+                user_input=update_info_temp,
                 special={
                     API.NICKNAME: lambda v: v or "",
                     API.GENDER: lambda v: self.validate_enum(API.GENDER, v, Gender),
                 },
             )
+                            
+            if update_setting or update_all_units:
+                registry = get_entity_registry(self.hass)
+                for unit_type in self.hub.unit_sensor_unique_ids:
+                    unit = (input if isinstance(input := update_setting.get(unit_type), Unit)
+                        else Unit(input) if input else getattr(self.member, unit_type, None))
+                    if (unit_type not in update_setting or not unit or not unit.device_class) and not update_all_units:
+                        continue
+                    _LOGGER.debug("Updating %s sensor entities", unit_type)
+                    if update_all_units and unit_type == API.FEED_UNIT:
+                        target_units = {"weight": unit if unit.device_class == "weight" else Unit.GRAMS,
+                            "volume": unit if unit.device_class == "volume" else Unit.MILLILITERS}
+                    else:
+                        target_units = {unit.device_class: unit}
+                    for device_class, target_unit in target_units.items():
+                        display_precision = ROUNDING_RULES.get(target_unit, 0)
+                        options = { "unit_of_measurement": target_unit.symbol,
+                                    "display_precision": display_precision,
+                                    "suggested_display_precision": display_precision }
+                        for unique_id in self.hub.unit_sensor_unique_ids.get(unit_type, {}).get(device_class, []):
+                            entity_id = registry.async_get_entity_id(Platform.SENSOR, DOMAIN, unique_id)
+                            _LOGGER.debug("Setting %s to %s with display precision %s", entity_id, unit.symbol, display_precision)
+                            registry.async_update_entity_options(entity_id, Platform.SENSOR, options)
 
             if not (update_info or update_setting):
                 _LOGGER.debug("No account settings were changed.")
-                return self.async_abort(reason="account_update_nochanges")
+                reason = "account_update_nochanges" + ("_update_sensors" if update_all_units else "")
+                return self.async_abort(reason=reason)
 
             no_error = await self.api.member_update_info(update_info, update_setting)
             await self.hub.async_refresh(force_member=True)
@@ -252,12 +283,12 @@ class PetlibroOptionsFlow(OptionsFlow):
                     vol.Required(
                         str(API.GENDER),
                         default=user_input.get(
-                            API.GENDER, getattr(self.member, API.GENDER, str(Gender.NONE))
+                            API.GENDER, getattr(self.member, API.GENDER, Gender.NONE).lower
                         ),
                     ): selector(
                         {
                             "select": {
-                                "options": [g.name.lower() for g in Gender],
+                                "options": [g.lower for g in Gender],
                                 "mode": "dropdown",
                                 "translation_key": "member_gender",
                             }
@@ -280,33 +311,32 @@ class PetlibroOptionsFlow(OptionsFlow):
                 vol.Required(
                     str(API.FEED_UNIT),
                     default=user_input.get(
-                        API.FEED_UNIT, getattr(self.member, API.FEED_UNIT, DEFAULT_FEED.name)
+                        API.FEED_UNIT, getattr(self.member, API.FEED_UNIT, DEFAULT_FEED).lower
                     ),
-                ): self._unit_selector(
-                    (UnitTypes.CUPS, UnitTypes.OUNCES, UnitTypes.GRAMS, UnitTypes.MILLILITERS)
-                ),
+                ): self._unit_selector((Unit.CUPS, Unit.OUNCES, Unit.GRAMS, Unit.MILLILITERS)),
                 vol.Required(
                     str(API.WATER_UNIT),
                     default=user_input.get(
-                        API.WATER_UNIT, getattr(self.member, API.WATER_UNIT, DEFAULT_WATER.name)
+                        API.WATER_UNIT, getattr(self.member, API.WATER_UNIT, DEFAULT_WATER).lower
                     ),
-                ): self._unit_selector((UnitTypes.OUNCES, UnitTypes.MILLILITERS)),
+                ): self._unit_selector((Unit.WATER_OUNCES, Unit.WATER_MILLILITERS)),
                 vol.Required(
                     str(API.WEIGHT_UNIT),
                     default=user_input.get(
                         API.WEIGHT_UNIT,
-                        getattr(self.member, API.WEIGHT_UNIT, DEFAULT_WEIGHT.name),
+                        getattr(self.member, API.WEIGHT_UNIT, DEFAULT_WEIGHT).lower,
                     ),
-                ): self._unit_selector((UnitTypes.POUNDS, UnitTypes.KILOGRAMS)),
+                ): self._unit_selector((Unit.POUNDS, Unit.KILOGRAMS)),
+                vol.Optional("update_all_units", default=user_input.get("update_all_units", False)): bool,
             }
         )
 
-    def _unit_selector(self, options: tuple[Enum, ...]) -> Any:
+    def _unit_selector(self, options: tuple[Unit, ...]) -> Any:
         """Return a dropdown selector for measurement unit options."""
         return selector(
             {
                 "select": {
-                    "options": [o.name.lower() for o in options],
+                    "options": [o.lower for o in options],
                     "mode": "dropdown",
                     "translation_key": "unit_type",
                 }
@@ -324,7 +354,7 @@ class PetlibroOptionsFlow(OptionsFlow):
 
         form_value_str = str(form_value).upper()
         if form_value_str in enum_cls.__members__:
-            return enum_cls[form_value_str].value
+            return enum_cls[form_value_str]
 
         _LOGGER.error("Invalid value: %s for API key: %s", form_value, api_key)
         return None
@@ -358,6 +388,7 @@ class PetlibroOptionsFlow(OptionsFlow):
             else:
                 api_value = form_value
 
-            updates[api_key] = api_value
-
+            if api_value != current_value:
+                updates[api_key] = api_value
+                
         return updates

--- a/custom_components/petlibro/config_flow.py
+++ b/custom_components/petlibro/config_flow.py
@@ -10,19 +10,20 @@ from typing import Any
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry, ConfigFlow, ConfigFlowResult, OptionsFlow
-from homeassistant.const import CONF_API_TOKEN, CONF_EMAIL, CONF_PASSWORD, CONF_REGION, Platform
+from homeassistant.const import CONF_API_TOKEN, CONF_EMAIL, CONF_PASSWORD, CONF_REGION
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import section
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.selector import selector
-from homeassistant.helpers.entity_registry import async_get as get_entity_registry
+from homeassistant.helpers.translation import async_get_translations
 
 from .api import PetLibroAPI
 from .const import (
+    SENTINEL,
     DEFAULT_FEED,
     DEFAULT_WATER,
     DEFAULT_WEIGHT,
-    ROUNDING_RULES,
+    MANUAL_FEED_PORTIONS,
     DOMAIN,
     APIKey as API,
     Gender,
@@ -161,8 +162,6 @@ class PetlibroConfigFlow(ConfigFlow, domain=DOMAIN):
 class PetlibroOptionsFlow(OptionsFlow):
     """Handle an options flow for Petlibro."""
 
-    _SENTINEL = object()
-
     def __init__(self):
         """Initialise Petlibro Options Flow."""
         self._data: dict[str, Any] = {}  # For storing temporary data.
@@ -181,6 +180,8 @@ class PetlibroOptionsFlow(OptionsFlow):
         """Handle the initial options menu."""
 
         _LOGGER.debug("Starting Petlibro options flow.")
+        self.translations = await async_get_translations(
+            self.hass, self.hass.config.language, "common")
         self.entry = self.config_entry
         self.hub = self.hass.data[DOMAIN][self.handler]
         self.api = self.hub.api
@@ -190,73 +191,116 @@ class PetlibroOptionsFlow(OptionsFlow):
         _LOGGER.debug(
             "Started Petlibro options flow for account %s", self.entry.data[CONF_EMAIL]
         )
+        return self.async_show_menu(menu_options=["integration_settings", "account_settings"])
 
-        # Using a menu so more things can be added later.
-        return self.async_show_menu(menu_options=["account_settings"])
+    async def async_step_integration_settings(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle integration-level settings for the Petlibro integration."""
+        
+        user_input = user_input or {}
+        
+        if user_input:
+            manual_feed_portions = user_input.get(MANUAL_FEED_PORTIONS)
+            current_value = self.entry.options.get(MANUAL_FEED_PORTIONS, False)            
+            
+            # --- Nothing changed
+            if manual_feed_portions == current_value:
+                _LOGGER.debug("No integration settings changed.")
+                return self.async_abort(reason=self.get_common_translation("no_settings_changed", "No settings were changed"))
 
+            # --- Update option
+            self.hub.update_options({MANUAL_FEED_PORTIONS: manual_feed_portions})
+            _LOGGER.debug("Updated %s to %s", MANUAL_FEED_PORTIONS, manual_feed_portions)
+            
+            abort_messages = [self.get_common_translation("settings_updated", "Settings updated")]
+
+            # --- Reload integration if feed unit is cups
+            if self.member.feedUnitType == Unit.CUPS:
+                reload_integration = await self.hub.unit_entities.sync_manual_feed_entity_visibility(Unit.CUPS)
+
+                if reload_integration:
+                    abort_messages.append(
+                        self.get_common_translation("reloading_integration", "The integration is being reloaded")
+                    )
+                    _LOGGER.debug("'manual_feed_portions' value changed while feed unit is 'cups', reloading integration.")
+                    self.hass.config_entries.async_schedule_reload(self.handler)
+                else:
+                    _LOGGER.debug("No Manual Feed entities found — nothing to reload.")
+            else:
+                await self.hub.async_refresh()
+
+            # --- Done
+            return self.async_abort(
+                reason="integration_settings_abort",
+                description_placeholders={"integration_settings_abort": "\n".join(abort_messages)},
+            )
+
+        _LOGGER.debug("Showing integration settings form.")
+        return self._show_integration_settings_form(user_input)
+        
     async def async_step_account_settings(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle account settings."""
 
         if not self.member:
-            return self.async_abort(reason="account_update_nomember")
+            return self.async_abort(reason="no_member_data")
 
         user_input = user_input or {}
-        if user_input:            
-            update_setting_temp = user_input.pop("measurement_unit", {})
-            update_info_temp = user_input.copy()
-            user_input.update(**update_setting_temp)
-            update_all_units = update_setting_temp.pop("update_all_units", False)
+        if user_input:
+            # --- Extract updates
+            measurement_units_raw: dict = user_input.pop("measurement_unit", {})
+            account_info_raw = user_input.copy()
+            user_input.update(**measurement_units_raw)
+            update_all_units = measurement_units_raw.pop("update_all_units", False)
             
-            update_setting = self.collect_updates(
+            unit_updates = self.collect_updates(
                 fields=(API.FEED_UNIT, API.WATER_UNIT, API.WEIGHT_UNIT),
-                user_input=update_setting_temp,
+                user_input=measurement_units_raw,
                 enum_cls=Unit,
             )
 
-            update_info = self.collect_updates(
+            info_updates = self.collect_updates(
                 fields=(API.NICKNAME, API.GENDER),
-                user_input=update_info_temp,
+                user_input=account_info_raw,
                 special={
                     API.NICKNAME: lambda v: v or "",
                     API.GENDER: lambda v: self.validate_enum(API.GENDER, v, Gender),
                 },
             )
-                            
-            if update_setting or update_all_units:
-                registry = get_entity_registry(self.hass)
-                for unit_type in self.hub.unit_sensor_unique_ids:
-                    unit = (input if isinstance(input := update_setting.get(unit_type), Unit)
-                        else Unit(input) if input else getattr(self.member, unit_type, None))
-                    if (unit_type not in update_setting or not unit or not unit.device_class) and not update_all_units:
-                        continue
-                    _LOGGER.debug("Updating %s sensor entities", unit_type)
-                    if update_all_units and unit_type == API.FEED_UNIT:
-                        target_units = {"weight": unit if unit.device_class == "weight" else Unit.GRAMS,
-                            "volume": unit if unit.device_class == "volume" else Unit.MILLILITERS}
-                    else:
-                        target_units = {unit.device_class: unit}
-                    for device_class, target_unit in target_units.items():
-                        display_precision = ROUNDING_RULES.get(target_unit, 0)
-                        options = { "unit_of_measurement": target_unit.symbol,
-                                    "display_precision": display_precision,
-                                    "suggested_display_precision": display_precision }
-                        for unique_id in self.hub.unit_sensor_unique_ids.get(unit_type, {}).get(device_class, []):
-                            entity_id = registry.async_get_entity_id(Platform.SENSOR, DOMAIN, unique_id)
-                            _LOGGER.debug("Setting %s to %s with display precision %s", entity_id, unit.symbol, display_precision)
-                            registry.async_update_entity_options(entity_id, Platform.SENSOR, options)
 
-            if not (update_info or update_setting):
+            # --- Update entity options if units changed or update_all_units
+            reload_integration = await self.hub.unit_entities.update_sensor_entity_units(unit_updates, update_all_units)
+
+            # --- Apply account-level changes through API
+            abort_messages = []
+            if not (info_updates or unit_updates):
                 _LOGGER.debug("No account settings were changed.")
-                reason = "account_update_nochanges" + ("_update_sensors" if update_all_units else "")
-                return self.async_abort(reason=reason)
+                abort_messages.append(self.get_common_translation("no_settings_changed", "No settings were changed"))
+            else:
+                success = await self.api.member_update_info(update_info = info_updates, update_setting = unit_updates)
+                if success:
+                    abort_messages.append(self.get_common_translation("account_updated", "Account update successful"))
+                else:
+                    _LOGGER.error("Error updating account info via API.")
+                    return self.async_abort(reason="error_check_logs")
 
-            no_error = await self.api.member_update_info(update_info, update_setting)
-            await self.hub.async_refresh(force_member=True)
+            if update_all_units:
+                abort_messages.append(self.get_common_translation("sensors_updated", "Sensor entities were updated"))
 
+            # --- Reload or refresh
+            if reload_integration:
+                _LOGGER.debug("Reloading integration due to feed unit change to/from cups, or update_all_units chosen.")
+                abort_messages.append(self.get_common_translation("reloading_integration", "The integration is being reloaded"))
+                self.hass.config_entries.async_schedule_reload(self.handler)
+            elif info_updates or unit_updates:
+                await self.hub.async_refresh(force_member=True)
+                
+            # --- Done
             return self.async_abort(
-                reason="account_update_success" if no_error else "error_check_logs"
+                reason="account_settings_abort",
+                description_placeholders={"account_settings_abort": "\n".join(abort_messages)},
             )
 
         _LOGGER.debug("Showing account settings form.")
@@ -265,6 +309,23 @@ class PetlibroOptionsFlow(OptionsFlow):
     # ------------------------------
     # Form Builders
     # ------------------------------
+    
+    def _show_integration_settings_form(self, user_input: dict[str, Any]) -> ConfigFlowResult:
+        """Build and show the integration settings form."""
+
+        return self.async_show_form(
+            data_schema=vol.Schema(
+                {
+                    vol.Optional(
+                        MANUAL_FEED_PORTIONS,
+                        default=self.entry.options.get(MANUAL_FEED_PORTIONS, False),
+                    ): selector({"boolean": {}})
+                }
+            ),
+            description_placeholders={
+                "uom": getattr(self.member, API.FEED_UNIT, DEFAULT_FEED).symbol
+            },
+        )
 
     def _show_account_settings_form(self, user_input: dict[str, Any]) -> ConfigFlowResult:
         """Build and show the account settings form."""
@@ -371,9 +432,9 @@ class PetlibroOptionsFlow(OptionsFlow):
 
         for api_key in fields:
             form_value = user_input.get(api_key)
-            current_value = getattr(self.member, api_key, self._SENTINEL)
+            current_value = getattr(self.member, api_key, SENTINEL)
 
-            if current_value is self._SENTINEL:
+            if current_value is SENTINEL:
                 _LOGGER.error("Unsupported API key: %s", api_key)
                 continue
             if form_value == current_value:
@@ -392,3 +453,10 @@ class PetlibroOptionsFlow(OptionsFlow):
                 updates[api_key] = api_value
                 
         return updates
+    
+    def get_common_translation(self, translation_key: str, fallback: str = "") -> str:
+        """Get a translated string under the 'common' key from the user's chosen language."""
+        translation_path = f"component.{DOMAIN}.common.{translation_key}"
+        if translation_path not in self.translations:
+            _LOGGER.warning("Translation key %s not found in translation file.", translation_key)
+        return self.translations.get(translation_path, fallback)

--- a/custom_components/petlibro/const.py
+++ b/custom_components/petlibro/const.py
@@ -4,6 +4,8 @@ from enum import IntEnum, StrEnum
 
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD, UnitOfMass, UnitOfVolume
 
+type _Unit = Unit
+
 DOMAIN = "petlibro"
 
 # Configuration keys
@@ -17,42 +19,6 @@ PLATFORMS = ["sensor", "switch", "button", "binary_sensor", "number", "select", 
 
 # Update interval for device data in seconds
 UPDATE_INTERVAL_SECONDS = 60  # You can adjust this value based on your needs
-
-
-class UnitTypes(IntEnum):
-    """Weight, feed, and water units with symbols."""
-
-    CUPS = 1, "cup"
-    OUNCES = 2, UnitOfMass.OUNCES
-    GRAMS = 3, UnitOfMass.GRAMS
-    MILLILITERS = 4, UnitOfVolume.MILLILITERS
-    KILOGRAMS = 5, UnitOfMass.KILOGRAMS
-    POUNDS = 6, UnitOfMass.POUNDS
-
-    def __new__(cls, value: int, symbol: str):
-        "Ensures IntEnum functionality while allowing symbols."
-        obj = int.__new__(cls, value)
-        obj._value_ = value
-        obj._symbol = symbol  # noqa: SLF001
-        return obj
-
-    def __str__(self) -> str:
-        """Returns the name as a string."""
-        return self.name
-
-    def __json__(self) -> int:
-        """Returns the int value when sending to the API."""
-        return int(self)
-
-    @property
-    def symbol(self) -> str:
-        """Returns unit symbol."""
-        return self._symbol
-
-
-DEFAULT_WEIGHT = UnitTypes.POUNDS
-DEFAULT_FEED = UnitTypes.CUPS
-DEFAULT_WATER = UnitTypes.OUNCES
 
 
 class Gender(IntEnum):
@@ -72,13 +38,10 @@ class Gender(IntEnum):
         obj._emoji = emoji  # noqa: SLF001
         return obj
 
-    def __str__(self) -> str:
-        """Returns the name as a string."""
-        return self.name
-
-    def __json__(self) -> int:
-        """Returns the int value when sending to API."""
-        return int(self)
+    @property
+    def lower(self) -> str:
+        """Returns unit name in lower case."""
+        return self.name.lower()
 
     @property
     def icon(self) -> str:
@@ -96,13 +59,120 @@ class Gender(IntEnum):
         return self._emoji
 
 
-class CommonAPIKeys(StrEnum):
+class APIKey(StrEnum):
     """Common API JSON keys."""
 
-    ACCOUNT_ID = "id"
+    # Common
+    ID = "id"
+    NAME = "name"
+    WEIGHT = "weight"
+
+    # Member
     EMAIL = "email"
     NICKNAME = "nickname"
     GENDER = "gender"
     FEED_UNIT = "feedUnitType"
     WATER_UNIT = "waterUnitType"
     WEIGHT_UNIT = "weightUnitType"
+
+    # Pet
+    BIRTHDAY = "birthday"
+    TYPE = "type"
+    SEX = "gender"
+    BREED_NAME = "breedName"
+    BREED_ID = "breedId"
+    PET_ID = "petId"
+
+
+class Unit(IntEnum):
+    """Weight, feed, and water units with symbols and conversion."""
+
+    CUPS = 1, 1/12, "cup", ""
+    OUNCES = 2, 0.35, UnitOfMass.OUNCES, "weight"
+    GRAMS = 3, 10, UnitOfMass.GRAMS, "weight"
+    MILLILITERS = 4, 20, UnitOfVolume.MILLILITERS, "volume"
+
+    KILOGRAMS = 5, 1, UnitOfMass.KILOGRAMS, "weight"
+    POUNDS = 6, 2.20459, UnitOfMass.POUNDS, "weight"
+
+    WATER_OUNCES = 2 +6, 0.035195, UnitOfVolume.FLUID_OUNCES, "volume"
+    WATER_MILLILITERS = 4 +6, 1, UnitOfVolume.MILLILITERS, "volume"
+    
+    # KILOGRAMS, POUNDS, and WATER_ values can be converted using HA's built-in unit
+    # converter, so their "factor"s and "device_class"s likely won't be used much or at all.
+    
+    # WATER_ int values must be different to avoid aliasing. Take care when using .value
+
+    def __new__(cls, value: int, factor: float, symbol: str, device_class: str):
+        "Ensures IntEnum functionality while allowing extra attributes."
+        
+        obj = int.__new__(cls, value if value <= 6 else value - 6)
+        obj._value_ = value
+        obj._factor = factor  # noqa: SLF001
+        obj._symbol = symbol  # noqa: SLF001
+        obj._device_class = device_class  # noqa: SLF001
+        return obj
+
+    @property
+    def lower(self) -> str:
+        """Returns unit name in lower case."""
+        return self.name.lower()
+
+    @property
+    def factor(self) -> float:
+        """Returns unit conversion factor."""
+        return self._factor
+
+    @property
+    def symbol(self) -> str:
+        """Returns unit symbol."""
+        return self._symbol
+
+    @property
+    def device_class(self) -> str:
+        """Returns unit device class."""
+        return self._device_class
+
+    @classmethod
+    def round(self, value: float, unit: _Unit):
+        return round(value, ROUNDING_RULES.get(unit, 0))
+
+    @classmethod
+    def convert_feed(
+        self, value: float, from_unit: _Unit | None, to_unit: _Unit | None, rounded: bool = False
+    ):
+        """Convert PetLibro feed units. Use **None** for portion unit (1/12th of a cup)."""
+        if value and from_unit != to_unit:
+            if not {from_unit, to_unit}.issubset(VALID_UNIT_TYPES[APIKey.FEED_UNIT]):
+                raise ValueError(f"Incompatible conversion: {from_unit} -> {to_unit}")
+
+            from_factor = from_unit.factor if from_unit else 1
+            to_factor = to_unit.factor if to_unit else 1
+
+            api_value = value / from_factor
+            new_value = api_value * to_factor
+        else:
+            new_value = value
+
+        if not to_unit:
+            return round(new_value)
+        if rounded:
+            return Unit.round(new_value, to_unit)
+        return new_value
+    
+
+DEFAULT_WEIGHT = Unit.POUNDS
+DEFAULT_FEED = Unit.CUPS
+DEFAULT_WATER = Unit.WATER_OUNCES
+MAX_FEED_PORTIONS = 48
+VALID_UNIT_TYPES: dict[str, set[Unit]] = {
+    APIKey.WEIGHT_UNIT: {Unit.POUNDS, Unit.KILOGRAMS, None},
+    APIKey.FEED_UNIT: {Unit.CUPS, Unit.OUNCES, Unit.GRAMS, Unit.MILLILITERS, None},
+    APIKey.WATER_UNIT: {Unit.WATER_OUNCES, Unit.WATER_MILLILITERS, None},
+}
+ROUNDING_RULES = {
+    Unit.CUPS: 3, Unit.OUNCES: 2, Unit.POUNDS: 2, Unit.WATER_OUNCES: 2, Unit.KILOGRAMS: 2
+}
+WATER_MAPPING = {
+    Unit.MILLILITERS: Unit.WATER_MILLILITERS, Unit.OUNCES: Unit.WATER_OUNCES
+}

--- a/custom_components/petlibro/const.py
+++ b/custom_components/petlibro/const.py
@@ -95,7 +95,7 @@ class Unit(IntEnum):
     KILOGRAMS = 5, 1, UnitOfMass.KILOGRAMS, "weight"
     POUNDS = 6, 2.20459, UnitOfMass.POUNDS, "weight"
 
-    WATER_OUNCES = 2 +6, 0.035195, UnitOfVolume.FLUID_OUNCES, "volume"
+    WATER_OUNCES = 2 +6, 0.033814, UnitOfVolume.FLUID_OUNCES, "volume"
     WATER_MILLILITERS = 4 +6, 1, UnitOfVolume.MILLILITERS, "volume"
     
     # KILOGRAMS, POUNDS, and WATER_ values can be converted using HA's built-in unit

--- a/custom_components/petlibro/const.py
+++ b/custom_components/petlibro/const.py
@@ -5,8 +5,10 @@ from enum import IntEnum, StrEnum
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD, UnitOfMass, UnitOfVolume
 
 type _Unit = Unit
+SENTINEL = object()
 
 DOMAIN = "petlibro"
+GITHUB = "https://github.com/jjjonesjr33/petlibro"
 
 # Configuration keys
 CONF_EMAIL = "email"
@@ -85,9 +87,15 @@ class APIKey(StrEnum):
 
 
 class Unit(IntEnum):
-    """Weight, feed, and water units with symbols and conversion."""
+    """Weight, feed, and water units with symbols and conversion.
+    
+    KILOGRAMS, POUNDS, and WATER values can be converted using HA's built-in unit
+    converter, so their 'factor's and 'device_class's likely won't be used much.
+    
+    WATER int values must be different to avoid aliasing. Take care when using .value
+    """
 
-    CUPS = 1, 1/12, "cup", ""
+    CUPS = 1, 1/12, "cups", ""
     OUNCES = 2, 0.35, UnitOfMass.OUNCES, "weight"
     GRAMS = 3, 10, UnitOfMass.GRAMS, "weight"
     MILLILITERS = 4, 20, UnitOfVolume.MILLILITERS, "volume"
@@ -97,11 +105,6 @@ class Unit(IntEnum):
 
     WATER_OUNCES = 2 +6, 0.033814, UnitOfVolume.FLUID_OUNCES, "volume"
     WATER_MILLILITERS = 4 +6, 1, UnitOfVolume.MILLILITERS, "volume"
-    
-    # KILOGRAMS, POUNDS, and WATER_ values can be converted using HA's built-in unit
-    # converter, so their "factor"s and "device_class"s likely won't be used much or at all.
-    
-    # WATER_ int values must be different to avoid aliasing. Take care when using .value
 
     def __new__(cls, value: int, factor: float, symbol: str, device_class: str):
         "Ensures IntEnum functionality while allowing extra attributes."
@@ -165,6 +168,7 @@ DEFAULT_WEIGHT = Unit.POUNDS
 DEFAULT_FEED = Unit.CUPS
 DEFAULT_WATER = Unit.WATER_OUNCES
 MAX_FEED_PORTIONS = 48
+MANUAL_FEED_PORTIONS = "manual_feed_portions"
 VALID_UNIT_TYPES: dict[str, set[Unit]] = {
     APIKey.WEIGHT_UNIT: {Unit.POUNDS, Unit.KILOGRAMS, None},
     APIKey.FEED_UNIT: {Unit.CUPS, Unit.OUNCES, Unit.GRAMS, Unit.MILLILITERS, None},

--- a/custom_components/petlibro/devices/device.py
+++ b/custom_components/petlibro/devices/device.py
@@ -5,16 +5,18 @@ from typing import cast
 
 from ..api import PetLibroAPI
 from .event import Event, EVENT_UPDATE
+from ..member import Member
 
 
 _LOGGER = getLogger(__name__)
 
 
 class Device(Event):
-    def __init__(self, data: dict, api: PetLibroAPI):
+    def __init__(self, data: dict, member: Member, api: PetLibroAPI):
         super().__init__()
         self._data: dict = {}
         self.api = api
+        self.member = member
 
         self.update_data(data)
 

--- a/custom_components/petlibro/devices/feeders/one_rfid_smart_feeder.py
+++ b/custom_components/petlibro/devices/feeders/one_rfid_smart_feeder.py
@@ -3,6 +3,7 @@ import aiohttp
 from ...api import make_api_call
 from aiohttp import ClientSession, ClientError
 from ...exceptions import PetLibroAPIError
+from ...const import MAX_FEED_PORTIONS
 from ..device import Device
 from typing import cast
 from logging import getLogger
@@ -237,6 +238,18 @@ class OneRFIDSmartFeeder(Device):
         return None
 
     @property
+    def last_feed_quantity(self) -> int | None:
+        """Return the last feed amount."""
+        raw = self._data.get("workRecord", [])
+        if raw and isinstance(raw, list):
+            for day_entry in raw:
+                for record in day_entry.get("workRecords", []):
+                    _LOGGER.debug("Evaluating record type: %s", record.get("type"))
+                    if record.get("type") == "GRAIN_OUTPUT_SUCCESS":
+                        return record.get("actualGrainNum") or 0
+        return 0
+
+    @property
     def feeding_plan_today_data(self) -> str:
         return self._data.get("getfeedingplantoday", {})
 
@@ -343,8 +356,7 @@ class OneRFIDSmartFeeder(Device):
     async def set_manual_feed_quantity(self, value: float):
         """Set the manual feed quantity with a default value handling"""
         _LOGGER.debug(f"Setting manual feed quantity: serial={self.serial}, value={value}")
-        self.manual_feed_quantity = max(1, min(value, 12))  # Ensure value is within valid range
-        await self.refresh()
+        self.manual_feed_quantity = max(1, min(value, MAX_FEED_PORTIONS))  # Ensure value is within valid range
 
     # Method for manual feeding
     async def set_manual_feed(self) -> None:

--- a/custom_components/petlibro/devices/feeders/space_smart_feeder.py
+++ b/custom_components/petlibro/devices/feeders/space_smart_feeder.py
@@ -3,6 +3,7 @@ import aiohttp
 from typing import cast
 from logging import getLogger
 from ...exceptions import PetLibroAPIError
+from ...const import MAX_FEED_PORTIONS
 from ..device import Device
 from datetime import datetime
 from homeassistant.util import dt as dt_util
@@ -315,8 +316,7 @@ class SpaceSmartFeeder(Device):  # Inherit directly from Device
     async def set_manual_feed_quantity(self, value: float):
         """Set the manual feed quantity with a default value handling"""
         _LOGGER.debug(f"Setting manual feed quantity: serial={self.serial}, value={value}")
-        self.manual_feed_quantity = max(1, min(value, 12))  # Ensure value is within valid range
-        await self.refresh()
+        self.manual_feed_quantity = max(1, min(value, MAX_FEED_PORTIONS))  # Ensure value is within valid range
 
     # Method for manual feeding
     async def set_manual_feed(self) -> None:

--- a/custom_components/petlibro/entity.py
+++ b/custom_components/petlibro/entity.py
@@ -11,7 +11,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity, DataUpda
 
 from .devices import Device
 from .devices.event import EVENT_UPDATE
-from .const import DOMAIN
+from .const import DOMAIN, APIKey
 from .hub import PetLibroHub
 
 _DeviceT = TypeVar("_DeviceT", bound=Device)
@@ -31,6 +31,7 @@ class PetLibroEntity(
         super().__init__(hub.coordinator)
         self.device = device
         self.hub = hub
+        self.member = hub.member
         self.entity_description = description
         self._attr_unique_id = f"{self.device.serial}-{description.key}"
 

--- a/custom_components/petlibro/helpers/__init__.py
+++ b/custom_components/petlibro/helpers/__init__.py
@@ -1,0 +1,1 @@
+"""Helper methods for components within the Petlibro integration."""

--- a/custom_components/petlibro/helpers/unit_entities.py
+++ b/custom_components/petlibro/helpers/unit_entities.py
@@ -7,8 +7,8 @@ from homeassistant.const import Platform
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_registry import (
-    async_get as get_entity_registry, 
-    RegistryEntryDisabler, 
+    async_get as get_entity_registry,
+    RegistryEntryDisabler,
     RegistryEntryHider
 )
 
@@ -32,7 +32,7 @@ class Unit_Entities:
     An example of a unit entity is the sensor 'today_feeding_quantity_weight', which syncronises with
     Petlibro Feeder units to display feed quantities in the user's configured feed weight.
     """
-    
+
     def __init__(self, *, hass: HomeAssistant, config_entry: ConfigEntry, hub: PetLibroHub):
         """Initialise the Unit_Entities class."""
         self.hass = hass
@@ -42,9 +42,9 @@ class Unit_Entities:
         self.member = self.hub.member
         self.entity_registry = get_entity_registry(self.hass)
         self._sync_task = None
-        
+
     async def sync_manual_feed_entity_visibility(
-        self, /, feed_unit: Unit | None = UNDEFINED, include_portions: bool = True, 
+        self, /, feed_unit: Unit | None = UNDEFINED, include_portions: bool = True,
     ) -> bool:
         """Enable/disable and hide/unhide manual feed entities based on compatibility.
 
@@ -58,12 +58,12 @@ class Unit_Entities:
 
         numbers = self.hub.manual_feed_unique_ids.get(Platform.NUMBER)
         selects = self.hub.manual_feed_unique_ids.get(Platform.SELECT)
-        
+
         if len(numbers) != len(selects):
-            raise HomeAssistantError(
+            _LOGGER.error(
                 "Not all Number entities have an equivalent Select entity, or vice versa. "
-                f"Please open an issue at {GITHUB}/issues if the problem persists.\n"
-                f"Number entities: {numbers}\nSelect entities: {selects}"
+                "Please open an issue at %s/issues if the problem persists.\n"
+                "Number entities: %s\nSelect entities: %s", GITHUB, numbers, selects
             )
         elif not (numbers and selects):
             # No entities to update
@@ -71,48 +71,48 @@ class Unit_Entities:
 
         feed_unit = self.member.feedUnitType if feed_unit is UNDEFINED else feed_unit
         set_as_portion = self.entry.options.get(MANUAL_FEED_PORTIONS) if include_portions else False
-        
-        def incompatible(platform: Platform) -> bool:     
+
+        def incompatible(platform: Platform) -> bool:
             match platform:
                 case Platform.SELECT: return feed_unit != Unit.CUPS or set_as_portion
                 case Platform.NUMBER: return feed_unit == Unit.CUPS and not set_as_portion
                 case _: raise ValueError(f"Unsupported platform: {platform}")
-        
+
         for platform, unique_ids in self.hub.manual_feed_unique_ids.items():
             entity_ids = []
             not_found = []
-        
+
             for unique_id in unique_ids:
                 if entity_id := self.entity_registry.async_get_entity_id(platform, DOMAIN, unique_id):
                     entity_ids.append(entity_id)
                 else:
                     not_found.append(unique_id)
-            
+
             if not_found:
                 _LOGGER.warning("Manual feed entities not found for %s: %s", platform, not_found)
-                
+
             if not entity_ids:
                 continue
-            
+
             incompat = incompatible(platform)
-            disable = RegistryEntryDisabler.CONFIG_ENTRY if incompat else None
+            disable = RegistryEntryDisabler.INTEGRATION if incompat else None
             hide = RegistryEntryHider.INTEGRATION if incompat else None
-            
+
             action = "Hiding/disabling incompatible" if incompat else "Unhiding/enabling compatible"
             _LOGGER.debug("%s entities for %s: %s", action, platform, entity_ids)
 
-            
+
             for entity_id in entity_ids:
                 self.entity_registry.async_update_entity(entity_id, disabled_by=disable, hidden_by=hide)
-                
+
         return True
-        
+
     @callback
     def schedule_manual_feed_sync(self) -> None:
         """Debounce manual feed entity visibility sync calls to avoid redundant calls."""
         if not self._sync_task or self._sync_task.done():
             self._sync_task = self.hass.async_create_task(self._run_manual_feed_sync())
-            
+
     async def _run_manual_feed_sync(self) -> None:
         """Run the sync_manual_feed_entity_visibility method with default args and reload if needed."""
         reload_needed = await self.sync_manual_feed_entity_visibility()
@@ -123,21 +123,21 @@ class Unit_Entities:
         self, /, new_units: dict[API|str, Unit] = UNDEFINED, update_all_units: bool = False
     ) -> bool:
         """Update all sensor entity units which use Petlibro's feed, weight or water units based on account settings.
-        
+
         Behavior:
         - If `new_units` is UNDEFINED, defaults to all three of the member's current unit types.
         - If `update_all_units` is True, updates all sensor entity units, and will default \
           to the member's current unit type for any not provided in `new_units`.
         - Returns True if the integration needs to be reloaded.
         """
-                
+
         if new_units is UNDEFINED:
             update_all_units = True
             new_units = {}
 
         if not (new_units or update_all_units):
             return False
-        
+
         reload_needed = False
 
         for unit_type, unit_classes in self.hub.unit_sensor_unique_ids.items():
@@ -177,10 +177,10 @@ class Unit_Entities:
                         entity_id, target_unit.symbol, precision,
                     )
                     self.entity_registry.async_update_entity_options(entity_id, Platform.SENSOR, options)
-                        
+
             if (
                 unit_type is API.FEED_UNIT
-                and Unit.CUPS in (unit, self.member.feedUnitType) 
+                and Unit.CUPS in (unit, self.member.feedUnitType)
                 and not self.entry.options.get(MANUAL_FEED_PORTIONS)
             ) or update_all_units:
                 try:

--- a/custom_components/petlibro/helpers/unit_entities.py
+++ b/custom_components/petlibro/helpers/unit_entities.py
@@ -1,0 +1,192 @@
+"""Class to manage entities which use Petlibro measurement units."""
+
+import logging
+
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.const import Platform
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity_registry import (
+    async_get as get_entity_registry, 
+    RegistryEntryDisabler, 
+    RegistryEntryHider
+)
+
+from ..const import (
+    SENTINEL as UNDEFINED,
+    DOMAIN,
+    GITHUB,
+    MANUAL_FEED_PORTIONS,
+    ROUNDING_RULES,
+    Unit,
+    APIKey as API,
+)
+from ..hub import PetLibroHub
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class Unit_Entities:
+    """Manage the entities which use Petlibro measurement units.
+
+    An example of a unit entity is the sensor 'today_feeding_quantity_weight', which syncronises with
+    Petlibro Feeder units to display feed quantities in the user's configured feed weight.
+    """
+    
+    def __init__(self, *, hass: HomeAssistant, config_entry: ConfigEntry, hub: PetLibroHub):
+        """Initialise the Unit_Entities class."""
+        self.hass = hass
+        self.entry = config_entry
+        self.handler = self.entry.entry_id
+        self.hub = hub
+        self.member = self.hub.member
+        self.entity_registry = get_entity_registry(self.hass)
+        self._sync_task = None
+        
+    async def sync_manual_feed_entity_visibility(
+        self, /, feed_unit: Unit | None = UNDEFINED, include_portions: bool = True, 
+    ) -> bool:
+        """Enable/disable and hide/unhide manual feed entities based on compatibility.
+
+        Behavior:
+        - If `feed_unit` is UNDEFINED, defaults to the member's current feed unit type.
+        - If `include_portions` is False, ignores MANUAL_FEED_PORTIONS integration option.
+        - SELECT entities are disabled when not using cups or when portions are enabled.
+        - NUMBER entities are disabled when using cups without portions.
+        - Returns True if the integration needs to be reloaded.
+        """
+
+        numbers = self.hub.manual_feed_unique_ids.get(Platform.NUMBER)
+        selects = self.hub.manual_feed_unique_ids.get(Platform.SELECT)
+        
+        if len(numbers) != len(selects):
+            raise HomeAssistantError(
+                "Not all Number entities have an equivalent Select entity, or vice versa. "
+                f"Please open an issue at {GITHUB}/issues if the problem persists.\n"
+                f"Number entities: {numbers}\nSelect entities: {selects}"
+            )
+        elif not (numbers and selects):
+            # No entities to update
+            return False
+
+        feed_unit = self.member.feedUnitType if feed_unit is UNDEFINED else feed_unit
+        set_as_portion = self.entry.options.get(MANUAL_FEED_PORTIONS) if include_portions else False
+        
+        def incompatible(platform: Platform) -> bool:     
+            match platform:
+                case Platform.SELECT: return feed_unit != Unit.CUPS or set_as_portion
+                case Platform.NUMBER: return feed_unit == Unit.CUPS and not set_as_portion
+                case _: raise ValueError(f"Unsupported platform: {platform}")
+        
+        for platform, unique_ids in self.hub.manual_feed_unique_ids.items():
+            entity_ids = []
+            not_found = []
+        
+            for unique_id in unique_ids:
+                if entity_id := self.entity_registry.async_get_entity_id(platform, DOMAIN, unique_id):
+                    entity_ids.append(entity_id)
+                else:
+                    not_found.append(unique_id)
+            
+            if not_found:
+                _LOGGER.warning("Manual feed entities not found for %s: %s", platform, not_found)
+                
+            if not entity_ids:
+                continue
+            
+            incompat = incompatible(platform)
+            disable = RegistryEntryDisabler.CONFIG_ENTRY if incompat else None
+            hide = RegistryEntryHider.INTEGRATION if incompat else None
+            
+            action = "Hiding/disabling incompatible" if incompat else "Unhiding/enabling compatible"
+            _LOGGER.debug("%s entities for %s: %s", action, platform, entity_ids)
+
+            
+            for entity_id in entity_ids:
+                self.entity_registry.async_update_entity(entity_id, disabled_by=disable, hidden_by=hide)
+                
+        return True
+        
+    @callback
+    def schedule_manual_feed_sync(self) -> None:
+        """Debounce manual feed entity visibility sync calls to avoid redundant calls."""
+        if not self._sync_task or self._sync_task.done():
+            self._sync_task = self.hass.async_create_task(self._run_manual_feed_sync())
+            
+    async def _run_manual_feed_sync(self) -> None:
+        """Run the sync_manual_feed_entity_visibility method with default args and reload if needed."""
+        reload_needed = await self.sync_manual_feed_entity_visibility()
+        if reload_needed:
+            self.hass.config_entries.async_schedule_reload(self.handler)
+
+    async def update_sensor_entity_units(
+        self, /, new_units: dict[API|str, Unit] = UNDEFINED, update_all_units: bool = False
+    ) -> bool:
+        """Update all sensor entity units which use Petlibro's feed, weight or water units based on account settings.
+        
+        Behavior:
+        - If `new_units` is UNDEFINED, defaults to all three of the member's current unit types.
+        - If `update_all_units` is True, updates all sensor entity units, and will default \
+          to the member's current unit type for any not provided in `new_units`.
+        - Returns True if the integration needs to be reloaded.
+        """
+                
+        if new_units is UNDEFINED:
+            update_all_units = True
+            new_units = {}
+
+        if not (new_units or update_all_units):
+            return False
+        
+        reload_needed = False
+
+        for unit_type, unit_classes in self.hub.unit_sensor_unique_ids.items():
+            selected = new_units.get(unit_type)
+            unit = (
+                selected if isinstance(selected, Unit)
+                else Unit(selected) if selected
+                else getattr(self.member, unit_type, None)
+            )
+            if not update_all_units and (unit_type not in new_units or not unit):
+                continue
+
+            _LOGGER.debug("Updating %s entities", unit_type)
+
+            target_units = (
+                {"weight": unit if unit and unit.device_class == "weight" else Unit.GRAMS,
+                "volume": unit if unit and unit.device_class == "volume" else Unit.MILLILITERS}
+                if update_all_units and unit_type == API.FEED_UNIT
+                else {unit.device_class: unit} if unit and unit.device_class else {}
+            )
+
+            for device_class, unique_ids in unit_classes.items():
+                if not (target_unit := target_units.get(device_class)):
+                    continue
+                precision = ROUNDING_RULES.get(target_unit, 0)
+                options = {
+                    "unit_of_measurement": target_unit.symbol,
+                    "display_precision": precision,
+                    "suggested_display_precision": precision,
+                }
+                for unique_id in unique_ids:
+                    entity_id = self.entity_registry.async_get_entity_id(Platform.SENSOR, DOMAIN, unique_id)
+                    if not entity_id:
+                        continue
+                    _LOGGER.debug(
+                        "Setting %s to %s with display precision %s",
+                        entity_id, target_unit.symbol, precision,
+                    )
+                    self.entity_registry.async_update_entity_options(entity_id, Platform.SENSOR, options)
+                        
+            if (
+                unit_type is API.FEED_UNIT
+                and Unit.CUPS in (unit, self.member.feedUnitType) 
+                and not self.entry.options.get(MANUAL_FEED_PORTIONS)
+            ) or update_all_units:
+                try:
+                    reload_needed = await self.sync_manual_feed_entity_visibility(unit)
+                except HomeAssistantError as e:
+                    _LOGGER.error("Error syncing manual feed entity visibility: %s", e)
+
+        _LOGGER.debug("Unit entity update complete (reload=%s)", reload_needed)
+        return reload_needed

--- a/custom_components/petlibro/hub.py
+++ b/custom_components/petlibro/hub.py
@@ -3,13 +3,16 @@ import asyncio
 from logging import getLogger
 from asyncio import gather
 from collections.abc import Mapping
+import sys
 from typing import List, Any, Optional
 from datetime import datetime, timedelta
 from .const import UPDATE_INTERVAL_SECONDS
 from homeassistant.core import HomeAssistant
-from homeassistant.const import CONF_REGION, CONF_API_TOKEN
+from homeassistant.const import CONF_REGION, CONF_API_TOKEN, Platform
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.components.sensor.const import SensorDeviceClass
 from aiohttp import ClientResponseError, ClientConnectorError
 from .api import PetLibroAPI  # Use a relative import if inside the same package
 from .const import DOMAIN, CONF_EMAIL, CONF_PASSWORD, APIKey  # Import CONF_EMAIL and CONF_PASSWORD
@@ -22,25 +25,30 @@ _LOGGER = getLogger(__name__)
 class PetLibroHub:
     """A PetLibro hub wrapper class."""
 
-    def __init__(self, hass: HomeAssistant, data: Mapping[str, Any]) -> None:
+    def __init__(self, hass: HomeAssistant, config_entry: ConfigEntry) -> None:
         """Initialize the PetLibro Hub."""
         self.hass = hass
-        self._data = data
+        self.entry = config_entry
+        self._data = self.entry.data
         self.devices: List[Device] = []  # Initialize devices as an instance variable
         self.member: Member = None
         self.last_refresh_times = {}  # Track the last refresh time for the member & each device
         self.loaded_device_sn = set()  # Track device serial numbers that have already been loaded
         self._last_online_status = {}  # Store online status per device
-        self.unit_sensor_unique_ids: dict[str | APIKey, dict[str, list[str]]] = {
-            APIKey.FEED_UNIT: {"weight": [], "volume": []},
-            APIKey.WEIGHT_UNIT: {"weight": []},
-            APIKey.WATER_UNIT: {"volume": []},
+
+        self.manual_feed_unique_ids: dict[Platform, list[str]] = {
+            Platform.NUMBER: [], Platform.SELECT: []
+        }
+        self.unit_sensor_unique_ids: dict[APIKey, dict[SensorDeviceClass, list[str]]] = {
+            APIKey.FEED_UNIT: {SensorDeviceClass.WEIGHT: [], SensorDeviceClass.VOLUME: []},
+            APIKey.WEIGHT_UNIT: {SensorDeviceClass.WEIGHT: []},
+            APIKey.WATER_UNIT: {SensorDeviceClass.VOLUME: []},
         }
 
         # Fetch email, password, and region from entry.data
-        email = data.get(CONF_EMAIL)
-        password = data.get(CONF_PASSWORD)
-        region = data.get(CONF_REGION)
+        email = self.entry.data.get(CONF_EMAIL)
+        password = self.entry.data.get(CONF_PASSWORD)
+        region = self.entry.data.get(CONF_REGION)
 
         # Check if the required information is provided
         if not email:
@@ -62,7 +70,7 @@ class PetLibroHub:
             region,
             email,
             password,
-            data.get(CONF_API_TOKEN)
+            self.entry.data.get(CONF_API_TOKEN)
         )
 
         # Setup DataUpdateCoordinator to periodically refresh device data
@@ -137,6 +145,11 @@ class PetLibroHub:
         self.member = Member(member_info, self.api)
         self.last_refresh_times[member_email] = datetime.utcnow()
         _LOGGER.debug("Member loaded successfully: %s", member_email)
+        
+    async def _initialize_helpers(self) -> None:
+        if "Unit_Entities" not in sys.modules:
+            from .helpers.unit_entities import Unit_Entities
+        self.unit_entities = Unit_Entities(hass=self.hass, config_entry=self.entry, hub=self)
 
     async def refresh_data(self) -> bool:
         """Refresh all known devices and member info from the PETLIBRO API."""
@@ -238,6 +251,14 @@ class PetLibroHub:
         if not device:
             _LOGGER.debug(f"Device with serial {serial} not found.")
         return device
+
+    def update_options(self, new_options: Mapping[str, Any]) -> None:
+        """Update config entry options."""
+        self.hass.config_entries.async_update_entry(
+            self.entry,
+            options={**self.entry.options, **new_options},
+        )
+        _LOGGER.debug(f"Config entry options updated with: {new_options}")
 
     async def async_refresh(self, force_member: bool = False) -> None:
         """Force a manual data refresh if enough time has passed.

--- a/custom_components/petlibro/number.py
+++ b/custom_components/petlibro/number.py
@@ -56,6 +56,7 @@ class PetLibroNumberEntityDescription(NumberEntityDescription, PetLibroEntityDes
     device_class: Optional[NumberDeviceClass] = None
     entity_registry_visible_default_fn: Callable[[PetLibroNumberEntity], bool | None] = lambda _: None
     entity_registry_enabled_default_fn: Callable[[PetLibroNumberEntity], bool | None] = lambda _: None
+    available_fn: Callable[[PetLibroNumberEntity], bool | None] = lambda _: None
     petlibro_unit: APIKey | str | None = None
 
 class PetLibroNumberEntity(PetLibroEntity[_DeviceT], NumberEntity):
@@ -65,7 +66,7 @@ class PetLibroNumberEntity(PetLibroEntity[_DeviceT], NumberEntity):
     def __init__(self, device, hub, description):
         """Initialize the number."""
         super().__init__(device, hub, description)
-        
+
         if (unit_type := self.entity_description.petlibro_unit) and unit_type == APIKey.FEED_UNIT:
             self.hub.manual_feed_unique_ids[Platform.NUMBER].append(self._attr_unique_id)
 
@@ -125,31 +126,38 @@ class PetLibroNumberEntity(PetLibroEntity[_DeviceT], NumberEntity):
         if (native_step := self.entity_description.native_step_fn(self)) is not None:
             return native_step
         return super().native_step
-    
+
+    @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        if (available := self.entity_description.available_fn(self)) is not None:
+            return available
+        return super().available
+
     @property
     def entity_registry_visible_default(self) -> bool:
         """Return if the entity should be visible when first added."""
         if (visible_default := self.entity_description.entity_registry_visible_default_fn(self)) is not None:
             return visible_default
         return super().entity_registry_visible_default
-    
+
     @property
     def entity_registry_enabled_default(self) -> bool:
         """Return if the entity should be enabled when first added."""
         if (enabled_default := self.entity_description.entity_registry_enabled_default_fn(self)) is not None:
             return enabled_default
         return super().entity_registry_enabled_default
-    
+
     @property
     def portions_enabled(self) -> bool:
-        """Return True if portions are enabled for setting manual feed."""        
+        """Return True if portions are enabled for setting manual feed."""
         return self.hub.entry.options.get(MANUAL_FEED_PORTIONS, False)
-        
+
     @property
     def enable_for_manual_feed(self) -> bool:
-        """Return True if the platform should be enabled for setting manual feed."""        
+        """Return True if the platform should be enabled for setting manual feed."""
         return self.member.feedUnitType is not Unit.CUPS or self.portions_enabled
-    
+
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
@@ -161,7 +169,7 @@ class PetLibroNumberEntity(PetLibroEntity[_DeviceT], NumberEntity):
 
         if self.enabled:
             super()._handle_coordinator_update()
-    
+
 
 DEVICE_NUMBER_MAP: dict[type[Device], list[PetLibroNumberEntityDescription]] = {
     Feeder: [],
@@ -173,16 +181,17 @@ DEVICE_NUMBER_MAP: dict[type[Device], list[PetLibroNumberEntityDescription]] = {
             icon="mdi:scale",
             mode=NumberMode.SLIDER,
             native_unit_of_measurement_fn=lambda s: s.member.feedUnitType.symbol if not s.portions_enabled else "portions",
-            native_max_value_fn=lambda s: Unit.round(s.member.feedUnitType.factor * MAX_FEED_PORTIONS, s.member.feedUnitType) 
+            native_max_value_fn=lambda s: Unit.round(s.member.feedUnitType.factor * MAX_FEED_PORTIONS, s.member.feedUnitType)
                 if not s.portions_enabled else MAX_FEED_PORTIONS,
             native_min_value_fn=lambda s: round(s.member.feedUnitType.factor, 16) if not s.portions_enabled else 1,
             native_step_fn=lambda s: s.member.feedUnitType.factor if not s.portions_enabled else 1,
-            method=lambda s, d, v: d.set_manual_feed_quantity(Unit.convert_feed(v, s.member.feedUnitType, None) 
+            method=lambda s, d, v: d.set_manual_feed_quantity(Unit.convert_feed(v, s.member.feedUnitType, None)
                 if not s.portions_enabled else v),
-            value_fn=lambda s, d: Unit.convert_feed(d.manual_feed_quantity, None, s.member.feedUnitType, True) 
+            value_fn=lambda s, d: Unit.convert_feed(d.manual_feed_quantity, None, s.member.feedUnitType, True)
                 if not s.portions_enabled else d.manual_feed_quantity,
             entity_registry_visible_default_fn=lambda self: self.enable_for_manual_feed,
             entity_registry_enabled_default_fn=lambda self: self.enable_for_manual_feed,
+            available_fn=lambda self: self.enable_for_manual_feed,
             petlibro_unit=APIKey.FEED_UNIT,
         ),
     ],
@@ -194,16 +203,17 @@ DEVICE_NUMBER_MAP: dict[type[Device], list[PetLibroNumberEntityDescription]] = {
             icon="mdi:scale",
             mode=NumberMode.SLIDER,
             native_unit_of_measurement_fn=lambda s: s.member.feedUnitType.symbol if not s.portions_enabled else "portions",
-            native_max_value_fn=lambda s: Unit.round(s.member.feedUnitType.factor * MAX_FEED_PORTIONS, s.member.feedUnitType) 
+            native_max_value_fn=lambda s: Unit.round(s.member.feedUnitType.factor * MAX_FEED_PORTIONS, s.member.feedUnitType)
                 if not s.portions_enabled else MAX_FEED_PORTIONS,
             native_min_value_fn=lambda s: round(s.member.feedUnitType.factor, 16) if not s.portions_enabled else 1,
             native_step_fn=lambda s: s.member.feedUnitType.factor if not s.portions_enabled else 1,
-            method=lambda s, d, v: d.set_manual_feed_quantity(Unit.convert_feed(v, s.member.feedUnitType, None) 
+            method=lambda s, d, v: d.set_manual_feed_quantity(Unit.convert_feed(v, s.member.feedUnitType, None)
                 if not s.portions_enabled else v),
-            value_fn=lambda s, d: Unit.convert_feed(d.manual_feed_quantity, None, s.member.feedUnitType, True) 
+            value_fn=lambda s, d: Unit.convert_feed(d.manual_feed_quantity, None, s.member.feedUnitType, True)
                 if not s.portions_enabled else d.manual_feed_quantity,
             entity_registry_visible_default_fn=lambda self: self.enable_for_manual_feed,
             entity_registry_enabled_default_fn=lambda self: self.enable_for_manual_feed,
+            available_fn=lambda self: self.enable_for_manual_feed,
             petlibro_unit=APIKey.FEED_UNIT,
         ),
         PetLibroNumberEntityDescription[GranarySmartFeeder](
@@ -228,16 +238,17 @@ DEVICE_NUMBER_MAP: dict[type[Device], list[PetLibroNumberEntityDescription]] = {
             icon="mdi:scale",
             mode=NumberMode.SLIDER,
             native_unit_of_measurement_fn=lambda s: s.member.feedUnitType.symbol if not s.portions_enabled else "portions",
-            native_max_value_fn=lambda s: Unit.round(s.member.feedUnitType.factor * MAX_FEED_PORTIONS, s.member.feedUnitType) 
+            native_max_value_fn=lambda s: Unit.round(s.member.feedUnitType.factor * MAX_FEED_PORTIONS, s.member.feedUnitType)
                 if not s.portions_enabled else MAX_FEED_PORTIONS,
             native_min_value_fn=lambda s: round(s.member.feedUnitType.factor, 16) if not s.portions_enabled else 1,
             native_step_fn=lambda s: s.member.feedUnitType.factor if not s.portions_enabled else 1,
-            method=lambda s, d, v: d.set_manual_feed_quantity(Unit.convert_feed(v, s.member.feedUnitType, None) 
+            method=lambda s, d, v: d.set_manual_feed_quantity(Unit.convert_feed(v, s.member.feedUnitType, None)
                 if not s.portions_enabled else v),
-            value_fn=lambda s, d: Unit.convert_feed(d.manual_feed_quantity, None, s.member.feedUnitType, True) 
+            value_fn=lambda s, d: Unit.convert_feed(d.manual_feed_quantity, None, s.member.feedUnitType, True)
                 if not s.portions_enabled else d.manual_feed_quantity,
             entity_registry_visible_default_fn=lambda self: self.enable_for_manual_feed,
             entity_registry_enabled_default_fn=lambda self: self.enable_for_manual_feed,
+            available_fn=lambda self: self.enable_for_manual_feed,
             petlibro_unit=APIKey.FEED_UNIT,
         ),
     ],
@@ -286,16 +297,17 @@ DEVICE_NUMBER_MAP: dict[type[Device], list[PetLibroNumberEntityDescription]] = {
             icon="mdi:scale",
             mode=NumberMode.SLIDER,
             native_unit_of_measurement_fn=lambda s: s.member.feedUnitType.symbol if not s.portions_enabled else "portions",
-            native_max_value_fn=lambda s: Unit.round(s.member.feedUnitType.factor * MAX_FEED_PORTIONS, s.member.feedUnitType) 
+            native_max_value_fn=lambda s: Unit.round(s.member.feedUnitType.factor * MAX_FEED_PORTIONS, s.member.feedUnitType)
                 if not s.portions_enabled else MAX_FEED_PORTIONS,
             native_min_value_fn=lambda s: round(s.member.feedUnitType.factor, 16) if not s.portions_enabled else 1,
             native_step_fn=lambda s: s.member.feedUnitType.factor if not s.portions_enabled else 1,
-            method=lambda s, d, v: d.set_manual_feed_quantity(Unit.convert_feed(v, s.member.feedUnitType, None) 
+            method=lambda s, d, v: d.set_manual_feed_quantity(Unit.convert_feed(v, s.member.feedUnitType, None)
                 if not s.portions_enabled else v),
-            value_fn=lambda s, d: Unit.convert_feed(d.manual_feed_quantity, None, s.member.feedUnitType, True) 
+            value_fn=lambda s, d: Unit.convert_feed(d.manual_feed_quantity, None, s.member.feedUnitType, True)
                 if not s.portions_enabled else d.manual_feed_quantity,
             entity_registry_visible_default_fn=lambda self: self.enable_for_manual_feed,
             entity_registry_enabled_default_fn=lambda self: self.enable_for_manual_feed,
+            available_fn=lambda self: self.enable_for_manual_feed,
             petlibro_unit=APIKey.FEED_UNIT,
         ),
     ],
@@ -308,16 +320,17 @@ DEVICE_NUMBER_MAP: dict[type[Device], list[PetLibroNumberEntityDescription]] = {
             icon="mdi:scale",
             mode=NumberMode.SLIDER,
             native_unit_of_measurement_fn=lambda s: s.member.feedUnitType.symbol if not s.portions_enabled else "portions",
-            native_max_value_fn=lambda s: Unit.round(s.member.feedUnitType.factor * MAX_FEED_PORTIONS, s.member.feedUnitType) 
+            native_max_value_fn=lambda s: Unit.round(s.member.feedUnitType.factor * MAX_FEED_PORTIONS, s.member.feedUnitType)
                 if not s.portions_enabled else MAX_FEED_PORTIONS,
             native_min_value_fn=lambda s: round(s.member.feedUnitType.factor, 16) if not s.portions_enabled else 1,
             native_step_fn=lambda s: s.member.feedUnitType.factor if not s.portions_enabled else 1,
-            method=lambda s, d, v: d.set_manual_feed_quantity(Unit.convert_feed(v, s.member.feedUnitType, None) 
+            method=lambda s, d, v: d.set_manual_feed_quantity(Unit.convert_feed(v, s.member.feedUnitType, None)
                 if not s.portions_enabled else v),
-            value_fn=lambda s, d: Unit.convert_feed(d.manual_feed_quantity, None, s.member.feedUnitType, True) 
+            value_fn=lambda s, d: Unit.convert_feed(d.manual_feed_quantity, None, s.member.feedUnitType, True)
                 if not s.portions_enabled else d.manual_feed_quantity,
             entity_registry_visible_default_fn=lambda self: self.enable_for_manual_feed,
             entity_registry_enabled_default_fn=lambda self: self.enable_for_manual_feed,
+            available_fn=lambda self: self.enable_for_manual_feed,
             petlibro_unit=APIKey.FEED_UNIT,
         ),
         PetLibroNumberEntityDescription[SpaceSmartFeeder](

--- a/custom_components/petlibro/number.py
+++ b/custom_components/petlibro/number.py
@@ -10,20 +10,19 @@ from functools import cached_property
 from typing import Optional
 from typing import Any
 import logging
-from .const import DOMAIN, Unit, MAX_FEED_PORTIONS
+from .const import DOMAIN, Unit, APIKey, MAX_FEED_PORTIONS, MANUAL_FEED_PORTIONS
 from homeassistant.components.number import (
     NumberEntity,
     NumberEntityDescription,
     NumberDeviceClass,
     NumberMode
 )
-from homeassistant.core import HomeAssistant
-from homeassistant.const import UnitOfVolume
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.const import UnitOfVolume, Platform
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.config_entries import ConfigEntry  # Added ConfigEntry import
 from homeassistant.util.unit_conversion import VolumeConverter
 from .hub import PetLibroHub  # Adjust the import path as necessary
-from .member import Member
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -48,18 +47,27 @@ class PetLibroNumberEntityDescription(NumberEntityDescription, PetLibroEntityDes
     """A class that describes device number entities."""
 
     device_class_fn: Callable[[_DeviceT], NumberDeviceClass | None] = lambda _: None
-    native_unit_of_measurement_fn: Callable[[Member], str | None] = lambda _: None
-    native_max_value_fn: Callable[[Member], float | None] = lambda _: None
-    native_min_value_fn: Callable[[Member], float | None] = lambda _: None
-    native_step_fn: Callable[[Member], float | None] = lambda _: None
-    value_fn: Callable[[_DeviceT, Member], float] = lambda d, m: 0
-    method: Callable[[_DeviceT, Member, float], float] = lambda d, m, v: None
+    native_unit_of_measurement_fn: Callable[[PetLibroNumberEntity], str | None] = lambda _: None
+    native_max_value_fn: Callable[[PetLibroNumberEntity], float | None] = lambda _: None
+    native_min_value_fn: Callable[[PetLibroNumberEntity], float | None] = lambda _: None
+    native_step_fn: Callable[[PetLibroNumberEntity], float | None] = lambda _: None
+    value_fn: Callable[[PetLibroNumberEntity, _DeviceT], float] = lambda s, d: 0
+    method: Callable[[PetLibroNumberEntity, _DeviceT, float], float] = lambda s, d, v: None
     device_class: Optional[NumberDeviceClass] = None
+    entity_registry_visible_default_fn: Callable[[PetLibroNumberEntity], bool | None] = lambda _: None
+    entity_registry_enabled_default_fn: Callable[[PetLibroNumberEntity], bool | None] = lambda _: None
+    petlibro_unit: APIKey | str | None = None
 
 class PetLibroNumberEntity(PetLibroEntity[_DeviceT], NumberEntity):
-    """PETLIBRO sensor entity."""
-
+    """PETLIBRO number entity."""
     entity_description: PetLibroNumberEntityDescription[_DeviceT]
+
+    def __init__(self, device, hub, description):
+        """Initialize the number."""
+        super().__init__(device, hub, description)
+        
+        if (unit_type := self.entity_description.petlibro_unit) and unit_type == APIKey.FEED_UNIT:
+            self.hub.manual_feed_unique_ids[Platform.NUMBER].append(self._attr_unique_id)
 
     @cached_property
     def device_class(self) -> NumberDeviceClass | None:
@@ -69,7 +77,7 @@ class PetLibroNumberEntity(PetLibroEntity[_DeviceT], NumberEntity):
     @property
     def native_value(self) -> float | None:
         """Return the current state."""
-        if (value_fn := self.entity_description.value_fn(self.device, self.member)) is not None:
+        if (value_fn := self.entity_description.value_fn(self, self.device)) is not None:
             return value_fn
         state = getattr(self.device, self.entity_description.key, None)
         if state is None:
@@ -84,7 +92,7 @@ class PetLibroNumberEntity(PetLibroEntity[_DeviceT], NumberEntity):
         try:
             # Regular case for sound_level or other methods that only need a value
             _LOGGER.debug(f"Calling method with value={value} for {self.device.name}")
-            await self.entity_description.method(self.device, self.member, value)
+            await self.entity_description.method(self, self.device, value)
             self.async_write_ha_state()
             _LOGGER.debug(f"Value {value} set successfully for {self.device.name}")
         except Exception as e:
@@ -93,31 +101,67 @@ class PetLibroNumberEntity(PetLibroEntity[_DeviceT], NumberEntity):
     @property
     def native_unit_of_measurement(self) -> str | None:
         """Return the native unit of measurement."""
-        if (uom := self.entity_description.native_unit_of_measurement_fn(self.member)) is not None:
+        if (uom := self.entity_description.native_unit_of_measurement_fn(self)) is not None:
             return uom
         return super().native_unit_of_measurement
 
     @property
     def native_min_value(self) -> float:
         """Return the minimum value."""
-        if (min_value := self.entity_description.native_min_value_fn(self.member)) is not None:
+        if (min_value := self.entity_description.native_min_value_fn(self)) is not None:
             return min_value
         return super().native_min_value
 
     @property
     def native_max_value(self) -> float:
         """Return the maximum value."""
-        if (max_value := self.entity_description.native_max_value_fn(self.member)) is not None:
+        if (max_value := self.entity_description.native_max_value_fn(self)) is not None:
             return max_value
         return super().native_max_value
 
     @property
     def native_step(self) -> float | None:
         """Return the increment/decrement step."""
-        if (native_step := self.entity_description.native_step_fn(self.member)) is not None:
+        if (native_step := self.entity_description.native_step_fn(self)) is not None:
             return native_step
         return super().native_step
+    
+    @property
+    def entity_registry_visible_default(self) -> bool:
+        """Return if the entity should be visible when first added."""
+        if (visible_default := self.entity_description.entity_registry_visible_default_fn(self)) is not None:
+            return visible_default
+        return super().entity_registry_visible_default
+    
+    @property
+    def entity_registry_enabled_default(self) -> bool:
+        """Return if the entity should be enabled when first added."""
+        if (enabled_default := self.entity_description.entity_registry_enabled_default_fn(self)) is not None:
+            return enabled_default
+        return super().entity_registry_enabled_default
+    
+    @property
+    def portions_enabled(self) -> bool:
+        """Return True if portions are enabled for setting manual feed."""        
+        return self.hub.entry.options.get(MANUAL_FEED_PORTIONS, False)
+        
+    @property
+    def enable_for_manual_feed(self) -> bool:
+        """Return True if the platform should be enabled for setting manual feed."""        
+        return self.member.feedUnitType is not Unit.CUPS or self.portions_enabled
+    
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        if (self.entity_description.petlibro_unit == APIKey.FEED_UNIT
+            and self.enabled != self.enable_for_manual_feed
+        ):
+            self.hub.unit_entities.schedule_manual_feed_sync()
+            _LOGGER.warning("Feed unit mismatch, reloading integration.")
 
+        if self.enabled:
+            super()._handle_coordinator_update()
+    
 
 DEVICE_NUMBER_MAP: dict[type[Device], list[PetLibroNumberEntityDescription]] = {
     Feeder: [],
@@ -128,12 +172,18 @@ DEVICE_NUMBER_MAP: dict[type[Device], list[PetLibroNumberEntityDescription]] = {
             name="Manual Feed Quantity",
             icon="mdi:scale",
             mode=NumberMode.SLIDER,
-            native_unit_of_measurement_fn=lambda m: m.feedUnitType.symbol,
-            native_max_value_fn=lambda m: Unit.round(m.feedUnitType.factor * MAX_FEED_PORTIONS, m.feedUnitType),
-            native_min_value_fn=lambda m: round(m.feedUnitType.factor, 16),
-            native_step_fn=lambda m: m.feedUnitType.factor,
-            method=lambda d, m, v: d.set_manual_feed_quantity(Unit.convert_feed(v, m.feedUnitType, None)),
-            value_fn=lambda d, m: Unit.convert_feed(d.manual_feed_quantity, None, m.feedUnitType, True),
+            native_unit_of_measurement_fn=lambda s: s.member.feedUnitType.symbol if not s.portions_enabled else "portions",
+            native_max_value_fn=lambda s: Unit.round(s.member.feedUnitType.factor * MAX_FEED_PORTIONS, s.member.feedUnitType) 
+                if not s.portions_enabled else MAX_FEED_PORTIONS,
+            native_min_value_fn=lambda s: round(s.member.feedUnitType.factor, 16) if not s.portions_enabled else 1,
+            native_step_fn=lambda s: s.member.feedUnitType.factor if not s.portions_enabled else 1,
+            method=lambda s, d, v: d.set_manual_feed_quantity(Unit.convert_feed(v, s.member.feedUnitType, None) 
+                if not s.portions_enabled else v),
+            value_fn=lambda s, d: Unit.convert_feed(d.manual_feed_quantity, None, s.member.feedUnitType, True) 
+                if not s.portions_enabled else d.manual_feed_quantity,
+            entity_registry_visible_default_fn=lambda self: self.enable_for_manual_feed,
+            entity_registry_enabled_default_fn=lambda self: self.enable_for_manual_feed,
+            petlibro_unit=APIKey.FEED_UNIT,
         ),
     ],
     GranarySmartFeeder: [
@@ -143,12 +193,18 @@ DEVICE_NUMBER_MAP: dict[type[Device], list[PetLibroNumberEntityDescription]] = {
             name="Manual Feed Quantity",
             icon="mdi:scale",
             mode=NumberMode.SLIDER,
-            native_unit_of_measurement_fn=lambda m: m.feedUnitType.symbol,
-            native_max_value_fn=lambda m: Unit.round(m.feedUnitType.factor * MAX_FEED_PORTIONS, m.feedUnitType),
-            native_min_value_fn=lambda m: round(m.feedUnitType.factor, 16),
-            native_step_fn=lambda m: m.feedUnitType.factor,
-            method=lambda d, m, v: d.set_manual_feed_quantity(Unit.convert_feed(v, m.feedUnitType, None)),
-            value_fn=lambda d, m: Unit.convert_feed(d.manual_feed_quantity, None, m.feedUnitType, True),
+            native_unit_of_measurement_fn=lambda s: s.member.feedUnitType.symbol if not s.portions_enabled else "portions",
+            native_max_value_fn=lambda s: Unit.round(s.member.feedUnitType.factor * MAX_FEED_PORTIONS, s.member.feedUnitType) 
+                if not s.portions_enabled else MAX_FEED_PORTIONS,
+            native_min_value_fn=lambda s: round(s.member.feedUnitType.factor, 16) if not s.portions_enabled else 1,
+            native_step_fn=lambda s: s.member.feedUnitType.factor if not s.portions_enabled else 1,
+            method=lambda s, d, v: d.set_manual_feed_quantity(Unit.convert_feed(v, s.member.feedUnitType, None) 
+                if not s.portions_enabled else v),
+            value_fn=lambda s, d: Unit.convert_feed(d.manual_feed_quantity, None, s.member.feedUnitType, True) 
+                if not s.portions_enabled else d.manual_feed_quantity,
+            entity_registry_visible_default_fn=lambda self: self.enable_for_manual_feed,
+            entity_registry_enabled_default_fn=lambda self: self.enable_for_manual_feed,
+            petlibro_unit=APIKey.FEED_UNIT,
         ),
         PetLibroNumberEntityDescription[GranarySmartFeeder](
             key="desiccant_frequency",
@@ -159,8 +215,8 @@ DEVICE_NUMBER_MAP: dict[type[Device], list[PetLibroNumberEntityDescription]] = {
             native_max_value=60,
             native_min_value=1,
             native_step=1,
-            value_fn=lambda device, m: device.desiccant_frequency,
-            method=lambda device, m, value: device.set_desiccant_frequency(value),
+            value_fn=lambda s, device: device.desiccant_frequency,
+            method=lambda s, device, value: device.set_desiccant_frequency(value),
             name="Desiccant Frequency",
         ),
     ],
@@ -171,12 +227,18 @@ DEVICE_NUMBER_MAP: dict[type[Device], list[PetLibroNumberEntityDescription]] = {
             name="Manual Feed Quantity",
             icon="mdi:scale",
             mode=NumberMode.SLIDER,
-            native_unit_of_measurement_fn=lambda m: m.feedUnitType.symbol,
-            native_max_value_fn=lambda m: Unit.round(m.feedUnitType.factor * MAX_FEED_PORTIONS, m.feedUnitType),
-            native_min_value_fn=lambda m: round(m.feedUnitType.factor, 16),
-            native_step_fn=lambda m: m.feedUnitType.factor,
-            method=lambda d, m, v: d.set_manual_feed_quantity(Unit.convert_feed(v, m.feedUnitType, None)),
-            value_fn=lambda d, m: Unit.convert_feed(d.manual_feed_quantity, None, m.feedUnitType, True),
+            native_unit_of_measurement_fn=lambda s: s.member.feedUnitType.symbol if not s.portions_enabled else "portions",
+            native_max_value_fn=lambda s: Unit.round(s.member.feedUnitType.factor * MAX_FEED_PORTIONS, s.member.feedUnitType) 
+                if not s.portions_enabled else MAX_FEED_PORTIONS,
+            native_min_value_fn=lambda s: round(s.member.feedUnitType.factor, 16) if not s.portions_enabled else 1,
+            native_step_fn=lambda s: s.member.feedUnitType.factor if not s.portions_enabled else 1,
+            method=lambda s, d, v: d.set_manual_feed_quantity(Unit.convert_feed(v, s.member.feedUnitType, None) 
+                if not s.portions_enabled else v),
+            value_fn=lambda s, d: Unit.convert_feed(d.manual_feed_quantity, None, s.member.feedUnitType, True) 
+                if not s.portions_enabled else d.manual_feed_quantity,
+            entity_registry_visible_default_fn=lambda self: self.enable_for_manual_feed,
+            entity_registry_enabled_default_fn=lambda self: self.enable_for_manual_feed,
+            petlibro_unit=APIKey.FEED_UNIT,
         ),
     ],
     OneRFIDSmartFeeder: [
@@ -189,8 +251,8 @@ DEVICE_NUMBER_MAP: dict[type[Device], list[PetLibroNumberEntityDescription]] = {
             native_max_value=60,
             native_min_value=1,
             native_step=1,
-            value_fn=lambda device, m: device.desiccant_cycle,
-            method=lambda device, m, value: device.set_desiccant_cycle(value),
+            value_fn=lambda s, device: device.desiccant_cycle,
+            method=lambda s, device, value: device.set_desiccant_cycle(value),
             name="Desiccant Cycle",
         ),
         PetLibroNumberEntityDescription[OneRFIDSmartFeeder](
@@ -201,8 +263,8 @@ DEVICE_NUMBER_MAP: dict[type[Device], list[PetLibroNumberEntityDescription]] = {
             native_max_value=100,
             native_min_value=1,
             native_step=1,
-            value_fn=lambda device, m: device.sound_level,
-            method=lambda device, m, value: device.set_sound_level(value),
+            value_fn=lambda s, device: device.sound_level,
+            method=lambda s, device, value: device.set_sound_level(value),
             name="Sound Level",
         ),
         PetLibroNumberEntityDescription[OneRFIDSmartFeeder](
@@ -213,8 +275,8 @@ DEVICE_NUMBER_MAP: dict[type[Device], list[PetLibroNumberEntityDescription]] = {
             native_max_value=10,
             native_min_value=1,
             native_step=1,
-            value_fn=lambda device, m: device.lid_close_time,
-            method=lambda device, m, value: device.set_lid_close_time(value),
+            value_fn=lambda s, device: device.lid_close_time,
+            method=lambda s, device, value: device.set_lid_close_time(value),
             name="Lid Close Time",
         ),
         PetLibroNumberEntityDescription[OneRFIDSmartFeeder](
@@ -223,12 +285,18 @@ DEVICE_NUMBER_MAP: dict[type[Device], list[PetLibroNumberEntityDescription]] = {
             name="Manual Feed Quantity",
             icon="mdi:scale",
             mode=NumberMode.SLIDER,
-            native_unit_of_measurement_fn=lambda m: m.feedUnitType.symbol,
-            native_max_value_fn=lambda m: Unit.round(m.feedUnitType.factor * MAX_FEED_PORTIONS, m.feedUnitType),
-            native_min_value_fn=lambda m: round(m.feedUnitType.factor, 16),
-            native_step_fn=lambda m: m.feedUnitType.factor,
-            method=lambda d, m, v: d.set_manual_feed_quantity(Unit.convert_feed(v, m.feedUnitType, None)),
-            value_fn=lambda d, m: Unit.convert_feed(d.manual_feed_quantity, None, m.feedUnitType, True),
+            native_unit_of_measurement_fn=lambda s: s.member.feedUnitType.symbol if not s.portions_enabled else "portions",
+            native_max_value_fn=lambda s: Unit.round(s.member.feedUnitType.factor * MAX_FEED_PORTIONS, s.member.feedUnitType) 
+                if not s.portions_enabled else MAX_FEED_PORTIONS,
+            native_min_value_fn=lambda s: round(s.member.feedUnitType.factor, 16) if not s.portions_enabled else 1,
+            native_step_fn=lambda s: s.member.feedUnitType.factor if not s.portions_enabled else 1,
+            method=lambda s, d, v: d.set_manual_feed_quantity(Unit.convert_feed(v, s.member.feedUnitType, None) 
+                if not s.portions_enabled else v),
+            value_fn=lambda s, d: Unit.convert_feed(d.manual_feed_quantity, None, s.member.feedUnitType, True) 
+                if not s.portions_enabled else d.manual_feed_quantity,
+            entity_registry_visible_default_fn=lambda self: self.enable_for_manual_feed,
+            entity_registry_enabled_default_fn=lambda self: self.enable_for_manual_feed,
+            petlibro_unit=APIKey.FEED_UNIT,
         ),
     ],
     PolarWetFoodFeeder: [],
@@ -239,12 +307,18 @@ DEVICE_NUMBER_MAP: dict[type[Device], list[PetLibroNumberEntityDescription]] = {
             name="Manual Feed Quantity",
             icon="mdi:scale",
             mode=NumberMode.SLIDER,
-            native_unit_of_measurement_fn=lambda m: m.feedUnitType.symbol,
-            native_max_value_fn=lambda m: Unit.round(m.feedUnitType.factor * MAX_FEED_PORTIONS, m.feedUnitType),
-            native_min_value_fn=lambda m: round(m.feedUnitType.factor, 16),
-            native_step_fn=lambda m: m.feedUnitType.factor,
-            method=lambda d, m, v: d.set_manual_feed_quantity(Unit.convert_feed(v, m.feedUnitType, None)),
-            value_fn=lambda d, m: Unit.convert_feed(d.manual_feed_quantity, None, m.feedUnitType, True),
+            native_unit_of_measurement_fn=lambda s: s.member.feedUnitType.symbol if not s.portions_enabled else "portions",
+            native_max_value_fn=lambda s: Unit.round(s.member.feedUnitType.factor * MAX_FEED_PORTIONS, s.member.feedUnitType) 
+                if not s.portions_enabled else MAX_FEED_PORTIONS,
+            native_min_value_fn=lambda s: round(s.member.feedUnitType.factor, 16) if not s.portions_enabled else 1,
+            native_step_fn=lambda s: s.member.feedUnitType.factor if not s.portions_enabled else 1,
+            method=lambda s, d, v: d.set_manual_feed_quantity(Unit.convert_feed(v, s.member.feedUnitType, None) 
+                if not s.portions_enabled else v),
+            value_fn=lambda s, d: Unit.convert_feed(d.manual_feed_quantity, None, s.member.feedUnitType, True) 
+                if not s.portions_enabled else d.manual_feed_quantity,
+            entity_registry_visible_default_fn=lambda self: self.enable_for_manual_feed,
+            entity_registry_enabled_default_fn=lambda self: self.enable_for_manual_feed,
+            petlibro_unit=APIKey.FEED_UNIT,
         ),
         PetLibroNumberEntityDescription[SpaceSmartFeeder](
             key="sound_level",
@@ -254,8 +328,8 @@ DEVICE_NUMBER_MAP: dict[type[Device], list[PetLibroNumberEntityDescription]] = {
             native_max_value=100,
             native_min_value=1,
             native_step=1,
-            value_fn=lambda device, m: device.sound_level,
-            method=lambda device, m, value: device.set_sound_level(value),
+            value_fn=lambda s, device: device.sound_level,
+            method=lambda s, device, value: device.set_sound_level(value),
             name="Sound Level",
         ),
     ],
@@ -268,8 +342,8 @@ DEVICE_NUMBER_MAP: dict[type[Device], list[PetLibroNumberEntityDescription]] = {
             native_max_value=180,
             native_min_value=1,
             native_step=1,
-            value_fn=lambda device, m: device.water_interval,
-            method=lambda device, m, value: device.set_water_interval(value),
+            value_fn=lambda s, device: device.water_interval,
+            method=lambda s, device, value: device.set_water_interval(value),
             name="Water Interval",
         ),
         PetLibroNumberEntityDescription[DockstreamSmartFountain](
@@ -280,8 +354,8 @@ DEVICE_NUMBER_MAP: dict[type[Device], list[PetLibroNumberEntityDescription]] = {
             native_max_value=180,
             native_min_value=1,
             native_step=1,
-            value_fn=lambda device, m: device.water_dispensing_duration,
-            method=lambda device, m, value: device.set_water_dispensing_duration(value),
+            value_fn=lambda s, device: device.water_dispensing_duration,
+            method=lambda s, device, value: device.set_water_dispensing_duration(value),
             name="Water Dispensing Duration",
         ),
         PetLibroNumberEntityDescription[DockstreamSmartFountain](
@@ -293,8 +367,8 @@ DEVICE_NUMBER_MAP: dict[type[Device], list[PetLibroNumberEntityDescription]] = {
             native_max_value=60,
             native_min_value=1,
             native_step=1,
-            value_fn=lambda device, m: device.cleaning_cycle,
-            method=lambda device, m, value: device.set_cleaning_cycle(value),
+            value_fn=lambda s, device: device.cleaning_cycle,
+            method=lambda s, device, value: device.set_cleaning_cycle(value),
             name="Cleaning Cycle",
         ),
         PetLibroNumberEntityDescription[DockstreamSmartFountain](
@@ -306,8 +380,8 @@ DEVICE_NUMBER_MAP: dict[type[Device], list[PetLibroNumberEntityDescription]] = {
             native_max_value=60,
             native_min_value=1,
             native_step=1,
-            value_fn=lambda device, m: device.filter_cycle,
-            method=lambda device, m, value: device.set_filter_cycle(value),
+            value_fn=lambda s, device: device.filter_cycle,
+            method=lambda s, device, value: device.set_filter_cycle(value),
             name="Filter Cycle",
         ),
     ],
@@ -320,8 +394,8 @@ DEVICE_NUMBER_MAP: dict[type[Device], list[PetLibroNumberEntityDescription]] = {
             native_max_value=180,
             native_min_value=1,
             native_step=1,
-            value_fn=lambda device, m: device.water_interval,
-            method=lambda device, m, value: device.set_water_interval(value),
+            value_fn=lambda s, device: device.water_interval,
+            method=lambda s, device, value: device.set_water_interval(value),
             name="Water Interval",
         ),
         PetLibroNumberEntityDescription[DockstreamSmartRFIDFountain](
@@ -332,8 +406,8 @@ DEVICE_NUMBER_MAP: dict[type[Device], list[PetLibroNumberEntityDescription]] = {
             native_max_value=180,
             native_min_value=1,
             native_step=1,
-            value_fn=lambda device, m: device.water_dispensing_duration,
-            method=lambda device, m, value: device.set_water_dispensing_duration(value),
+            value_fn=lambda s, device: device.water_dispensing_duration,
+            method=lambda s, device, value: device.set_water_dispensing_duration(value),
             name="Water Dispensing Duration",
         ),
         PetLibroNumberEntityDescription[DockstreamSmartRFIDFountain](
@@ -345,8 +419,8 @@ DEVICE_NUMBER_MAP: dict[type[Device], list[PetLibroNumberEntityDescription]] = {
             native_max_value=60,
             native_min_value=1,
             native_step=1,
-            value_fn=lambda device, m: device.cleaning_cycle,
-            method=lambda device, m, value: device.set_cleaning_cycle(value),
+            value_fn=lambda s, device: device.cleaning_cycle,
+            method=lambda s, device, value: device.set_cleaning_cycle(value),
             name="Cleaning Cycle",
         ),
         PetLibroNumberEntityDescription[DockstreamSmartRFIDFountain](
@@ -358,8 +432,8 @@ DEVICE_NUMBER_MAP: dict[type[Device], list[PetLibroNumberEntityDescription]] = {
             native_max_value=60,
             native_min_value=1,
             native_step=1,
-            value_fn=lambda device, m: device.filter_cycle,
-            method=lambda device, m, value: device.set_filter_cycle(value),
+            value_fn=lambda s, device: device.filter_cycle,
+            method=lambda s, device, value: device.set_filter_cycle(value),
             name="Filter Cycle",
         ),
     ],
@@ -374,8 +448,8 @@ DEVICE_NUMBER_MAP: dict[type[Device], list[PetLibroNumberEntityDescription]] = {
         #     native_max_value=180,
         #     native_min_value=1,
         #     native_step=1,
-        #     value_fn=lambda device, m: device.water_sensing_delay,
-        #     method=lambda device, value: device.set_water_sensing_delay(value),
+        #     value_fn=lambda s, device: device.water_sensing_delay,
+        #     method=lambda s, device, value: device.set_water_sensing_delay(value),
         #     name="Water Sensing Delay"
         # ),
         PetLibroNumberEntityDescription[Dockstream2SmartCordlessFountain](
@@ -383,14 +457,14 @@ DEVICE_NUMBER_MAP: dict[type[Device], list[PetLibroNumberEntityDescription]] = {
             translation_key="water_low_threshold",
             icon="mdi:gauge",
             mode="slider",
-            native_unit_of_measurement_fn=lambda m: m.waterUnitType.symbol,
-            native_max_value_fn=lambda m: Unit.round(m.waterUnitType.factor * 3000, m.waterUnitType),
-            native_min_value_fn=lambda m: Unit.round(m.waterUnitType.factor * 650, m.waterUnitType),
-            native_step_fn=lambda m: Unit.round(m.waterUnitType.factor, m.waterUnitType),
-            value_fn=lambda d, m: Unit.round(VolumeConverter.convert(
-                d.water_low_threshold, UnitOfVolume.MILLILITERS, m.waterUnitType.symbol), m.waterUnitType),
-            method=lambda d, m, v: d.set_water_low_threshold(round(VolumeConverter.convert(
-                v, m.waterUnitType.symbol, UnitOfVolume.MILLILITERS))),
+            native_unit_of_measurement_fn=lambda s: s.member.waterUnitType.symbol,
+            native_max_value_fn=lambda s: Unit.round(s.member.waterUnitType.factor * 3000, s.member.waterUnitType),
+            native_min_value_fn=lambda s: Unit.round(s.member.waterUnitType.factor * 650, s.member.waterUnitType),
+            native_step_fn=lambda s: Unit.round(s.member.waterUnitType.factor, s.member.waterUnitType),
+            value_fn=lambda s, d: Unit.round(VolumeConverter.convert(
+                d.water_low_threshold, UnitOfVolume.MILLILITERS, s.member.waterUnitType.symbol), s.member.waterUnitType),
+            method=lambda s, d, v: d.set_water_low_threshold(round(VolumeConverter.convert(
+                v, s.member.waterUnitType.symbol, UnitOfVolume.MILLILITERS))),
             name="Water Low Threshold"
         ),
         PetLibroNumberEntityDescription[Dockstream2SmartCordlessFountain](
@@ -402,8 +476,8 @@ DEVICE_NUMBER_MAP: dict[type[Device], list[PetLibroNumberEntityDescription]] = {
             native_max_value=60,
             native_min_value=1,
             native_step=1,
-            value_fn=lambda device, m: device.cleaning_cycle,
-            method=lambda device, value: device.set_cleaning_cycle(value),
+            value_fn=lambda s, device: device.cleaning_cycle,
+            method=lambda s, device, value: device.set_cleaning_cycle(value),
             name="Cleaning Cycle"
         ),
         PetLibroNumberEntityDescription[Dockstream2SmartCordlessFountain](
@@ -415,8 +489,8 @@ DEVICE_NUMBER_MAP: dict[type[Device], list[PetLibroNumberEntityDescription]] = {
             native_max_value=60,
             native_min_value=1,
             native_step=1,
-            value_fn=lambda device, m: device.filter_cycle,
-            method=lambda device, value: device.set_filter_cycle(value),
+            value_fn=lambda s, device: device.filter_cycle,
+            method=lambda s, device, value: device.set_filter_cycle(value),
             name="Filter Cycle"
         ),
     ],
@@ -431,8 +505,8 @@ DEVICE_NUMBER_MAP: dict[type[Device], list[PetLibroNumberEntityDescription]] = {
         #     native_max_value=180,
         #     native_min_value=1,
         #     native_step=1,
-        #     value_fn=lambda device, m: device.water_sensing_delay,
-        #     method=lambda device, value: device.set_water_sensing_delay(value),
+        #     value_fn=lambda s, device: device.water_sensing_delay,
+        #     method=lambda s, device, value: device.set_water_sensing_delay(value),
         #     name="Water Sensing Delay"
         # ),
         PetLibroNumberEntityDescription[Dockstream2SmartFountain](
@@ -440,14 +514,14 @@ DEVICE_NUMBER_MAP: dict[type[Device], list[PetLibroNumberEntityDescription]] = {
             translation_key="water_low_threshold",
             icon="mdi:gauge",
             mode="slider",
-            native_unit_of_measurement_fn=lambda m: m.waterUnitType.symbol,
-            native_max_value_fn=lambda m: Unit.round(m.waterUnitType.factor * 3000, m.waterUnitType),
-            native_min_value_fn=lambda m: Unit.round(m.waterUnitType.factor * 650, m.waterUnitType),
-            native_step_fn=lambda m: Unit.round(m.waterUnitType.factor, m.waterUnitType),
-            value_fn=lambda d, m: Unit.round(VolumeConverter.convert(
-                d.water_low_threshold, UnitOfVolume.MILLILITERS, m.waterUnitType.symbol), m.waterUnitType),
-            method=lambda d, m, v: d.set_water_low_threshold(round(VolumeConverter.convert(
-                v, m.waterUnitType.symbol, UnitOfVolume.MILLILITERS))),
+            native_unit_of_measurement_fn=lambda s: s.member.waterUnitType.symbol,
+            native_max_value_fn=lambda s: Unit.round(s.member.waterUnitType.factor * 3000, s.member.waterUnitType),
+            native_min_value_fn=lambda s: Unit.round(s.member.waterUnitType.factor * 650, s.member.waterUnitType),
+            native_step_fn=lambda s: Unit.round(s.member.waterUnitType.factor, s.member.waterUnitType),
+            value_fn=lambda s, d: Unit.round(VolumeConverter.convert(
+                d.water_low_threshold, UnitOfVolume.MILLILITERS, s.member.waterUnitType.symbol), s.member.waterUnitType),
+            method=lambda s, d, v: d.set_water_low_threshold(round(VolumeConverter.convert(
+                v, s.member.waterUnitType.symbol, UnitOfVolume.MILLILITERS))),
             name="Water Low Threshold"
         ),
         PetLibroNumberEntityDescription[Dockstream2SmartFountain](
@@ -459,8 +533,8 @@ DEVICE_NUMBER_MAP: dict[type[Device], list[PetLibroNumberEntityDescription]] = {
             native_max_value=60,
             native_min_value=1,
             native_step=1,
-            value_fn=lambda device, m: device.cleaning_cycle,
-            method=lambda device, value: device.set_cleaning_cycle(value),
+            value_fn=lambda s, device: device.cleaning_cycle,
+            method=lambda s, device, value: device.set_cleaning_cycle(value),
             name="Cleaning Cycle"
         ),
         PetLibroNumberEntityDescription[Dockstream2SmartFountain](
@@ -472,8 +546,8 @@ DEVICE_NUMBER_MAP: dict[type[Device], list[PetLibroNumberEntityDescription]] = {
             native_max_value=60,
             native_min_value=1,
             native_step=1,
-            value_fn=lambda device, m: device.filter_cycle,
-            method=lambda device, value: device.set_filter_cycle(value),
+            value_fn=lambda s, device: device.filter_cycle,
+            method=lambda s, device, value: device.set_filter_cycle(value),
             name="Filter Cycle"
         ),
         PetLibroNumberEntityDescription[Dockstream2SmartFountain](
@@ -484,8 +558,8 @@ DEVICE_NUMBER_MAP: dict[type[Device], list[PetLibroNumberEntityDescription]] = {
             native_max_value=180,
             native_min_value=1,
             native_step=1,
-            value_fn=lambda device, m: device.water_interval,
-            method=lambda device, value: device.set_water_interval(value),
+            value_fn=lambda s, device: device.water_interval,
+            method=lambda s, device, value: device.set_water_interval(value),
             name="Water Interval"
         ),
         PetLibroNumberEntityDescription[Dockstream2SmartFountain](
@@ -496,8 +570,8 @@ DEVICE_NUMBER_MAP: dict[type[Device], list[PetLibroNumberEntityDescription]] = {
             native_max_value=180,
             native_min_value=1,
             native_step=1,
-            value_fn=lambda device, m: device.water_dispensing_duration,
-            method=lambda device, value: device.set_water_dispensing_duration(value),
+            value_fn=lambda s, device: device.water_dispensing_duration,
+            method=lambda s, device, value: device.set_water_dispensing_duration(value),
             name="Water Dispensing Duration"
         ),
     ],

--- a/custom_components/petlibro/number.py
+++ b/custom_components/petlibro/number.py
@@ -387,7 +387,8 @@ DEVICE_NUMBER_MAP: dict[type[Device], list[PetLibroNumberEntityDescription]] = {
             native_max_value_fn=lambda m: Unit.round(m.waterUnitType.factor * 3000, m.waterUnitType),
             native_min_value_fn=lambda m: Unit.round(m.waterUnitType.factor * 650, m.waterUnitType),
             native_step_fn=lambda m: Unit.round(m.waterUnitType.factor, m.waterUnitType),
-            value_fn=lambda d, m: Unit.convert_feed(d.water_low_threshold, None, m.waterUnitType, True),
+            value_fn=lambda d, m: Unit.round(VolumeConverter.convert(
+                d.water_low_threshold, UnitOfVolume.MILLILITERS, m.waterUnitType.symbol), m.waterUnitType),
             method=lambda d, m, v: d.set_water_low_threshold(round(VolumeConverter.convert(
                 v, m.waterUnitType.symbol, UnitOfVolume.MILLILITERS))),
             name="Water Low Threshold"
@@ -443,7 +444,8 @@ DEVICE_NUMBER_MAP: dict[type[Device], list[PetLibroNumberEntityDescription]] = {
             native_max_value_fn=lambda m: Unit.round(m.waterUnitType.factor * 3000, m.waterUnitType),
             native_min_value_fn=lambda m: Unit.round(m.waterUnitType.factor * 650, m.waterUnitType),
             native_step_fn=lambda m: Unit.round(m.waterUnitType.factor, m.waterUnitType),
-            value_fn=lambda d, m: Unit.convert_feed(d.water_low_threshold, None, m.waterUnitType, True),
+            value_fn=lambda d, m: Unit.round(VolumeConverter.convert(
+                d.water_low_threshold, UnitOfVolume.MILLILITERS, m.waterUnitType.symbol), m.waterUnitType),
             method=lambda d, m, v: d.set_water_low_threshold(round(VolumeConverter.convert(
                 v, m.waterUnitType.symbol, UnitOfVolume.MILLILITERS))),
             name="Water Low Threshold"

--- a/custom_components/petlibro/number.py
+++ b/custom_components/petlibro/number.py
@@ -10,17 +10,20 @@ from functools import cached_property
 from typing import Optional
 from typing import Any
 import logging
-from .const import DOMAIN
+from .const import DOMAIN, Unit, MAX_FEED_PORTIONS
 from homeassistant.components.number import (
     NumberEntity,
     NumberEntityDescription,
     NumberDeviceClass,
-
+    NumberMode
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.const import UnitOfVolume
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.config_entries import ConfigEntry  # Added ConfigEntry import
+from homeassistant.util.unit_conversion import VolumeConverter
 from .hub import PetLibroHub  # Adjust the import path as necessary
+from .member import Member
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -45,8 +48,12 @@ class PetLibroNumberEntityDescription(NumberEntityDescription, PetLibroEntityDes
     """A class that describes device number entities."""
 
     device_class_fn: Callable[[_DeviceT], NumberDeviceClass | None] = lambda _: None
-    value: Callable[[_DeviceT], float] = lambda _: True
-    method: Callable[[_DeviceT], float] = lambda _: True
+    native_unit_of_measurement_fn: Callable[[Member], str | None] = lambda _: None
+    native_max_value_fn: Callable[[Member], float | None] = lambda _: None
+    native_min_value_fn: Callable[[Member], float | None] = lambda _: None
+    native_step_fn: Callable[[Member], float | None] = lambda _: None
+    value_fn: Callable[[_DeviceT, Member], float] = lambda d, m: 0
+    method: Callable[[_DeviceT, Member, float], float] = lambda d, m, v: None
     device_class: Optional[NumberDeviceClass] = None
 
 class PetLibroNumberEntity(PetLibroEntity[_DeviceT], NumberEntity):
@@ -62,6 +69,8 @@ class PetLibroNumberEntity(PetLibroEntity[_DeviceT], NumberEntity):
     @property
     def native_value(self) -> float | None:
         """Return the current state."""
+        if (value_fn := self.entity_description.value_fn(self.device, self.member)) is not None:
+            return value_fn
         state = getattr(self.device, self.entity_description.key, None)
         if state is None:
             _LOGGER.warning(f"Value '{self.entity_description.key}' is None for device {self.device.name}")
@@ -75,38 +84,71 @@ class PetLibroNumberEntity(PetLibroEntity[_DeviceT], NumberEntity):
         try:
             # Regular case for sound_level or other methods that only need a value
             _LOGGER.debug(f"Calling method with value={value} for {self.device.name}")
-            await self.entity_description.method(self.device, value)
+            await self.entity_description.method(self.device, self.member, value)
+            self.async_write_ha_state()
             _LOGGER.debug(f"Value {value} set successfully for {self.device.name}")
         except Exception as e:
             _LOGGER.error(f"Error setting value {value} for {self.device.name}: {e}")
 
+    @property
+    def native_unit_of_measurement(self) -> str | None:
+        """Return the native unit of measurement."""
+        if (uom := self.entity_description.native_unit_of_measurement_fn(self.member)) is not None:
+            return uom
+        return super().native_unit_of_measurement
+
+    @property
+    def native_min_value(self) -> float:
+        """Return the minimum value."""
+        if (min_value := self.entity_description.native_min_value_fn(self.member)) is not None:
+            return min_value
+        return super().native_min_value
+
+    @property
+    def native_max_value(self) -> float:
+        """Return the maximum value."""
+        if (max_value := self.entity_description.native_max_value_fn(self.member)) is not None:
+            return max_value
+        return super().native_max_value
+
+    @property
+    def native_step(self) -> float | None:
+        """Return the increment/decrement step."""
+        if (native_step := self.entity_description.native_step_fn(self.member)) is not None:
+            return native_step
+        return super().native_step
+
+
 DEVICE_NUMBER_MAP: dict[type[Device], list[PetLibroNumberEntityDescription]] = {
-    Feeder: [
-    ],
+    Feeder: [],
     AirSmartFeeder: [
         PetLibroNumberEntityDescription[AirSmartFeeder](
-            key ="manual_feed_quantity",
-            translation_key ="manual_feed_quantity",
-            native_unit_of_measurement = "  / 24 cups",
-            native_max_value = 24,
-            native_min_value = 1,
-            native_step = 1,
-            value = lambda device: device.manual_feed_quantity,
-            method = lambda device, value: device.set_manual_feed_quantity(value),
-            name = "Manual Feed Quantity"
+            key="manual_feed_quantity",
+            translation_key="manual_feed_quantity",
+            name="Manual Feed Quantity",
+            icon="mdi:scale",
+            mode=NumberMode.SLIDER,
+            native_unit_of_measurement_fn=lambda m: m.feedUnitType.symbol,
+            native_max_value_fn=lambda m: Unit.round(m.feedUnitType.factor * MAX_FEED_PORTIONS, m.feedUnitType),
+            native_min_value_fn=lambda m: round(m.feedUnitType.factor, 16),
+            native_step_fn=lambda m: m.feedUnitType.factor,
+            method=lambda d, m, v: d.set_manual_feed_quantity(Unit.convert_feed(v, m.feedUnitType, None)),
+            value_fn=lambda d, m: Unit.convert_feed(d.manual_feed_quantity, None, m.feedUnitType, True),
         ),
     ],
     GranarySmartFeeder: [
         PetLibroNumberEntityDescription[GranarySmartFeeder](
-            key ="manual_feed_quantity",
-            translation_key ="manual_feed_quantity",
-            native_unit_of_measurement = "  / 12 cups",
-            native_max_value = 12,
-            native_min_value = 1,
-            native_step = 1,
-            value = lambda device: device.manual_feed_quantity,
-            method = lambda device, value: device.set_manual_feed_quantity(value),
-            name = "Manual Feed Quantity"
+            key="manual_feed_quantity",
+            translation_key="manual_feed_quantity",
+            name="Manual Feed Quantity",
+            icon="mdi:scale",
+            mode=NumberMode.SLIDER,
+            native_unit_of_measurement_fn=lambda m: m.feedUnitType.symbol,
+            native_max_value_fn=lambda m: Unit.round(m.feedUnitType.factor * MAX_FEED_PORTIONS, m.feedUnitType),
+            native_min_value_fn=lambda m: round(m.feedUnitType.factor, 16),
+            native_step_fn=lambda m: m.feedUnitType.factor,
+            method=lambda d, m, v: d.set_manual_feed_quantity(Unit.convert_feed(v, m.feedUnitType, None)),
+            value_fn=lambda d, m: Unit.convert_feed(d.manual_feed_quantity, None, m.feedUnitType, True),
         ),
         PetLibroNumberEntityDescription[GranarySmartFeeder](
             key="desiccant_frequency",
@@ -117,22 +159,24 @@ DEVICE_NUMBER_MAP: dict[type[Device], list[PetLibroNumberEntityDescription]] = {
             native_max_value=60,
             native_min_value=1,
             native_step=1,
-            value=lambda device: device.desiccant_frequency,
-            method=lambda device, value: device.set_desiccant_frequency(value),
-            name="Desiccant Frequency"
+            value_fn=lambda device, m: device.desiccant_frequency,
+            method=lambda device, m, value: device.set_desiccant_frequency(value),
+            name="Desiccant Frequency",
         ),
     ],
     GranarySmartCameraFeeder: [
         PetLibroNumberEntityDescription[GranarySmartCameraFeeder](
-            key ="manual_feed_quantity",
-            translation_key ="manual_feed_quantity",
-            native_unit_of_measurement = "  / 12 cups",
-            native_max_value = 12,
-            native_min_value = 1,
-            native_step = 1,
-            value = lambda device: device.manual_feed_quantity,
-            method = lambda device, value: device.set_manual_feed_quantity(value),
-            name = "Manual Feed Quantity"
+            key="manual_feed_quantity",
+            translation_key="manual_feed_quantity",
+            name="Manual Feed Quantity",
+            icon="mdi:scale",
+            mode=NumberMode.SLIDER,
+            native_unit_of_measurement_fn=lambda m: m.feedUnitType.symbol,
+            native_max_value_fn=lambda m: Unit.round(m.feedUnitType.factor * MAX_FEED_PORTIONS, m.feedUnitType),
+            native_min_value_fn=lambda m: round(m.feedUnitType.factor, 16),
+            native_step_fn=lambda m: m.feedUnitType.factor,
+            method=lambda d, m, v: d.set_manual_feed_quantity(Unit.convert_feed(v, m.feedUnitType, None)),
+            value_fn=lambda d, m: Unit.convert_feed(d.manual_feed_quantity, None, m.feedUnitType, True),
         ),
     ],
     OneRFIDSmartFeeder: [
@@ -145,9 +189,9 @@ DEVICE_NUMBER_MAP: dict[type[Device], list[PetLibroNumberEntityDescription]] = {
             native_max_value=60,
             native_min_value=1,
             native_step=1,
-            value=lambda device: device.desiccant_cycle,
-            method=lambda device, value: device.set_desiccant_cycle(value),
-            name="Desiccant Cycle"
+            value_fn=lambda device, m: device.desiccant_cycle,
+            method=lambda device, m, value: device.set_desiccant_cycle(value),
+            name="Desiccant Cycle",
         ),
         PetLibroNumberEntityDescription[OneRFIDSmartFeeder](
             key="sound_level",
@@ -157,9 +201,9 @@ DEVICE_NUMBER_MAP: dict[type[Device], list[PetLibroNumberEntityDescription]] = {
             native_max_value=100,
             native_min_value=1,
             native_step=1,
-            value=lambda device: device.sound_level,
-            method=lambda device, value: device.set_sound_level(value),
-            name="Sound Level"
+            value_fn=lambda device, m: device.sound_level,
+            method=lambda device, m, value: device.set_sound_level(value),
+            name="Sound Level",
         ),
         PetLibroNumberEntityDescription[OneRFIDSmartFeeder](
             key="lid_close_time",
@@ -169,35 +213,38 @@ DEVICE_NUMBER_MAP: dict[type[Device], list[PetLibroNumberEntityDescription]] = {
             native_max_value=10,
             native_min_value=1,
             native_step=1,
-            value=lambda device: device.lid_close_time,
-            method=lambda device, value: device.set_lid_close_time(value),
-            name="Lid Close Time"
+            value_fn=lambda device, m: device.lid_close_time,
+            method=lambda device, m, value: device.set_lid_close_time(value),
+            name="Lid Close Time",
         ),
         PetLibroNumberEntityDescription[OneRFIDSmartFeeder](
             key="manual_feed_quantity",
             translation_key="manual_feed_quantity",
-            native_unit_of_measurement=" / 12 cups",
-            native_max_value=12,
-            native_min_value=1,
-            native_step=1,
-            value=lambda device: getattr(device, "manual_feed_quantity", 1),  # Default to 1 if not set
-            method=lambda device, value: device.set_manual_feed_quantity(value),
-            name="Manual Feed Quantity"
+            name="Manual Feed Quantity",
+            icon="mdi:scale",
+            mode=NumberMode.SLIDER,
+            native_unit_of_measurement_fn=lambda m: m.feedUnitType.symbol,
+            native_max_value_fn=lambda m: Unit.round(m.feedUnitType.factor * MAX_FEED_PORTIONS, m.feedUnitType),
+            native_min_value_fn=lambda m: round(m.feedUnitType.factor, 16),
+            native_step_fn=lambda m: m.feedUnitType.factor,
+            method=lambda d, m, v: d.set_manual_feed_quantity(Unit.convert_feed(v, m.feedUnitType, None)),
+            value_fn=lambda d, m: Unit.convert_feed(d.manual_feed_quantity, None, m.feedUnitType, True),
         ),
     ],
-    PolarWetFoodFeeder: [
-    ],
+    PolarWetFoodFeeder: [],
     SpaceSmartFeeder: [
         PetLibroNumberEntityDescription[SpaceSmartFeeder](
-            key ="manual_feed_quantity",
-            translation_key ="manual_feed_quantity",
-            native_unit_of_measurement = "  / 12 cups",
-            native_max_value = 12,
-            native_min_value = 1,
-            native_step = 1,
-            value = lambda device: device.manual_feed_quantity,
-            method = lambda device, value: device.set_manual_feed_quantity(value),
-            name = "Manual Feed Quantity"
+            key="manual_feed_quantity",
+            translation_key="manual_feed_quantity",
+            name="Manual Feed Quantity",
+            icon="mdi:scale",
+            mode=NumberMode.SLIDER,
+            native_unit_of_measurement_fn=lambda m: m.feedUnitType.symbol,
+            native_max_value_fn=lambda m: Unit.round(m.feedUnitType.factor * MAX_FEED_PORTIONS, m.feedUnitType),
+            native_min_value_fn=lambda m: round(m.feedUnitType.factor, 16),
+            native_step_fn=lambda m: m.feedUnitType.factor,
+            method=lambda d, m, v: d.set_manual_feed_quantity(Unit.convert_feed(v, m.feedUnitType, None)),
+            value_fn=lambda d, m: Unit.convert_feed(d.manual_feed_quantity, None, m.feedUnitType, True),
         ),
         PetLibroNumberEntityDescription[SpaceSmartFeeder](
             key="sound_level",
@@ -207,9 +254,9 @@ DEVICE_NUMBER_MAP: dict[type[Device], list[PetLibroNumberEntityDescription]] = {
             native_max_value=100,
             native_min_value=1,
             native_step=1,
-            value=lambda device: device.sound_level,
-            method=lambda device, value: device.set_sound_level(value),
-            name="Sound Level"
+            value_fn=lambda device, m: device.sound_level,
+            method=lambda device, m, value: device.set_sound_level(value),
+            name="Sound Level",
         ),
     ],
     DockstreamSmartFountain: [
@@ -221,9 +268,9 @@ DEVICE_NUMBER_MAP: dict[type[Device], list[PetLibroNumberEntityDescription]] = {
             native_max_value=180,
             native_min_value=1,
             native_step=1,
-            value=lambda device: device.water_interval,
-            method=lambda device, value: device.set_water_interval(value),
-            name="Water Interval"
+            value_fn=lambda device, m: device.water_interval,
+            method=lambda device, m, value: device.set_water_interval(value),
+            name="Water Interval",
         ),
         PetLibroNumberEntityDescription[DockstreamSmartFountain](
             key="water_dispensing_duration",
@@ -233,9 +280,9 @@ DEVICE_NUMBER_MAP: dict[type[Device], list[PetLibroNumberEntityDescription]] = {
             native_max_value=180,
             native_min_value=1,
             native_step=1,
-            value=lambda device: device.water_dispensing_duration,
-            method=lambda device, value: device.set_water_dispensing_duration(value),
-            name="Water Dispensing Duration"
+            value_fn=lambda device, m: device.water_dispensing_duration,
+            method=lambda device, m, value: device.set_water_dispensing_duration(value),
+            name="Water Dispensing Duration",
         ),
         PetLibroNumberEntityDescription[DockstreamSmartFountain](
             key="cleaning_cycle",
@@ -246,9 +293,9 @@ DEVICE_NUMBER_MAP: dict[type[Device], list[PetLibroNumberEntityDescription]] = {
             native_max_value=60,
             native_min_value=1,
             native_step=1,
-            value=lambda device: device.cleaning_cycle,
-            method=lambda device, value: device.set_cleaning_cycle(value),
-            name="Cleaning Cycle"
+            value_fn=lambda device, m: device.cleaning_cycle,
+            method=lambda device, m, value: device.set_cleaning_cycle(value),
+            name="Cleaning Cycle",
         ),
         PetLibroNumberEntityDescription[DockstreamSmartFountain](
             key="filter_cycle",
@@ -259,9 +306,9 @@ DEVICE_NUMBER_MAP: dict[type[Device], list[PetLibroNumberEntityDescription]] = {
             native_max_value=60,
             native_min_value=1,
             native_step=1,
-            value=lambda device: device.filter_cycle,
-            method=lambda device, value: device.set_filter_cycle(value),
-            name="Filter Cycle"
+            value_fn=lambda device, m: device.filter_cycle,
+            method=lambda device, m, value: device.set_filter_cycle(value),
+            name="Filter Cycle",
         ),
     ],
     DockstreamSmartRFIDFountain: [
@@ -273,9 +320,9 @@ DEVICE_NUMBER_MAP: dict[type[Device], list[PetLibroNumberEntityDescription]] = {
             native_max_value=180,
             native_min_value=1,
             native_step=1,
-            value=lambda device: device.water_interval,
-            method=lambda device, value: device.set_water_interval(value),
-            name="Water Interval"
+            value_fn=lambda device, m: device.water_interval,
+            method=lambda device, m, value: device.set_water_interval(value),
+            name="Water Interval",
         ),
         PetLibroNumberEntityDescription[DockstreamSmartRFIDFountain](
             key="water_dispensing_duration",
@@ -285,9 +332,9 @@ DEVICE_NUMBER_MAP: dict[type[Device], list[PetLibroNumberEntityDescription]] = {
             native_max_value=180,
             native_min_value=1,
             native_step=1,
-            value=lambda device: device.water_dispensing_duration,
-            method=lambda device, value: device.set_water_dispensing_duration(value),
-            name="Water Dispensing Duration"
+            value_fn=lambda device, m: device.water_dispensing_duration,
+            method=lambda device, m, value: device.set_water_dispensing_duration(value),
+            name="Water Dispensing Duration",
         ),
         PetLibroNumberEntityDescription[DockstreamSmartRFIDFountain](
             key="cleaning_cycle",
@@ -298,9 +345,9 @@ DEVICE_NUMBER_MAP: dict[type[Device], list[PetLibroNumberEntityDescription]] = {
             native_max_value=60,
             native_min_value=1,
             native_step=1,
-            value=lambda device: device.cleaning_cycle,
-            method=lambda device, value: device.set_cleaning_cycle(value),
-            name="Cleaning Cycle"
+            value_fn=lambda device, m: device.cleaning_cycle,
+            method=lambda device, m, value: device.set_cleaning_cycle(value),
+            name="Cleaning Cycle",
         ),
         PetLibroNumberEntityDescription[DockstreamSmartRFIDFountain](
             key="filter_cycle",
@@ -311,9 +358,9 @@ DEVICE_NUMBER_MAP: dict[type[Device], list[PetLibroNumberEntityDescription]] = {
             native_max_value=60,
             native_min_value=1,
             native_step=1,
-            value=lambda device: device.filter_cycle,
-            method=lambda device, value: device.set_filter_cycle(value),
-            name="Filter Cycle"
+            value_fn=lambda device, m: device.filter_cycle,
+            method=lambda device, m, value: device.set_filter_cycle(value),
+            name="Filter Cycle",
         ),
     ],
     Dockstream2SmartCordlessFountain: [
@@ -327,7 +374,7 @@ DEVICE_NUMBER_MAP: dict[type[Device], list[PetLibroNumberEntityDescription]] = {
         #     native_max_value=180,
         #     native_min_value=1,
         #     native_step=1,
-        #     value=lambda device: device.water_sensing_delay,
+        #     value_fn=lambda device, m: device.water_sensing_delay,
         #     method=lambda device, value: device.set_water_sensing_delay(value),
         #     name="Water Sensing Delay"
         # ),
@@ -336,12 +383,13 @@ DEVICE_NUMBER_MAP: dict[type[Device], list[PetLibroNumberEntityDescription]] = {
             translation_key="water_low_threshold",
             icon="mdi:gauge",
             mode="slider",
-            native_unit_of_measurement="mL",
-            native_max_value=3000,
-            native_min_value=650,
-            native_step=1,
-            value=lambda device: device.water_low_threshold,
-            method=lambda device, value: device.set_water_low_threshold(value),
+            native_unit_of_measurement_fn=lambda m: m.waterUnitType.symbol,
+            native_max_value_fn=lambda m: Unit.round(m.waterUnitType.factor * 3000, m.waterUnitType),
+            native_min_value_fn=lambda m: Unit.round(m.waterUnitType.factor * 650, m.waterUnitType),
+            native_step_fn=lambda m: Unit.round(m.waterUnitType.factor, m.waterUnitType),
+            value_fn=lambda d, m: Unit.convert_feed(d.water_low_threshold, None, m.waterUnitType, True),
+            method=lambda d, m, v: d.set_water_low_threshold(round(VolumeConverter.convert(
+                v, m.waterUnitType.symbol, UnitOfVolume.MILLILITERS))),
             name="Water Low Threshold"
         ),
         PetLibroNumberEntityDescription[Dockstream2SmartCordlessFountain](
@@ -353,7 +401,7 @@ DEVICE_NUMBER_MAP: dict[type[Device], list[PetLibroNumberEntityDescription]] = {
             native_max_value=60,
             native_min_value=1,
             native_step=1,
-            value=lambda device: device.cleaning_cycle,
+            value_fn=lambda device, m: device.cleaning_cycle,
             method=lambda device, value: device.set_cleaning_cycle(value),
             name="Cleaning Cycle"
         ),
@@ -366,7 +414,7 @@ DEVICE_NUMBER_MAP: dict[type[Device], list[PetLibroNumberEntityDescription]] = {
             native_max_value=60,
             native_min_value=1,
             native_step=1,
-            value=lambda device: device.filter_cycle,
+            value_fn=lambda device, m: device.filter_cycle,
             method=lambda device, value: device.set_filter_cycle(value),
             name="Filter Cycle"
         ),
@@ -382,7 +430,7 @@ DEVICE_NUMBER_MAP: dict[type[Device], list[PetLibroNumberEntityDescription]] = {
         #     native_max_value=180,
         #     native_min_value=1,
         #     native_step=1,
-        #     value=lambda device: device.water_sensing_delay,
+        #     value_fn=lambda device, m: device.water_sensing_delay,
         #     method=lambda device, value: device.set_water_sensing_delay(value),
         #     name="Water Sensing Delay"
         # ),
@@ -391,12 +439,13 @@ DEVICE_NUMBER_MAP: dict[type[Device], list[PetLibroNumberEntityDescription]] = {
             translation_key="water_low_threshold",
             icon="mdi:gauge",
             mode="slider",
-            native_unit_of_measurement="mL",
-            native_max_value=3000,
-            native_min_value=650,
-            native_step=1,
-            value=lambda device: device.water_low_threshold,
-            method=lambda device, value: device.set_water_low_threshold(value),
+            native_unit_of_measurement_fn=lambda m: m.waterUnitType.symbol,
+            native_max_value_fn=lambda m: Unit.round(m.waterUnitType.factor * 3000, m.waterUnitType),
+            native_min_value_fn=lambda m: Unit.round(m.waterUnitType.factor * 650, m.waterUnitType),
+            native_step_fn=lambda m: Unit.round(m.waterUnitType.factor, m.waterUnitType),
+            value_fn=lambda d, m: Unit.convert_feed(d.water_low_threshold, None, m.waterUnitType, True),
+            method=lambda d, m, v: d.set_water_low_threshold(round(VolumeConverter.convert(
+                v, m.waterUnitType.symbol, UnitOfVolume.MILLILITERS))),
             name="Water Low Threshold"
         ),
         PetLibroNumberEntityDescription[Dockstream2SmartFountain](
@@ -408,7 +457,7 @@ DEVICE_NUMBER_MAP: dict[type[Device], list[PetLibroNumberEntityDescription]] = {
             native_max_value=60,
             native_min_value=1,
             native_step=1,
-            value=lambda device: device.cleaning_cycle,
+            value_fn=lambda device, m: device.cleaning_cycle,
             method=lambda device, value: device.set_cleaning_cycle(value),
             name="Cleaning Cycle"
         ),
@@ -421,7 +470,7 @@ DEVICE_NUMBER_MAP: dict[type[Device], list[PetLibroNumberEntityDescription]] = {
             native_max_value=60,
             native_min_value=1,
             native_step=1,
-            value=lambda device: device.filter_cycle,
+            value_fn=lambda device, m: device.filter_cycle,
             method=lambda device, value: device.set_filter_cycle(value),
             name="Filter Cycle"
         ),
@@ -433,7 +482,7 @@ DEVICE_NUMBER_MAP: dict[type[Device], list[PetLibroNumberEntityDescription]] = {
             native_max_value=180,
             native_min_value=1,
             native_step=1,
-            value=lambda device: device.water_interval,
+            value_fn=lambda device, m: device.water_interval,
             method=lambda device, value: device.set_water_interval(value),
             name="Water Interval"
         ),
@@ -445,7 +494,7 @@ DEVICE_NUMBER_MAP: dict[type[Device], list[PetLibroNumberEntityDescription]] = {
             native_max_value=180,
             native_min_value=1,
             native_step=1,
-            value=lambda device: device.water_dispensing_duration,
+            value_fn=lambda device, m: device.water_dispensing_duration,
             method=lambda device, value: device.set_water_dispensing_duration(value),
             name="Water Dispensing Duration"
         ),

--- a/custom_components/petlibro/select.py
+++ b/custom_components/petlibro/select.py
@@ -71,17 +71,18 @@ class PetLibroSelectEntityDescription(SelectEntityDescription, PetLibroEntityDes
     current_selection: Callable[[PetLibroSelectEntity, _DeviceT], str] | None = lambda s,d: None  # Default to None
     entity_registry_visible_default_fn: Callable[[PetLibroSelectEntity], bool | None] = lambda _: None
     entity_registry_enabled_default_fn: Callable[[PetLibroSelectEntity], bool | None] = lambda _: None
+    available_fn: Callable[[PetLibroSelectEntity], bool | None] = lambda _: None
     petlibro_unit: APIKey | str | None = None
 
 class PetLibroSelectEntity(PetLibroEntity[_DeviceT], SelectEntity):
     """PETLIBRO select entity."""
 
     entity_description: PetLibroSelectEntityDescription[_DeviceT]
-    
+
     def __init__(self, device, hub, description):
         """Initialize the select entity."""
         super().__init__(device, hub, description)
-        
+
         if (unit_type := self.entity_description.petlibro_unit) and unit_type == APIKey.FEED_UNIT:
             self.hub.manual_feed_unique_ids[Platform.SELECT].append(self._attr_unique_id)
 
@@ -118,7 +119,7 @@ class PetLibroSelectEntity(PetLibroEntity[_DeviceT], SelectEntity):
             return None
         _LOGGER.debug("Retrieved current option for '%s', %s: %s", self.entity_description.key, self.device.name, state)
         return state if state in self.options else None
-    
+
     async def async_select_option(self, current_selection: str) -> None:
         _LOGGER.debug(f"Setting current option {current_selection} for {self.device.name}")
         try:
@@ -134,26 +135,33 @@ class PetLibroSelectEntity(PetLibroEntity[_DeviceT], SelectEntity):
             _LOGGER.debug(f"Current option {current_selection} set successfully for {self.device.name}")
         except Exception as e:
             _LOGGER.error(f"Error setting current option {current_selection} for {self.device.name}: {e}")
-    
+
+    @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        if (available := self.entity_description.available_fn(self)) is not None:
+            return available
+        return super().available
+
     @property
     def entity_registry_visible_default(self) -> bool:
         """Return if the entity should be visible when first added."""
         if (visible_default := self.entity_description.entity_registry_visible_default_fn(self)) is not None:
             return visible_default
         return super().entity_registry_visible_default
-    
+
     @property
     def entity_registry_enabled_default(self) -> bool:
         """Return if the entity should be enabled when first added."""
         if (enabled_default := self.entity_description.entity_registry_enabled_default_fn(self)) is not None:
             return enabled_default
         return super().entity_registry_enabled_default
-        
+
     @property
     def enable_for_manual_feed(self) -> bool:
-        """Return True if entity should be enabled for manual feed portion setting."""        
+        """Return True if entity should be enabled for manual feed portion setting."""
         return self.member.feedUnitType is Unit.CUPS and not self.hub.entry.options.get(MANUAL_FEED_PORTIONS, False)
-    
+
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
@@ -197,7 +205,7 @@ class PetLibroSelectEntity(PetLibroEntity[_DeviceT], SelectEntity):
             }
         }
         return mappings.get(key, {}).get(current_selection, "unknown")
-    
+
 CUPS_FRACTIONS_LIST = [
     f"{f"{whole} " if whole else ""}{str(fraction)+"/₁₂" if fraction else ""}"
     for whole in range(5)
@@ -208,7 +216,7 @@ CUPS_FRACTIONS_LIST = [
 DEVICE_SELECT_MAP: dict[type[Device], list[PetLibroSelectEntityDescription]] = {
     Feeder: [
     ],
-    AirSmartFeeder: [        
+    AirSmartFeeder: [
         PetLibroSelectEntityDescription[AirSmartFeeder](
             key="manual_feed_quantity_cups",
             translation_key="manual_feed_quantity_cups",
@@ -220,10 +228,11 @@ DEVICE_SELECT_MAP: dict[type[Device], list[PetLibroSelectEntityDescription]] = {
             name="Manual Feed Quantity",
             entity_registry_visible_default_fn=lambda self: self.enable_for_manual_feed,
             entity_registry_enabled_default_fn=lambda self: self.enable_for_manual_feed,
+            available_fn=lambda self: self.enable_for_manual_feed,
             petlibro_unit=APIKey.FEED_UNIT
         )
     ],
-    GranarySmartFeeder: [        
+    GranarySmartFeeder: [
         PetLibroSelectEntityDescription[GranarySmartFeeder](
             key="manual_feed_quantity_cups",
             translation_key="manual_feed_quantity_cups",
@@ -235,10 +244,11 @@ DEVICE_SELECT_MAP: dict[type[Device], list[PetLibroSelectEntityDescription]] = {
             name="Manual Feed Quantity",
             entity_registry_visible_default_fn=lambda self: self.enable_for_manual_feed,
             entity_registry_enabled_default_fn=lambda self: self.enable_for_manual_feed,
+            available_fn=lambda self: self.enable_for_manual_feed,
             petlibro_unit=APIKey.FEED_UNIT
         )
     ],
-    GranarySmartCameraFeeder: [        
+    GranarySmartCameraFeeder: [
         PetLibroSelectEntityDescription[GranarySmartCameraFeeder](
             key="manual_feed_quantity_cups",
             translation_key="manual_feed_quantity_cups",
@@ -250,6 +260,7 @@ DEVICE_SELECT_MAP: dict[type[Device], list[PetLibroSelectEntityDescription]] = {
             name="Manual Feed Quantity",
             entity_registry_visible_default_fn=lambda self: self.enable_for_manual_feed,
             entity_registry_enabled_default_fn=lambda self: self.enable_for_manual_feed,
+            available_fn=lambda self: self.enable_for_manual_feed,
             petlibro_unit=APIKey.FEED_UNIT
         )
     ],
@@ -274,6 +285,7 @@ DEVICE_SELECT_MAP: dict[type[Device], list[PetLibroSelectEntityDescription]] = {
             name="Manual Feed Quantity",
             entity_registry_visible_default_fn=lambda self: self.enable_for_manual_feed,
             entity_registry_enabled_default_fn=lambda self: self.enable_for_manual_feed,
+            available_fn=lambda self: self.enable_for_manual_feed,
             petlibro_unit=APIKey.FEED_UNIT
         )
     ],
@@ -289,6 +301,7 @@ DEVICE_SELECT_MAP: dict[type[Device], list[PetLibroSelectEntityDescription]] = {
             name="Manual Feed Quantity",
             entity_registry_visible_default_fn=lambda self: self.enable_for_manual_feed,
             entity_registry_enabled_default_fn=lambda self: self.enable_for_manual_feed,
+            available_fn=lambda self: self.enable_for_manual_feed,
             petlibro_unit=APIKey.FEED_UNIT
         ),
         PetLibroSelectEntityDescription[OneRFIDSmartFeeder](
@@ -326,7 +339,7 @@ DEVICE_SELECT_MAP: dict[type[Device], list[PetLibroSelectEntityDescription]] = {
             icon="mdi:arrow-oscillating",
             current_selection=lambda s, device: device.water_dispensing_mode,
             method=lambda s, d, opt: (
-                _apply_with_cached_schedule(d, lambda interval, duration, _off: d.api.set_water_mode_intermittent(d.serial, interval, duration)) if opt == "Intermittent Water (Scheduled)" 
+                _apply_with_cached_schedule(d, lambda interval, duration, _off: d.api.set_water_mode_intermittent(d.serial, interval, duration)) if opt == "Intermittent Water (Scheduled)"
                 else
                 _apply_with_cached_schedule(d, lambda interval, duration, _off: d.api.set_water_mode_constant(d.serial, interval, duration))
             ),
@@ -341,11 +354,11 @@ DEVICE_SELECT_MAP: dict[type[Device], list[PetLibroSelectEntityDescription]] = {
             icon="mdi:arrow-oscillating",
             current_selection=lambda s, device: device.water_dispensing_mode,
             method=lambda s, d, opt: (
-                _apply_and_refresh(d, d.api.set_water_mode_off(d.serial)) if opt == "Off" 
+                _apply_and_refresh(d, d.api.set_water_mode_off(d.serial)) if opt == "Off"
                 else
-                _apply_with_cached_schedule(d, lambda interval, duration, off: d.api.set_water_mode_radar_near(d.serial, interval, duration, currently_off=off)) if opt == "Sensor-Activated (Near)" 
+                _apply_with_cached_schedule(d, lambda interval, duration, off: d.api.set_water_mode_radar_near(d.serial, interval, duration, currently_off=off)) if opt == "Sensor-Activated (Near)"
                 else
-                _apply_with_cached_schedule(d, lambda interval, duration, off: d.api.set_water_mode_radar_far(d.serial, interval, duration, currently_off=off)) if opt == "Sensor-Activated (Far)" 
+                _apply_with_cached_schedule(d, lambda interval, duration, off: d.api.set_water_mode_radar_far(d.serial, interval, duration, currently_off=off)) if opt == "Sensor-Activated (Far)"
                 else
                 _apply_with_cached_schedule( d, lambda interval, duration, off: d.api.set_new_water_mode_constant(d.serial, interval, duration, currently_off=off))  # Flowing Water (Constant)
             ),
@@ -360,9 +373,9 @@ DEVICE_SELECT_MAP: dict[type[Device], list[PetLibroSelectEntityDescription]] = {
             icon="mdi:arrow-oscillating",
             current_selection=lambda s, device: device.water_dispensing_mode,
             method=lambda s, d, opt: (
-                _apply_and_refresh(d, d.api.set_water_mode_off(d.serial)) if opt == "Off" 
+                _apply_and_refresh(d, d.api.set_water_mode_off(d.serial)) if opt == "Off"
                 else
-                _apply_with_cached_schedule(d, lambda interval, duration, off: d.api.set_new_water_mode_intermittent(d.serial, interval, duration, currently_off=off)) if opt == "Intermittent Water (Scheduled)" 
+                _apply_with_cached_schedule(d, lambda interval, duration, off: d.api.set_new_water_mode_intermittent(d.serial, interval, duration, currently_off=off)) if opt == "Intermittent Water (Scheduled)"
                 else
                 _apply_with_cached_schedule(d, lambda interval, duration, off: d.api.set_new_water_mode_constant(d.serial, interval, duration, currently_off=off))
             ),
@@ -377,7 +390,7 @@ DEVICE_SELECT_MAP: dict[type[Device], list[PetLibroSelectEntityDescription]] = {
             icon="mdi:arrow-oscillating",
             current_selection=lambda s, device: device.water_dispensing_mode,
             method=lambda s, d, opt: (
-                _apply_with_cached_schedule(d, lambda interval, duration, _off: d.api.set_water_mode_intermittent(d.serial, interval, duration)) if opt == "Intermittent Water (Scheduled)" 
+                _apply_with_cached_schedule(d, lambda interval, duration, _off: d.api.set_water_mode_intermittent(d.serial, interval, duration)) if opt == "Intermittent Water (Scheduled)"
                 else
                 _apply_with_cached_schedule(d, lambda interval, duration, _off: d.api.set_water_mode_constant(d.serial, interval, duration))
             ),
@@ -394,7 +407,7 @@ DEVICE_SELECT_MAP: dict[type[Device], list[PetLibroSelectEntityDescription]] = {
             method=lambda s, d, opt: d.set_plate_position(int(opt.split()[-1])),
             options_list=["Plate 1", "Plate 2", "Plate 3"],
             name="Plate Position"
-        ), 
+        ),
     ]
 }
 

--- a/custom_components/petlibro/select.py
+++ b/custom_components/petlibro/select.py
@@ -11,13 +11,14 @@ from typing import Optional
 from typing import Any
 from typing import List, Awaitable
 import logging
-from .const import DOMAIN
+from .const import DOMAIN, MANUAL_FEED_PORTIONS, Unit, APIKey
 from homeassistant.components.select import (
     SelectEntity,
     SelectEntityDescription,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.core import callback
+from homeassistant.const import Platform
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.config_entries import ConfigEntry  # Added ConfigEntry import
 from .hub import PetLibroHub  # Adjust the import path as necessary
@@ -66,13 +67,23 @@ class PetLibroSelectEntityDescription(SelectEntityDescription, PetLibroEntityDes
     """A class that describes device select entities."""
 
     options_list: list[str] = field(default_factory=list)  # Default to empty list
-    method: Callable[[_DeviceT, str], Any] = field(default=lambda _: True)  # Default lambda function
-    current_selection: Callable[[_DeviceT], str] | None = None  # Default to None
+    method: Callable[[PetLibroSelectEntity, _DeviceT, str], Any] = field(default=lambda s,d,_: True)  # Default lambda function
+    current_selection: Callable[[PetLibroSelectEntity, _DeviceT], str] | None = lambda s,d: None  # Default to None
+    entity_registry_visible_default_fn: Callable[[PetLibroSelectEntity], bool | None] = lambda _: None
+    entity_registry_enabled_default_fn: Callable[[PetLibroSelectEntity], bool | None] = lambda _: None
+    petlibro_unit: APIKey | str | None = None
 
 class PetLibroSelectEntity(PetLibroEntity[_DeviceT], SelectEntity):
     """PETLIBRO select entity."""
 
     entity_description: PetLibroSelectEntityDescription[_DeviceT]
+    
+    def __init__(self, device, hub, description):
+        """Initialize the select entity."""
+        super().__init__(device, hub, description)
+        
+        if (unit_type := self.entity_description.petlibro_unit) and unit_type == APIKey.FEED_UNIT:
+            self.hub.manual_feed_unique_ids[Platform.SELECT].append(self._attr_unique_id)
 
     @property
     def options(self) -> list[str]:
@@ -94,7 +105,7 @@ class PetLibroSelectEntity(PetLibroEntity[_DeviceT], SelectEntity):
 
         if self.entity_description.current_selection is not None:
             try:
-                state = self.entity_description.current_selection(self.device)
+                state = self.entity_description.current_selection(self, self.device)
                 # Only expose labels HA knows about
                 return state if state in self.options else None
             except Exception as e:
@@ -112,7 +123,8 @@ class PetLibroSelectEntity(PetLibroEntity[_DeviceT], SelectEntity):
         _LOGGER.debug(f"Setting current option {current_selection} for {self.device.name}")
         try:
             _LOGGER.debug(f"Calling method with current option={current_selection} for {self.device.name}")
-            await self.entity_description.method(self.device, current_selection)
+            if method := self.entity_description.method:
+                await method(self, self.device, current_selection)
 
             # Immediately reflect the user's choice if it's a valid option
             if current_selection in self.options:
@@ -122,6 +134,37 @@ class PetLibroSelectEntity(PetLibroEntity[_DeviceT], SelectEntity):
             _LOGGER.debug(f"Current option {current_selection} set successfully for {self.device.name}")
         except Exception as e:
             _LOGGER.error(f"Error setting current option {current_selection} for {self.device.name}: {e}")
+    
+    @property
+    def entity_registry_visible_default(self) -> bool:
+        """Return if the entity should be visible when first added."""
+        if (visible_default := self.entity_description.entity_registry_visible_default_fn(self)) is not None:
+            return visible_default
+        return super().entity_registry_visible_default
+    
+    @property
+    def entity_registry_enabled_default(self) -> bool:
+        """Return if the entity should be enabled when first added."""
+        if (enabled_default := self.entity_description.entity_registry_enabled_default_fn(self)) is not None:
+            return enabled_default
+        return super().entity_registry_enabled_default
+        
+    @property
+    def enable_for_manual_feed(self) -> bool:
+        """Return True if entity should be enabled for manual feed portion setting."""        
+        return self.member.feedUnitType is Unit.CUPS and not self.hub.entry.options.get(MANUAL_FEED_PORTIONS, False)
+    
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        if (self.entity_description.petlibro_unit == APIKey.FEED_UNIT
+            and self.enabled != self.enable_for_manual_feed
+        ):
+            self.hub.unit_entities.schedule_manual_feed_sync()
+            _LOGGER.warning("Feed unit mismatch, reloading integration.")
+
+        if self.enabled:
+            super()._handle_coordinator_update()
 
     @staticmethod
     def map_value_to_api(*, key: str, current_selection: str) -> str:
@@ -154,28 +197,106 @@ class PetLibroSelectEntity(PetLibroEntity[_DeviceT], SelectEntity):
             }
         }
         return mappings.get(key, {}).get(current_selection, "unknown")
+    
+CUPS_FRACTIONS_LIST = [
+    f"{f"{whole} " if whole else ""}{str(fraction)+"/₁₂" if fraction else ""}"
+    for whole in range(5)
+    for i, fraction in enumerate([0, "¹", "²", "³", "⁴", "⁵", "⁶", "⁷", "⁸", "⁹", "¹⁰", "¹¹"])
+    if not (whole >= 4 and i > 0) and not (not whole and not fraction)
+]
 
 DEVICE_SELECT_MAP: dict[type[Device], list[PetLibroSelectEntityDescription]] = {
     Feeder: [
+    ],
+    AirSmartFeeder: [        
+        PetLibroSelectEntityDescription[AirSmartFeeder](
+            key="manual_feed_quantity_cups",
+            translation_key="manual_feed_quantity_cups",
+            icon="mdi:scale",
+            current_selection=lambda s, d: s.options[d.manual_feed_quantity - 1],
+            method=lambda s, d, opt: d.set_manual_feed_quantity(s.options.index(opt) + 1),
+            options_list=CUPS_FRACTIONS_LIST,
+            unit_of_measurement=Unit.CUPS.symbol,
+            name="Manual Feed Quantity",
+            entity_registry_visible_default_fn=lambda self: self.enable_for_manual_feed,
+            entity_registry_enabled_default_fn=lambda self: self.enable_for_manual_feed,
+            petlibro_unit=APIKey.FEED_UNIT
+        )
+    ],
+    GranarySmartFeeder: [        
+        PetLibroSelectEntityDescription[GranarySmartFeeder](
+            key="manual_feed_quantity_cups",
+            translation_key="manual_feed_quantity_cups",
+            icon="mdi:scale",
+            current_selection=lambda s, d: s.options[d.manual_feed_quantity - 1],
+            method=lambda s, d, opt: d.set_manual_feed_quantity(s.options.index(opt) + 1),
+            options_list=CUPS_FRACTIONS_LIST,
+            unit_of_measurement=Unit.CUPS.symbol,
+            name="Manual Feed Quantity",
+            entity_registry_visible_default_fn=lambda self: self.enable_for_manual_feed,
+            entity_registry_enabled_default_fn=lambda self: self.enable_for_manual_feed,
+            petlibro_unit=APIKey.FEED_UNIT
+        )
+    ],
+    GranarySmartCameraFeeder: [        
+        PetLibroSelectEntityDescription[GranarySmartCameraFeeder](
+            key="manual_feed_quantity_cups",
+            translation_key="manual_feed_quantity_cups",
+            icon="mdi:scale",
+            current_selection=lambda s, d: s.options[d.manual_feed_quantity - 1],
+            method=lambda s, d, opt: d.set_manual_feed_quantity(s.options.index(opt) + 1),
+            options_list=CUPS_FRACTIONS_LIST,
+            unit_of_measurement=Unit.CUPS.symbol,
+            name="Manual Feed Quantity",
+            entity_registry_visible_default_fn=lambda self: self.enable_for_manual_feed,
+            entity_registry_enabled_default_fn=lambda self: self.enable_for_manual_feed,
+            petlibro_unit=APIKey.FEED_UNIT
+        )
     ],
     SpaceSmartFeeder: [
         PetLibroSelectEntityDescription[SpaceSmartFeeder](
             key="vacuum_mode",
             translation_key="vacuum_mode",
             icon="mdi:air-purifier",
-            current_selection=lambda device: device.vacuum_mode,
-            method=lambda device, current_selection: device.set_vacuum_mode(PetLibroSelectEntity.map_value_to_api(key="vacuum_mode", current_selection=current_selection)),
+            current_selection=lambda s, device: device.vacuum_mode,
+            method=lambda s, device, current_selection: device.set_vacuum_mode(PetLibroSelectEntity.map_value_to_api(key="vacuum_mode", current_selection=current_selection)),
             options_list=['Study','Normal','Manual'],
             name="Vacuum Mode"
         ),
+        PetLibroSelectEntityDescription[SpaceSmartFeeder](
+            key="manual_feed_quantity_cups",
+            translation_key="manual_feed_quantity_cups",
+            icon="mdi:scale",
+            current_selection=lambda s, d: s.options[d.manual_feed_quantity - 1],
+            method=lambda s, d, opt: d.set_manual_feed_quantity(s.options.index(opt) + 1),
+            options_list=CUPS_FRACTIONS_LIST,
+            unit_of_measurement=Unit.CUPS.symbol,
+            name="Manual Feed Quantity",
+            entity_registry_visible_default_fn=lambda self: self.enable_for_manual_feed,
+            entity_registry_enabled_default_fn=lambda self: self.enable_for_manual_feed,
+            petlibro_unit=APIKey.FEED_UNIT
+        )
     ],
     OneRFIDSmartFeeder: [
+        PetLibroSelectEntityDescription[OneRFIDSmartFeeder](
+            key="manual_feed_quantity_cups",
+            translation_key="manual_feed_quantity_cups",
+            icon="mdi:scale",
+            current_selection=lambda s, d: s.options[d.manual_feed_quantity - 1],
+            method=lambda s, d, opt: d.set_manual_feed_quantity(s.options.index(opt) + 1),
+            options_list=CUPS_FRACTIONS_LIST,
+            unit_of_measurement=Unit.CUPS.symbol,
+            name="Manual Feed Quantity",
+            entity_registry_visible_default_fn=lambda self: self.enable_for_manual_feed,
+            entity_registry_enabled_default_fn=lambda self: self.enable_for_manual_feed,
+            petlibro_unit=APIKey.FEED_UNIT
+        ),
         PetLibroSelectEntityDescription[OneRFIDSmartFeeder](
             key="lid_speed",
             translation_key="lid_speed",
             icon="mdi:speedometer",
-            current_selection=lambda device: device.lid_speed,
-            method=lambda device, current_selection: device.set_lid_speed(PetLibroSelectEntity.map_value_to_api(key="lid_speed", current_selection=current_selection)),
+            current_selection=lambda s, device: device.lid_speed,
+            method=lambda s, device, current_selection: device.set_lid_speed(PetLibroSelectEntity.map_value_to_api(key="lid_speed", current_selection=current_selection)),
             options_list=['Slow','Medium','Fast'],
             name="Lid Speed"
         ),
@@ -183,8 +304,8 @@ DEVICE_SELECT_MAP: dict[type[Device], list[PetLibroSelectEntityDescription]] = {
             key="lid_mode",
             translation_key="lid_mode",
             icon="mdi:arrow-oscillating",
-            current_selection=lambda device: device.lid_mode,
-            method=lambda device, current_selection: device.set_lid_mode(PetLibroSelectEntity.map_value_to_api(key="lid_mode", current_selection=current_selection)),
+            current_selection=lambda s, device: device.lid_mode,
+            method=lambda s, device, current_selection: device.set_lid_mode(PetLibroSelectEntity.map_value_to_api(key="lid_mode", current_selection=current_selection)),
             options_list=['Open Mode (Stays Open Until Closed)','Personal Mode (Opens on Detection)'],
             name="Lid Mode"
         ),
@@ -192,8 +313,8 @@ DEVICE_SELECT_MAP: dict[type[Device], list[PetLibroSelectEntityDescription]] = {
             key="display_icon",
             translation_key="display_icon",
             icon="mdi:monitor-star",
-            current_selection=lambda device: device.display_icon,
-            method=lambda device, current_selection: device.set_display_icon(PetLibroSelectEntity.map_value_to_api(key="display_icon", current_selection=current_selection)),
+            current_selection=lambda s, device: device.display_icon,
+            method=lambda s, device, current_selection: device.set_display_icon(PetLibroSelectEntity.map_value_to_api(key="display_icon", current_selection=current_selection)),
             options_list=['Heart','Dog','Cat','Elk'],
             name="Icon to Display"
         )
@@ -203,8 +324,8 @@ DEVICE_SELECT_MAP: dict[type[Device], list[PetLibroSelectEntityDescription]] = {
             key="water_dispensing_mode",
             translation_key="water_dispensing_mode",
             icon="mdi:arrow-oscillating",
-            current_selection=lambda device: device.water_dispensing_mode,
-            method=lambda d, opt: (
+            current_selection=lambda s, device: device.water_dispensing_mode,
+            method=lambda s, d, opt: (
                 _apply_with_cached_schedule(d, lambda interval, duration, _off: d.api.set_water_mode_intermittent(d.serial, interval, duration)) if opt == "Intermittent Water (Scheduled)" 
                 else
                 _apply_with_cached_schedule(d, lambda interval, duration, _off: d.api.set_water_mode_constant(d.serial, interval, duration))
@@ -218,8 +339,8 @@ DEVICE_SELECT_MAP: dict[type[Device], list[PetLibroSelectEntityDescription]] = {
             key="water_dispensing_mode",
             translation_key="water_dispensing_mode",
             icon="mdi:arrow-oscillating",
-            current_selection=lambda device: device.water_dispensing_mode,
-            method=lambda d, opt: (
+            current_selection=lambda s, device: device.water_dispensing_mode,
+            method=lambda s, d, opt: (
                 _apply_and_refresh(d, d.api.set_water_mode_off(d.serial)) if opt == "Off" 
                 else
                 _apply_with_cached_schedule(d, lambda interval, duration, off: d.api.set_water_mode_radar_near(d.serial, interval, duration, currently_off=off)) if opt == "Sensor-Activated (Near)" 
@@ -237,8 +358,8 @@ DEVICE_SELECT_MAP: dict[type[Device], list[PetLibroSelectEntityDescription]] = {
             key="water_dispensing_mode",
             translation_key="water_dispensing_mode",
             icon="mdi:arrow-oscillating",
-            current_selection=lambda device: device.water_dispensing_mode,
-            method=lambda d, opt: (
+            current_selection=lambda s, device: device.water_dispensing_mode,
+            method=lambda s, d, opt: (
                 _apply_and_refresh(d, d.api.set_water_mode_off(d.serial)) if opt == "Off" 
                 else
                 _apply_with_cached_schedule(d, lambda interval, duration, off: d.api.set_new_water_mode_intermittent(d.serial, interval, duration, currently_off=off)) if opt == "Intermittent Water (Scheduled)" 
@@ -254,8 +375,8 @@ DEVICE_SELECT_MAP: dict[type[Device], list[PetLibroSelectEntityDescription]] = {
             key="water_dispensing_mode",
             translation_key="water_dispensing_mode",
             icon="mdi:arrow-oscillating",
-            current_selection=lambda device: device.water_dispensing_mode,
-            method=lambda d, opt: (
+            current_selection=lambda s, device: device.water_dispensing_mode,
+            method=lambda s, d, opt: (
                 _apply_with_cached_schedule(d, lambda interval, duration, _off: d.api.set_water_mode_intermittent(d.serial, interval, duration)) if opt == "Intermittent Water (Scheduled)" 
                 else
                 _apply_with_cached_schedule(d, lambda interval, duration, _off: d.api.set_water_mode_constant(d.serial, interval, duration))
@@ -269,8 +390,8 @@ DEVICE_SELECT_MAP: dict[type[Device], list[PetLibroSelectEntityDescription]] = {
             key="plate_position",
             translation_key="plate_position",
             icon="mdi:rotate-3d-variant",
-            current_selection=lambda d: f"Plate {d.plate_position}" if d.plate_position else None,
-            method=lambda d, opt: d.set_plate_position(int(opt.split()[-1])),
+            current_selection=lambda s, d: f"Plate {d.plate_position}" if d.plate_position else None,
+            method=lambda s, d, opt: d.set_plate_position(int(opt.split()[-1])),
             options_list=["Plate 1", "Plate 2", "Plate 3"],
             name="Plate Position"
         ), 

--- a/custom_components/petlibro/sensor.py
+++ b/custom_components/petlibro/sensor.py
@@ -13,7 +13,7 @@ from homeassistant.components.sensor.const import SensorStateClass, SensorDevice
 from homeassistant.components.sensor import SensorEntity, SensorEntityDescription
 from homeassistant.const import UnitOfMass, UnitOfVolume
 from homeassistant.core import HomeAssistant
-from homeassistant.util.unit_conversion import MassConverter, VolumeConverter
+from homeassistant.util.unit_conversion import VolumeConverter
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.config_entries import ConfigEntry  # Added ConfigEntry import
 from .hub import PetLibroHub  # Adjust the import path as necessary
@@ -1089,7 +1089,7 @@ DEVICE_SENSOR_MAP: dict[type[Device], list[PetLibroSensorEntityDescription]] = {
             icon="mdi:water",
             native_unit_of_measurement=UnitOfVolume.MILLILITERS,
             suggested_unit_of_measurement_fn=lambda m: m.waterUnitType.symbol,
-            state_class=SensorStateClass.MEASUREMENT,
+            state_class=SensorStateClass.TOTAL,
             device_class=SensorDeviceClass.VOLUME,
             extra_state_attributes_fn=lambda d, m: {
                 unit.symbol: VolumeConverter.convert(d.weight, UnitOfVolume.MILLILITERS, unit.symbol)
@@ -1230,7 +1230,7 @@ DEVICE_SENSOR_MAP: dict[type[Device], list[PetLibroSensorEntityDescription]] = {
             icon="mdi:water",
             native_unit_of_measurement=UnitOfVolume.MILLILITERS,
             suggested_unit_of_measurement_fn=lambda m: m.waterUnitType.symbol,
-            state_class=SensorStateClass.MEASUREMENT,
+            state_class=SensorStateClass.TOTAL,
             device_class=SensorDeviceClass.VOLUME,
             extra_state_attributes_fn=lambda d, m: {
                 unit.symbol: VolumeConverter.convert(d.weight, UnitOfVolume.MILLILITERS, unit.symbol)
@@ -1333,7 +1333,7 @@ DEVICE_SENSOR_MAP: dict[type[Device], list[PetLibroSensorEntityDescription]] = {
             icon="mdi:water",
             native_unit_of_measurement=UnitOfVolume.MILLILITERS,
             suggested_unit_of_measurement_fn=lambda m: m.waterUnitType.symbol,
-            state_class=SensorStateClass.MEASUREMENT,
+            state_class=SensorStateClass.TOTAL,
             device_class=SensorDeviceClass.VOLUME,
             extra_state_attributes_fn=lambda d, m: {
                 unit.symbol: VolumeConverter.convert(d.weight, UnitOfVolume.MILLILITERS, unit.symbol)
@@ -1481,7 +1481,7 @@ DEVICE_SENSOR_MAP: dict[type[Device], list[PetLibroSensorEntityDescription]] = {
             icon="mdi:water",
             native_unit_of_measurement=UnitOfVolume.MILLILITERS,
             suggested_unit_of_measurement_fn=lambda m: m.waterUnitType.symbol,
-            state_class=SensorStateClass.MEASUREMENT,
+            state_class=SensorStateClass.TOTAL,
             device_class=SensorDeviceClass.VOLUME,
             extra_state_attributes_fn=lambda d, m: {
                 unit.symbol: VolumeConverter.convert(d.weight, UnitOfVolume.MILLILITERS, unit.symbol)

--- a/custom_components/petlibro/sensor.py
+++ b/custom_components/petlibro/sensor.py
@@ -8,15 +8,16 @@ from logging import getLogger
 from collections.abc import Callable
 from datetime import datetime
 from typing import Any, cast
-from .const import DOMAIN
+from .const import DOMAIN, VALID_UNIT_TYPES, Unit, APIKey as API
 from homeassistant.components.sensor.const import SensorStateClass, SensorDeviceClass
 from homeassistant.components.sensor import SensorEntity, SensorEntityDescription
 from homeassistant.const import UnitOfMass, UnitOfVolume
 from homeassistant.core import HomeAssistant
+from homeassistant.util.unit_conversion import MassConverter, VolumeConverter
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.config_entries import ConfigEntry  # Added ConfigEntry import
 from .hub import PetLibroHub  # Adjust the import path as necessary
-from .member import MemberEntity
+from .member import Member, MemberEntity
 
 _LOGGER = getLogger(__name__)
 
@@ -46,25 +47,18 @@ def icon_for_gauge_level(gauge_level: int | None = None, offset: int = 0) -> str
     return "mdi:gauge-low"
 
 
-def unit_of_measurement_feeder(device: Feeder) -> str | None:
-    return device.unit_type
-
-
-def device_class_feeder(device: Feeder) -> SensorDeviceClass | None:
-    if device.unit_type in [UnitOfMass.OUNCES, UnitOfMass.GRAMS]:
-        return SensorDeviceClass.WEIGHT
-    if device.unit_type in [UnitOfVolume.MILLILITERS]:
-        return SensorDeviceClass.VOLUME
-
-
 @dataclass(frozen=True)
 class PetLibroSensorEntityDescription(SensorEntityDescription, PetLibroEntityDescription[_DeviceT]):
     """A class that describes device sensor entities."""
 
     icon_fn: Callable[[Any], str | None] = lambda _: None
-    native_unit_of_measurement_fn: Callable[[_DeviceT], str | None] = lambda _: None
+    native_unit_of_measurement_fn: Callable[[Member], str | None] = lambda _: None
+    suggested_unit_of_measurement_fn: Callable[[Member], str | None] = lambda _: None
+    extra_state_attributes_fn: Callable[[_DeviceT, Member], dict[str, Any] | None] = lambda d,m: None
     device_class_fn: Callable[[_DeviceT], SensorDeviceClass | None] = lambda _: None
     should_report: Callable[[_DeviceT], bool] = lambda _: True
+    value_fn: Callable[[_DeviceT, Member], Any | None] = lambda d,m: None
+    petlibro_unit: API | str | None = None
 
 
 class PetLibroSensorEntity(PetLibroEntity[_DeviceT], SensorEntity):
@@ -82,6 +76,10 @@ class PetLibroSensorEntity(PetLibroEntity[_DeviceT], SensorEntity):
             self._attr_unique_id = f"{device.serial}-{description.key}-{mac_address.replace(':', '')}"
         else:
             self._attr_unique_id = f"{device.serial}-{description.key}"
+        
+        if unit_type := self.entity_description.petlibro_unit:
+            device_class = self.entity_description.device_class
+            self.hub.unit_sensor_unique_ids[unit_type][device_class].append(self._attr_unique_id)
         
         # Dictionary to keep track of the last known state for each sensor key
         self._last_sensor_state = {}
@@ -121,23 +119,6 @@ class PetLibroSensorEntity(PetLibroEntity[_DeviceT], SensorEntity):
             yesterday_drinking_time_seconds = getattr(self.device, sensor_key, 0)
             return yesterday_drinking_time_seconds
 
-        # Handle today_feeding_quantity or last_feed_quantity as raw numeric value, converting to cups
-        elif sensor_key in ["today_feeding_quantity","last_feed_quantity"]:
-            feeding_quantity = getattr(self.device, sensor_key, 0) or 0
-            if not isinstance(feeding_quantity, (int, float)):
-                try:
-                    feeding_quantity = float(feeding_quantity)
-                except (TypeError, ValueError):
-                    return None  # don't crash; show 'unknown' until there’s a number
-                
-            # Determine the conversion factor based on device-specific attributes or context
-            conversion_factor = 1 / 12  # Default conversion factor
-            if hasattr(self.device, "conversion_mode") and self.device.conversion_mode == "1/24":
-                conversion_factor = 1 / 24
-            
-            cups = feeding_quantity * conversion_factor
-            return f"{round(cups, 2)}"
-
         # Handle wifi_rssi to display only the numeric value
         elif sensor_key == "wifi_rssi":
             wifi_rssi = getattr(self.device, sensor_key, None)
@@ -147,15 +128,12 @@ class PetLibroSensorEntity(PetLibroEntity[_DeviceT], SensorEntity):
                     self._last_sensor_state[sensor_key] = wifi_rssi
                 return wifi_rssi
 
-        # Handle weight in grams and convert to ounces
-        elif sensor_key == "weight":
-            weight_in_grams = getattr(self.device, sensor_key, 0.0)
-            ounces = round(weight_in_grams * 0.035274, 2)
-            return ounces
-
         # Default behavior for other sensors
         if self.entity_description.should_report(self.device):
-            val = getattr(self.device, sensor_key, None)
+            if (value_fn := self.entity_description.value_fn(self.device, self.member)) is not None:
+                val = value_fn
+            else:
+                val = getattr(self.device, sensor_key, None)
             # Log only if the state has changed
             if self._last_sensor_state.get(sensor_key) != val:
                 _LOGGER.debug(f"Raw {sensor_key} for device {self.device.serial}: {val}")
@@ -176,24 +154,15 @@ class PetLibroSensorEntity(PetLibroEntity[_DeviceT], SensorEntity):
         # For temperature, display as Fahrenheit
         if self.entity_description.key == "temperature":
             return "°F"
-        # For today_feeding_quantity or last_feed_quantity, display as cups in the frontend
-        if self.entity_description.key in ["today_feeding_quantity","last_feed_quantity"]:
-            return "cups"
         # For today_eating_time, display as seconds in the frontend
         elif self.entity_description.key in ["today_eating_time", "today_drinking_time", "today_avg_time"]:
             return "s"
         # For remaining_desiccant, remaining_cleaning_days & remaining_filter_days, display as days in the frontend
         elif self.entity_description.key in ["remaining_cleaning_days", "remaining_filter_days", "remaining_desiccant"]:
             return "d"
-        # For remaining_desiccant, remaining_cleaning_days & remaining_filter_days, display as days in the frontend
-        elif self.entity_description.key in ["today_drinking_amount", "yesterday_drinking_amount"]:
-            return "mL"
         # For wifi_rssi, display as dBm
         elif self.entity_description.key == "wifi_rssi":
             return "dBm"
-        # For weight, display as ounces in the frontend
-        elif self.entity_description.key == "weight":
-            return "oz"
         # For use_water_interval and use_water_duration, display as minutes
         elif self.entity_description.key in ["use_water_interval", "use_water_duration"]:
             return "min"
@@ -203,8 +172,18 @@ class PetLibroSensorEntity(PetLibroEntity[_DeviceT], SensorEntity):
         # For electric_quantity, display as a percentage
         elif self.entity_description.key == "electric_quantity":
             return "%"
-        # Default behavior for other sensors
-        return self.entity_description.native_unit_of_measurement_fn(self.device)
+        elif (
+            uom := self.entity_description.native_unit_of_measurement_fn(self.member)
+        ) is not None:
+            return uom
+        return super().native_unit_of_measurement
+
+    @property
+    def suggested_unit_of_measurement(self) -> int | None:
+        """Return the suggested unit of measurement."""
+        if (uom := self.entity_description.suggested_unit_of_measurement_fn(self.member)) is not None:
+            return uom
+        return super().suggested_unit_of_measurement
 
     @property
     def device_class(self) -> SensorDeviceClass | None:
@@ -218,39 +197,24 @@ class PetLibroSensorEntity(PetLibroEntity[_DeviceT], SensorEntity):
         """Return entity specific state attributes."""
         if self.entity_description.key == "feeding_plan_state":
             plans = self.device.feeding_plan_today_data.get("plans", [])
-            unit = getattr(self.device, "unit_type", None)
-
-            # Define conversion rates from 1 grain to each unit
-            conversions = {
-                UnitOfMass.GRAMS: 10,             # 1 grain ≈ 10 grams
-                UnitOfMass.OUNCES: 0.35274,       # 1 grain ≈ 0.35274 ounces
-                UnitOfVolume.MILLILITERS: 10,     # 1 grain ≈ 10 mL
-                "cups": 1 / 12                    # 1 grain ≈ 0.0833 cups
-            }
-
-            # Determine conversion factor and unit label
-            if unit in conversions:
-                conversion_factor = conversions[unit]
-                resolved_unit = (
-                    "g" if unit == UnitOfMass.GRAMS else
-                    "oz" if unit == UnitOfMass.OUNCES else
-                    "mL" if unit == UnitOfVolume.MILLILITERS else
-                    "cups"
-                )
-            else:
-                conversion_factor = conversions["cups"]
-                resolved_unit = "cups"
 
             return {
                 f"plan_{plan['index']}": {
                     "time": plan["time"],
-                    "amount": f"{round(plan['grainNum'] * conversion_factor, 2)} {resolved_unit}",
+                    "amount": f"{Unit.convert_feed(plan['grainNum'], None, 
+                    self.member.feedUnitType, True)} {self.member.feedUnitType.symbol}",
                     "state": self._format_state(plan["state"]),
                     "repeat": plan["repeat"],
                     "planID": plan["planId"]
                 }
                 for plan in plans
             }
+            
+        if (extra_state_attributes := self.entity_description.extra_state_attributes_fn(
+            self.device, self.member
+        )) is not None:
+            return extra_state_attributes
+        return super().extra_state_attributes
 
     def _format_state(self, state):
         return {
@@ -312,13 +276,35 @@ DEVICE_SENSOR_MAP: dict[type[Device], list[PetLibroSensorEntityDescription]] = {
             should_report=lambda device: device.feeding_plan_state is not None,
         ),
         PetLibroSensorEntityDescription[AirSmartFeeder](
-            key="today_feeding_quantity",
-            translation_key="today_feeding_quantity",
+            key="today_feeding_quantity_weight",
+            translation_key="today_feeding_quantity_weight",
+            name="Today Feeding Quantity (Weight)",
             icon="mdi:scale",
-            native_unit_of_measurement_fn=unit_of_measurement_feeder,
-            device_class_fn=device_class_feeder,
+            native_unit_of_measurement=UnitOfMass.GRAMS,
+            suggested_unit_of_measurement_fn=lambda m: getattr(UnitOfMass, m.feedUnitType.name, None),
+            value_fn=lambda d,m: Unit.convert_feed(d.today_feeding_quantity, None, Unit.GRAMS, True),
+            device_class=SensorDeviceClass.WEIGHT,
             state_class=SensorStateClass.TOTAL_INCREASING,
-            name="Today Feeding Quantity"
+            extra_state_attributes_fn=lambda d, m: {"portion": d.today_feeding_quantity}|{
+                unit.symbol: Unit.convert_feed(d.today_feeding_quantity, None, unit, True) 
+                for unit in VALID_UNIT_TYPES[API.FEED_UNIT] if unit
+            },
+            petlibro_unit=API.FEED_UNIT
+        ),
+        PetLibroSensorEntityDescription[AirSmartFeeder](
+            key="today_feeding_quantity_volume",
+            translation_key="today_feeding_quantity_volume",
+            name="Today Feeding Quantity (Volume)",
+            icon="mdi:scale",
+            native_unit_of_measurement=UnitOfVolume.MILLILITERS,
+            value_fn=lambda d,m: Unit.convert_feed(d.today_feeding_quantity, None, Unit.MILLILITERS, True),
+            device_class=SensorDeviceClass.VOLUME,
+            state_class=SensorStateClass.TOTAL_INCREASING,
+            extra_state_attributes_fn=lambda d, m: {"portion": d.today_feeding_quantity}|{
+                unit.symbol: Unit.convert_feed(d.today_feeding_quantity, None, unit, True) 
+                for unit in VALID_UNIT_TYPES[API.FEED_UNIT] if unit
+            },
+            petlibro_unit=API.FEED_UNIT
         ),
         PetLibroSensorEntityDescription[AirSmartFeeder](
             key="today_feeding_times",
@@ -335,13 +321,35 @@ DEVICE_SENSOR_MAP: dict[type[Device], list[PetLibroSensorEntityDescription]] = {
             device_class=SensorDeviceClass.TIMESTAMP,
         ),
         PetLibroSensorEntityDescription[AirSmartFeeder](
-            key="last_feed_quantity",
-            translation_key="last_feed_quantity",
+            key="last_feed_quantity_weight",
+            translation_key="last_feed_quantity_weight",
+            name="Last Feed Quantity (Weight)",
             icon="mdi:history",
-            native_unit_of_measurement_fn=unit_of_measurement_feeder,
-            device_class_fn=device_class_feeder,
+            native_unit_of_measurement=UnitOfMass.GRAMS,
+            suggested_unit_of_measurement_fn=lambda m: getattr(UnitOfMass, m.feedUnitType.name, None),
+            value_fn=lambda d,m: Unit.convert_feed(d.last_feed_quantity, None, Unit.GRAMS, True),
+            device_class=SensorDeviceClass.WEIGHT,
             state_class=SensorStateClass.MEASUREMENT,
-            name="Last Feed Quantity"
+            extra_state_attributes_fn=lambda d, m: {"portion": d.last_feed_quantity}|{
+                unit.symbol: Unit.convert_feed(d.last_feed_quantity, None, unit, True) 
+                for unit in VALID_UNIT_TYPES[API.FEED_UNIT] if unit
+            },
+            petlibro_unit=API.FEED_UNIT
+        ),
+        PetLibroSensorEntityDescription[AirSmartFeeder](
+            key="last_feed_quantity_volume",
+            translation_key="last_feed_quantity_volume",
+            name="Last Feed Quantity (Volume)",
+            icon="mdi:history",
+            native_unit_of_measurement=UnitOfVolume.MILLILITERS,
+            value_fn=lambda d,m: Unit.convert_feed(d.last_feed_quantity, None, Unit.MILLILITERS, True),
+            device_class=SensorDeviceClass.VOLUME,
+            state_class=SensorStateClass.TOTAL,
+            extra_state_attributes_fn=lambda d, m: {"portion": d.last_feed_quantity}|{
+                unit.symbol: Unit.convert_feed(d.last_feed_quantity, None, unit, True) 
+                for unit in VALID_UNIT_TYPES[API.FEED_UNIT] if unit
+            },
+            petlibro_unit=API.FEED_UNIT
         ),
         PetLibroSensorEntityDescription[AirSmartFeeder](
             key="child_lock_switch",
@@ -408,13 +416,35 @@ DEVICE_SENSOR_MAP: dict[type[Device], list[PetLibroSensorEntityDescription]] = {
             should_report=lambda device: device.feeding_plan_state is not None,
         ),
         PetLibroSensorEntityDescription[GranarySmartFeeder](
-            key="today_feeding_quantity",
-            translation_key="today_feeding_quantity",
+            key="today_feeding_quantity_weight",
+            translation_key="today_feeding_quantity_weight",
+            name="Today Feeding Quantity (Weight)",
             icon="mdi:scale",
-            native_unit_of_measurement_fn=unit_of_measurement_feeder,
-            device_class_fn=device_class_feeder,
+            native_unit_of_measurement=UnitOfMass.GRAMS,
+            suggested_unit_of_measurement_fn=lambda m: getattr(UnitOfMass, m.feedUnitType.name, None),
+            value_fn=lambda d,m: Unit.convert_feed(d.today_feeding_quantity, None, Unit.GRAMS, True),
+            device_class=SensorDeviceClass.WEIGHT,
             state_class=SensorStateClass.TOTAL_INCREASING,
-            name="Today Feeding Quantity"
+            extra_state_attributes_fn=lambda d, m: {"portion": d.today_feeding_quantity}|{
+                unit.symbol: Unit.convert_feed(d.today_feeding_quantity, None, unit, True) 
+                for unit in VALID_UNIT_TYPES[API.FEED_UNIT] if unit
+            },
+            petlibro_unit=API.FEED_UNIT
+        ),
+        PetLibroSensorEntityDescription[GranarySmartFeeder](
+            key="today_feeding_quantity_volume",
+            translation_key="today_feeding_quantity_volume",
+            name="Today Feeding Quantity (Volume)",
+            icon="mdi:scale",
+            native_unit_of_measurement=UnitOfVolume.MILLILITERS,
+            value_fn=lambda d,m: Unit.convert_feed(d.today_feeding_quantity, None, Unit.MILLILITERS, True),
+            device_class=SensorDeviceClass.VOLUME,
+            state_class=SensorStateClass.TOTAL_INCREASING,
+            extra_state_attributes_fn=lambda d, m: {"portion": d.today_feeding_quantity}|{
+                unit.symbol: Unit.convert_feed(d.today_feeding_quantity, None, unit, True) 
+                for unit in VALID_UNIT_TYPES[API.FEED_UNIT] if unit
+            },
+            petlibro_unit=API.FEED_UNIT
         ),
         PetLibroSensorEntityDescription[GranarySmartFeeder](
             key="today_feeding_times",
@@ -431,13 +461,35 @@ DEVICE_SENSOR_MAP: dict[type[Device], list[PetLibroSensorEntityDescription]] = {
             device_class=SensorDeviceClass.TIMESTAMP,
         ),
         PetLibroSensorEntityDescription[GranarySmartFeeder](
-            key="last_feed_quantity",
-            translation_key="last_feed_quantity",
+            key="last_feed_quantity_weight",
+            translation_key="last_feed_quantity_weight",
+            name="Last Feed Quantity (Weight)",
             icon="mdi:history",
-            native_unit_of_measurement_fn=unit_of_measurement_feeder,
-            device_class_fn=device_class_feeder,
+            native_unit_of_measurement=UnitOfMass.GRAMS,
+            suggested_unit_of_measurement_fn=lambda m: getattr(UnitOfMass, m.feedUnitType.name, None),
+            value_fn=lambda d,m: Unit.convert_feed(d.last_feed_quantity, None, Unit.GRAMS, True),
+            device_class=SensorDeviceClass.WEIGHT,
             state_class=SensorStateClass.MEASUREMENT,
-            name="Last Feed Quantity"
+            extra_state_attributes_fn=lambda d, m: {"portion": d.last_feed_quantity}|{
+                unit.symbol: Unit.convert_feed(d.last_feed_quantity, None, unit, True) 
+                for unit in VALID_UNIT_TYPES[API.FEED_UNIT] if unit
+            },
+            petlibro_unit=API.FEED_UNIT
+        ),
+        PetLibroSensorEntityDescription[GranarySmartFeeder](
+            key="last_feed_quantity_volume",
+            translation_key="last_feed_quantity_volume",
+            name="Last Feed Quantity (Volume)",
+            icon="mdi:history",
+            native_unit_of_measurement=UnitOfVolume.MILLILITERS,
+            value_fn=lambda d,m: Unit.convert_feed(d.last_feed_quantity, None, Unit.MILLILITERS, True),
+            device_class=SensorDeviceClass.VOLUME,
+            state_class=SensorStateClass.TOTAL,
+            extra_state_attributes_fn=lambda d, m: {"portion": d.last_feed_quantity}|{
+                unit.symbol: Unit.convert_feed(d.last_feed_quantity, None, unit, True) 
+                for unit in VALID_UNIT_TYPES[API.FEED_UNIT] if unit
+            },
+            petlibro_unit=API.FEED_UNIT
         ),
         PetLibroSensorEntityDescription[GranarySmartFeeder](
             key="child_lock_switch",
@@ -504,13 +556,35 @@ DEVICE_SENSOR_MAP: dict[type[Device], list[PetLibroSensorEntityDescription]] = {
             should_report=lambda device: device.feeding_plan_state is not None,
         ),
         PetLibroSensorEntityDescription[GranarySmartCameraFeeder](
-            key="today_feeding_quantity",
-            translation_key="today_feeding_quantity",
+            key="today_feeding_quantity_weight",
+            translation_key="today_feeding_quantity_weight",
+            name="Today Feeding Quantity (Weight)",
             icon="mdi:scale",
-            native_unit_of_measurement_fn=unit_of_measurement_feeder,
-            device_class_fn=device_class_feeder,
+            native_unit_of_measurement=UnitOfMass.GRAMS,
+            suggested_unit_of_measurement_fn=lambda m: getattr(UnitOfMass, m.feedUnitType.name, None),
+            value_fn=lambda d,m: Unit.convert_feed(d.today_feeding_quantity, None, Unit.GRAMS, True),
+            device_class=SensorDeviceClass.WEIGHT,
             state_class=SensorStateClass.TOTAL_INCREASING,
-            name="Today Feeding Quantity"
+            extra_state_attributes_fn=lambda d, m: {"portion": d.today_feeding_quantity}|{
+                unit.symbol: Unit.convert_feed(d.today_feeding_quantity, None, unit, True) 
+                for unit in VALID_UNIT_TYPES[API.FEED_UNIT] if unit
+            },
+            petlibro_unit=API.FEED_UNIT
+        ),
+        PetLibroSensorEntityDescription[GranarySmartCameraFeeder](
+            key="today_feeding_quantity_volume",
+            translation_key="today_feeding_quantity_volume",
+            name="Today Feeding Quantity (Volume)",
+            icon="mdi:scale",
+            native_unit_of_measurement=UnitOfVolume.MILLILITERS,
+            value_fn=lambda d,m: Unit.convert_feed(d.today_feeding_quantity, None, Unit.MILLILITERS, True),
+            device_class=SensorDeviceClass.VOLUME,
+            state_class=SensorStateClass.TOTAL_INCREASING,
+            extra_state_attributes_fn=lambda d, m: {"portion": d.today_feeding_quantity}|{
+                unit.symbol: Unit.convert_feed(d.today_feeding_quantity, None, unit, True) 
+                for unit in VALID_UNIT_TYPES[API.FEED_UNIT] if unit
+            },
+            petlibro_unit=API.FEED_UNIT
         ),
         PetLibroSensorEntityDescription[GranarySmartCameraFeeder](
             key="today_feeding_times",
@@ -527,13 +601,35 @@ DEVICE_SENSOR_MAP: dict[type[Device], list[PetLibroSensorEntityDescription]] = {
             device_class=SensorDeviceClass.TIMESTAMP,
         ),
         PetLibroSensorEntityDescription[GranarySmartCameraFeeder](
-            key="last_feed_quantity",
-            translation_key="last_feed_quantity",
+            key="last_feed_quantity_weight",
+            translation_key="last_feed_quantity_weight",
+            name="Last Feed Quantity (Weight)",
             icon="mdi:history",
-            native_unit_of_measurement_fn=unit_of_measurement_feeder,
-            device_class_fn=device_class_feeder,
+            native_unit_of_measurement=UnitOfMass.GRAMS,
+            suggested_unit_of_measurement_fn=lambda m: getattr(UnitOfMass, m.feedUnitType.name, None),
+            value_fn=lambda d,m: Unit.convert_feed(d.last_feed_quantity, None, Unit.GRAMS, True),
+            device_class=SensorDeviceClass.WEIGHT,
             state_class=SensorStateClass.MEASUREMENT,
-            name="Last Feed Quantity"
+            extra_state_attributes_fn=lambda d, m: {"portion": d.last_feed_quantity}|{
+                unit.symbol: Unit.convert_feed(d.last_feed_quantity, None, unit, True) 
+                for unit in VALID_UNIT_TYPES[API.FEED_UNIT] if unit
+            },
+            petlibro_unit=API.FEED_UNIT
+        ),
+        PetLibroSensorEntityDescription[GranarySmartCameraFeeder](
+            key="last_feed_quantity_volume",
+            translation_key="last_feed_quantity_volume",
+            name="Last Feed Quantity (Volume)",
+            icon="mdi:history",
+            native_unit_of_measurement=UnitOfVolume.MILLILITERS,
+            value_fn=lambda d,m: Unit.convert_feed(d.last_feed_quantity, None, Unit.MILLILITERS, True),
+            device_class=SensorDeviceClass.VOLUME,
+            state_class=SensorStateClass.TOTAL,
+            extra_state_attributes_fn=lambda d, m: {"portion": d.last_feed_quantity}|{
+                unit.symbol: Unit.convert_feed(d.last_feed_quantity, None, unit, True) 
+                for unit in VALID_UNIT_TYPES[API.FEED_UNIT] if unit
+            },
+            petlibro_unit=API.FEED_UNIT
         ),
         PetLibroSensorEntityDescription[GranarySmartCameraFeeder](
             key="child_lock_switch",
@@ -635,13 +731,35 @@ DEVICE_SENSOR_MAP: dict[type[Device], list[PetLibroSensorEntityDescription]] = {
             should_report=lambda device: device.feeding_plan_state is not None,
         ),
         PetLibroSensorEntityDescription[OneRFIDSmartFeeder](
-            key="today_feeding_quantity",
-            translation_key="today_feeding_quantity",
+            key="today_feeding_quantity_weight",
+            translation_key="today_feeding_quantity_weight",
+            name="Today Feeding Quantity (Weight)",
             icon="mdi:scale",
-            native_unit_of_measurement_fn=unit_of_measurement_feeder,
-            device_class_fn=device_class_feeder,
+            native_unit_of_measurement=UnitOfMass.GRAMS,
+            suggested_unit_of_measurement_fn=lambda m: getattr(UnitOfMass, m.feedUnitType.name, None),
+            value_fn=lambda d,m: Unit.convert_feed(d.today_feeding_quantity, None, Unit.GRAMS, True),
+            device_class=SensorDeviceClass.WEIGHT,
             state_class=SensorStateClass.TOTAL_INCREASING,
-            name="Today Feeding Quantity"
+            extra_state_attributes_fn=lambda d, m: {"portion": d.today_feeding_quantity}|{
+                unit.symbol: Unit.convert_feed(d.today_feeding_quantity, None, unit, True) 
+                for unit in VALID_UNIT_TYPES[API.FEED_UNIT] if unit
+            },
+            petlibro_unit=API.FEED_UNIT
+        ),
+        PetLibroSensorEntityDescription[OneRFIDSmartFeeder](
+            key="today_feeding_quantity_volume",
+            translation_key="today_feeding_quantity_volume",
+            name="Today Feeding Quantity (Volume)",
+            icon="mdi:scale",
+            native_unit_of_measurement=UnitOfVolume.MILLILITERS,
+            value_fn=lambda d,m: Unit.convert_feed(d.today_feeding_quantity, None, Unit.MILLILITERS, True),
+            device_class=SensorDeviceClass.VOLUME,
+            state_class=SensorStateClass.TOTAL_INCREASING,
+            extra_state_attributes_fn=lambda d, m: {"portion": d.today_feeding_quantity}|{
+                unit.symbol: Unit.convert_feed(d.today_feeding_quantity, None, unit, True) 
+                for unit in VALID_UNIT_TYPES[API.FEED_UNIT] if unit
+            },
+            petlibro_unit=API.FEED_UNIT
         ),
         PetLibroSensorEntityDescription[OneRFIDSmartFeeder](
             key="today_feeding_times",
@@ -672,13 +790,35 @@ DEVICE_SENSOR_MAP: dict[type[Device], list[PetLibroSensorEntityDescription]] = {
             device_class=SensorDeviceClass.TIMESTAMP,
         ),
         PetLibroSensorEntityDescription[OneRFIDSmartFeeder](
-            key="last_feed_quantity",
-            translation_key="last_feed_quantity",
+            key="last_feed_quantity_weight",
+            translation_key="last_feed_quantity_weight",
+            name="Last Feed Quantity (Weight)",
             icon="mdi:history",
-            native_unit_of_measurement_fn=unit_of_measurement_feeder,
-            device_class_fn=device_class_feeder,
+            native_unit_of_measurement=UnitOfMass.GRAMS,
+            suggested_unit_of_measurement_fn=lambda m: getattr(UnitOfMass, m.feedUnitType.name, None),
+            value_fn=lambda d,m: Unit.convert_feed(d.last_feed_quantity, None, Unit.GRAMS, True),
+            device_class=SensorDeviceClass.WEIGHT,
             state_class=SensorStateClass.MEASUREMENT,
-            name="Last Feed Quantity"
+            extra_state_attributes_fn=lambda d, m: {"portion": d.last_feed_quantity}|{
+                unit.symbol: Unit.convert_feed(d.last_feed_quantity, None, unit, True) 
+                for unit in VALID_UNIT_TYPES[API.FEED_UNIT] if unit
+            },
+            petlibro_unit=API.FEED_UNIT
+        ),
+        PetLibroSensorEntityDescription[OneRFIDSmartFeeder](
+            key="last_feed_quantity_volume",
+            translation_key="last_feed_quantity_volume",
+            name="Last Feed Quantity (Volume)",
+            icon="mdi:history",
+            native_unit_of_measurement=UnitOfVolume.MILLILITERS,
+            value_fn=lambda d,m: Unit.convert_feed(d.last_feed_quantity, None, Unit.MILLILITERS, True),
+            device_class=SensorDeviceClass.VOLUME,
+            state_class=SensorStateClass.TOTAL,
+            extra_state_attributes_fn=lambda d, m: {"portion": d.last_feed_quantity}|{
+                unit.symbol: Unit.convert_feed(d.last_feed_quantity, None, unit, True) 
+                for unit in VALID_UNIT_TYPES[API.FEED_UNIT] if unit
+            },
+            petlibro_unit=API.FEED_UNIT
         ),
         PetLibroSensorEntityDescription[OneRFIDSmartFeeder](
             key="display_selection",
@@ -819,13 +959,35 @@ DEVICE_SENSOR_MAP: dict[type[Device], list[PetLibroSensorEntityDescription]] = {
             should_report=lambda device: device.feeding_plan_state is not None,
         ),
         PetLibroSensorEntityDescription[SpaceSmartFeeder](
-            key="today_feeding_quantity",
-            translation_key="today_feeding_quantity",
+            key="today_feeding_quantity_weight",
+            translation_key="today_feeding_quantity_weight",
+            name="Today Feeding Quantity (Weight)",
             icon="mdi:scale",
-            native_unit_of_measurement_fn=unit_of_measurement_feeder,
-            device_class_fn=device_class_feeder,
+            native_unit_of_measurement=UnitOfMass.GRAMS,
+            suggested_unit_of_measurement_fn=lambda m: getattr(UnitOfMass, m.feedUnitType.name, None),
+            value_fn=lambda d,m: Unit.convert_feed(d.today_feeding_quantity, None, Unit.GRAMS, True),
+            device_class=SensorDeviceClass.WEIGHT,
             state_class=SensorStateClass.TOTAL_INCREASING,
-            name="Today Feeding Quantity"
+            extra_state_attributes_fn=lambda d, m: {"portion": d.today_feeding_quantity}|{
+                unit.symbol: Unit.convert_feed(d.today_feeding_quantity, None, unit, True) 
+                for unit in VALID_UNIT_TYPES[API.FEED_UNIT] if unit
+            },
+            petlibro_unit=API.FEED_UNIT
+        ),
+        PetLibroSensorEntityDescription[SpaceSmartFeeder](
+            key="today_feeding_quantity_volume",
+            translation_key="today_feeding_quantity_volume",
+            name="Today Feeding Quantity (Volume)",
+            icon="mdi:scale",
+            native_unit_of_measurement=UnitOfVolume.MILLILITERS,
+            value_fn=lambda d,m: Unit.convert_feed(d.today_feeding_quantity, None, Unit.MILLILITERS, True),
+            device_class=SensorDeviceClass.VOLUME,
+            state_class=SensorStateClass.TOTAL_INCREASING,
+            extra_state_attributes_fn=lambda d, m: {"portion": d.today_feeding_quantity}|{
+                unit.symbol: Unit.convert_feed(d.today_feeding_quantity, None, unit, True) 
+                for unit in VALID_UNIT_TYPES[API.FEED_UNIT] if unit
+            },
+            petlibro_unit=API.FEED_UNIT
         ),
         PetLibroSensorEntityDescription[SpaceSmartFeeder](
             key="today_feeding_times",
@@ -842,13 +1004,35 @@ DEVICE_SENSOR_MAP: dict[type[Device], list[PetLibroSensorEntityDescription]] = {
             device_class=SensorDeviceClass.TIMESTAMP,
         ),
         PetLibroSensorEntityDescription[SpaceSmartFeeder](
-            key="last_feed_quantity",
-            translation_key="last_feed_quantity",
+            key="last_feed_quantity_weight",
+            translation_key="last_feed_quantity_weight",
+            name="Last Feed Quantity (Weight)",
             icon="mdi:history",
-            native_unit_of_measurement_fn=unit_of_measurement_feeder,
-            device_class_fn=device_class_feeder,
+            native_unit_of_measurement=UnitOfMass.GRAMS,
+            suggested_unit_of_measurement_fn=lambda m: getattr(UnitOfMass, m.feedUnitType.name, None),
+            value_fn=lambda d,m: Unit.convert_feed(d.last_feed_quantity, None, Unit.GRAMS, True),
+            device_class=SensorDeviceClass.WEIGHT,
             state_class=SensorStateClass.MEASUREMENT,
-            name="Last Feed Quantity"
+            extra_state_attributes_fn=lambda d, m: {"portion": d.last_feed_quantity}|{
+                unit.symbol: Unit.convert_feed(d.last_feed_quantity, None, unit, True) 
+                for unit in VALID_UNIT_TYPES[API.FEED_UNIT] if unit
+            },
+            petlibro_unit=API.FEED_UNIT
+        ),
+        PetLibroSensorEntityDescription[SpaceSmartFeeder](
+            key="last_feed_quantity_volume",
+            translation_key="last_feed_quantity_volume",
+            name="Last Feed Quantity (Volume)",
+            icon="mdi:history",
+            native_unit_of_measurement=UnitOfVolume.MILLILITERS,
+            value_fn=lambda d,m: Unit.convert_feed(d.last_feed_quantity, None, Unit.MILLILITERS, True),
+            device_class=SensorDeviceClass.VOLUME,
+            state_class=SensorStateClass.TOTAL,
+            extra_state_attributes_fn=lambda d, m: {"portion": d.last_feed_quantity}|{
+                unit.symbol: Unit.convert_feed(d.last_feed_quantity, None, unit, True) 
+                for unit in VALID_UNIT_TYPES[API.FEED_UNIT] if unit
+            },
+            petlibro_unit=API.FEED_UNIT
         ),
         PetLibroSensorEntityDescription[SpaceSmartFeeder](
             key="pump_air_state",
@@ -899,30 +1083,50 @@ DEVICE_SENSOR_MAP: dict[type[Device], list[PetLibroSensorEntityDescription]] = {
             name="Remaining Cleaning Days"
         ),
         PetLibroSensorEntityDescription[DockstreamSmartFountain](
-            key="weight",
-            translation_key="weight",
-            icon="mdi:scale",
-            native_unit_of_measurement="oz",
+            key="remaining_water",
+            translation_key="remaining_water",
+            name="Remaining Water Volume",
+            icon="mdi:water",
+            native_unit_of_measurement=UnitOfVolume.MILLILITERS,
+            suggested_unit_of_measurement_fn=lambda m: m.waterUnitType.symbol,
             state_class=SensorStateClass.MEASUREMENT,
-            name="Current Weight"
+            device_class=SensorDeviceClass.VOLUME,
+            extra_state_attributes_fn=lambda d, m: {
+                unit.symbol: VolumeConverter.convert(d.weight, UnitOfVolume.MILLILITERS, unit.symbol)
+                for unit in VALID_UNIT_TYPES[API.WATER_UNIT] if unit
+            },
+            value_fn=lambda d,m: d.weight,
+            petlibro_unit=API.WATER_UNIT
         ),
         PetLibroSensorEntityDescription[DockstreamSmartFountain](
             key="today_drinking_amount",
             translation_key="today_drinking_amount",
             icon="mdi:water",
-            native_unit_of_measurement="mL",
+            native_unit_of_measurement=UnitOfVolume.MILLILITERS,
+            suggested_unit_of_measurement_fn=lambda m: m.waterUnitType.symbol,
             state_class=SensorStateClass.TOTAL_INCREASING,
             device_class=SensorDeviceClass.VOLUME,
-            name="Today's Water Consumption"
+            name="Today's Water Consumption",
+            extra_state_attributes_fn=lambda d, m: { unit.symbol: VolumeConverter.convert(
+                d.today_drinking_amount, UnitOfVolume.MILLILITERS, unit.symbol)
+                for unit in VALID_UNIT_TYPES[API.WATER_UNIT] if unit
+            },
+            petlibro_unit=API.WATER_UNIT
         ),
         PetLibroSensorEntityDescription[DockstreamSmartFountain](
             key="yesterday_drinking_amount",
             translation_key="yesterday_drinking_amount",
             icon="mdi:water",
-            native_unit_of_measurement="mL",
+            native_unit_of_measurement=UnitOfVolume.MILLILITERS,
+            suggested_unit_of_measurement_fn=lambda m: m.waterUnitType.symbol,
             state_class=SensorStateClass.TOTAL_INCREASING,
             device_class=SensorDeviceClass.VOLUME,
-            name="Yesterday's Water Consumption"
+            name="Yesterday's Water Consumption",
+            extra_state_attributes_fn=lambda d, m: { unit.symbol: VolumeConverter.convert(
+                d.today_drinking_amount, UnitOfVolume.MILLILITERS, unit.symbol)
+                for unit in VALID_UNIT_TYPES[API.WATER_UNIT] if unit
+            },
+            petlibro_unit=API.WATER_UNIT
         ),
         PetLibroSensorEntityDescription[DockstreamSmartFountain](
             key="today_drinking_time",
@@ -955,7 +1159,7 @@ DEVICE_SENSOR_MAP: dict[type[Device], list[PetLibroSensorEntityDescription]] = {
         PetLibroSensorEntityDescription[DockstreamSmartFountain](
             key="weight_percent",
             translation_key="weight_percent",
-            icon="mdi:scale",
+            icon="mdi:water-percent",
             native_unit_of_measurement="%",
             state_class=SensorStateClass.MEASUREMENT,
             name="Current Weight Percent"
@@ -1020,17 +1224,25 @@ DEVICE_SENSOR_MAP: dict[type[Device], list[PetLibroSensorEntityDescription]] = {
             name="Remaining Cleaning Days"
         ),
         PetLibroSensorEntityDescription[DockstreamSmartRFIDFountain](
-            key="weight",
-            translation_key="weight",
-            icon="mdi:scale",
-            native_unit_of_measurement="oz",
+            key="remaining_water",
+            translation_key="remaining_water",
+            name="Remaining Water Volume",
+            icon="mdi:water",
+            native_unit_of_measurement=UnitOfVolume.MILLILITERS,
+            suggested_unit_of_measurement_fn=lambda m: m.waterUnitType.symbol,
             state_class=SensorStateClass.MEASUREMENT,
-            name="Current Weight"
+            device_class=SensorDeviceClass.VOLUME,
+            extra_state_attributes_fn=lambda d, m: {
+                unit.symbol: VolumeConverter.convert(d.weight, UnitOfVolume.MILLILITERS, unit.symbol)
+                for unit in VALID_UNIT_TYPES[API.WATER_UNIT] if unit
+            },
+            value_fn=lambda d,m: d.weight,
+            petlibro_unit=API.WATER_UNIT
         ),
         PetLibroSensorEntityDescription[DockstreamSmartRFIDFountain](
             key="weight_percent",
             translation_key="weight_percent",
-            icon="mdi:scale",
+            icon="mdi:water-percent",
             native_unit_of_measurement="%",
             state_class=SensorStateClass.MEASUREMENT,
             name="Current Weight Percent"
@@ -1058,9 +1270,16 @@ DEVICE_SENSOR_MAP: dict[type[Device], list[PetLibroSensorEntityDescription]] = {
 #            key="today_drinking_amount",
 #            translation_key="today_drinking_amount",
 #            icon="mdi:water",
-#            native_unit_of_measurement="mL",
+#            native_unit_of_measurement=UnitOfVolume.MILLILITERS,
+#            suggested_unit_of_measurement_fn=lambda m: m.waterUnitType.symbol,
 #            state_class=SensorStateClass.TOTAL_INCREASING,
-#            name="Total Water Used Today"
+#            device_class=SensorDeviceClass.VOLUME,
+#            name="Total Water Used Today",
+#            extra_state_attributes_fn=lambda d, m: { unit.symbol: VolumeConverter.convert(
+#                d.today_drinking_amount, UnitOfVolume.MILLILITERS, unit.symbol)
+#                for unit in VALID_UNIT_TYPES[API.WATER_UNIT] if unit
+#            },
+#            petlibro_unit=API.WATER_UNIT
 #        ),
         PetLibroSensorEntityDescription[DockstreamSmartRFIDFountain](
             key="remaining_filter_days",
@@ -1108,17 +1327,25 @@ DEVICE_SENSOR_MAP: dict[type[Device], list[PetLibroSensorEntityDescription]] = {
             name="Remaining Cleaning Days"
         ),
         PetLibroSensorEntityDescription[Dockstream2SmartCordlessFountain](
-            key="weight",
-            translation_key="weight",
-            icon="mdi:scale",
-            native_unit_of_measurement="oz",
+            key="remaining_water",
+            translation_key="remaining_water",
+            name="Remaining Water Volume",
+            icon="mdi:water",
+            native_unit_of_measurement=UnitOfVolume.MILLILITERS,
+            suggested_unit_of_measurement_fn=lambda m: m.waterUnitType.symbol,
             state_class=SensorStateClass.MEASUREMENT,
-            name="Current Weight"
+            device_class=SensorDeviceClass.VOLUME,
+            extra_state_attributes_fn=lambda d, m: {
+                unit.symbol: VolumeConverter.convert(d.weight, UnitOfVolume.MILLILITERS, unit.symbol)
+                for unit in VALID_UNIT_TYPES[API.WATER_UNIT] if unit
+            },
+            value_fn=lambda d,m: d.weight,
+            petlibro_unit=API.WATER_UNIT
         ),
         PetLibroSensorEntityDescription[Dockstream2SmartCordlessFountain](
             key="weight_percent",
             translation_key="weight_percent",
-            icon="mdi:scale",
+            icon="mdi:water-percent",
             native_unit_of_measurement="%",
             state_class=SensorStateClass.MEASUREMENT,
             name="Current Weight Percent"
@@ -1127,19 +1354,31 @@ DEVICE_SENSOR_MAP: dict[type[Device], list[PetLibroSensorEntityDescription]] = {
             key="today_drinking_amount",
             translation_key="today_drinking_amount",
             icon="mdi:water",
-            native_unit_of_measurement="mL",
+            native_unit_of_measurement=UnitOfVolume.MILLILITERS,
+            suggested_unit_of_measurement_fn=lambda m: m.waterUnitType.symbol,
             state_class=SensorStateClass.TOTAL_INCREASING,
             device_class=SensorDeviceClass.VOLUME,
-            name="Today's Water Consumption"
+            name="Today's Water Consumption",
+            extra_state_attributes_fn=lambda d, m: { unit.symbol: VolumeConverter.convert(
+                d.today_drinking_amount, UnitOfVolume.MILLILITERS, unit.symbol)
+                for unit in VALID_UNIT_TYPES[API.WATER_UNIT] if unit
+            },
+            petlibro_unit=API.WATER_UNIT
         ),
         PetLibroSensorEntityDescription[Dockstream2SmartCordlessFountain](
             key="yesterday_drinking_amount",
             translation_key="yesterday_drinking_amount",
             icon="mdi:water",
-            native_unit_of_measurement="mL",
+            native_unit_of_measurement=UnitOfVolume.MILLILITERS,
+            suggested_unit_of_measurement_fn=lambda m: m.waterUnitType.symbol,
             state_class=SensorStateClass.TOTAL_INCREASING,
             device_class=SensorDeviceClass.VOLUME,
-            name="Yesterday's Water Consumption"
+            name="Yesterday's Water Consumption",
+            extra_state_attributes_fn=lambda d, m: { unit.symbol: VolumeConverter.convert(
+                d.yesterday_drinking_amount, UnitOfVolume.MILLILITERS, unit.symbol)
+                for unit in VALID_UNIT_TYPES[API.WATER_UNIT] if unit
+            },
+            petlibro_unit=API.WATER_UNIT
         ),
         PetLibroSensorEntityDescription[Dockstream2SmartCordlessFountain](
             key="remaining_filter_days",
@@ -1236,17 +1475,25 @@ DEVICE_SENSOR_MAP: dict[type[Device], list[PetLibroSensorEntityDescription]] = {
             name="Remaining Cleaning Days"
         ),
         PetLibroSensorEntityDescription[Dockstream2SmartFountain](
-            key="weight",
-            translation_key="weight",
-            icon="mdi:scale",
-            native_unit_of_measurement="oz",
+            key="remaining_water",
+            translation_key="remaining_water",
+            name="Remaining Water Volume",
+            icon="mdi:water",
+            native_unit_of_measurement=UnitOfVolume.MILLILITERS,
+            suggested_unit_of_measurement_fn=lambda m: m.waterUnitType.symbol,
             state_class=SensorStateClass.MEASUREMENT,
-            name="Current Weight"
+            device_class=SensorDeviceClass.VOLUME,
+            extra_state_attributes_fn=lambda d, m: {
+                unit.symbol: VolumeConverter.convert(d.weight, UnitOfVolume.MILLILITERS, unit.symbol)
+                for unit in VALID_UNIT_TYPES[API.WATER_UNIT] if unit
+            },
+            value_fn=lambda d,m: d.weight,
+            petlibro_unit=API.WATER_UNIT
         ),
         PetLibroSensorEntityDescription[Dockstream2SmartFountain](
             key="weight_percent",
             translation_key="weight_percent",
-            icon="mdi:scale",
+            icon="mdi:water-percent",
             native_unit_of_measurement="%",
             state_class=SensorStateClass.MEASUREMENT,
             name="Current Weight Percent"
@@ -1255,19 +1502,31 @@ DEVICE_SENSOR_MAP: dict[type[Device], list[PetLibroSensorEntityDescription]] = {
             key="today_drinking_amount",
             translation_key="today_drinking_amount",
             icon="mdi:water",
-            native_unit_of_measurement="mL",
+            native_unit_of_measurement=UnitOfVolume.MILLILITERS,
+            suggested_unit_of_measurement_fn=lambda m: m.waterUnitType.symbol,
             state_class=SensorStateClass.TOTAL_INCREASING,
             device_class=SensorDeviceClass.VOLUME,
-            name="Today's Water Consumption"
+            name="Today's Water Consumption",
+            extra_state_attributes_fn=lambda d, m: { unit.symbol: VolumeConverter.convert(
+                d.today_drinking_amount, UnitOfVolume.MILLILITERS, unit.symbol)
+                for unit in VALID_UNIT_TYPES[API.WATER_UNIT] if unit
+            },
+            petlibro_unit=API.WATER_UNIT
         ),
         PetLibroSensorEntityDescription[Dockstream2SmartFountain](
             key="yesterday_drinking_amount",
             translation_key="yesterday_drinking_amount",
             icon="mdi:water",
-            native_unit_of_measurement="mL",
+            native_unit_of_measurement=UnitOfVolume.MILLILITERS,
+            suggested_unit_of_measurement_fn=lambda m: m.waterUnitType.symbol,
             state_class=SensorStateClass.TOTAL_INCREASING,
             device_class=SensorDeviceClass.VOLUME,
-            name="Yesterday's Water Consumption"
+            name="Yesterday's Water Consumption",
+            extra_state_attributes_fn=lambda d, m: { unit.symbol: VolumeConverter.convert(
+                d.yesterday_drinking_amount, UnitOfVolume.MILLILITERS, unit.symbol)
+                for unit in VALID_UNIT_TYPES[API.WATER_UNIT] if unit
+            },
+            petlibro_unit=API.WATER_UNIT
         ),
         PetLibroSensorEntityDescription[Dockstream2SmartFountain](
             key="remaining_filter_days",

--- a/custom_components/petlibro/translations/ar.json
+++ b/custom_components/petlibro/translations/ar.json
@@ -25,6 +25,63 @@
             }
         }
     },
+    "options": {
+        "abort": {
+            "account_update_success": "تم تحديث الحساب",
+            "account_update_nomember": "لم يتم تحميل بيانات العضو، يرجى التحقق من السجلات",
+            "account_update_nochanges": "لم يتم تغيير أي إعدادات",
+            "account_update_nochanges_update_sensors": "لم يتم تغيير أي إعدادات\nتم تحديث كيانات المستشعر",
+            "error_check_logs": "خطأ، يرجى التحقق من السجلات"
+        },
+        "error": {
+            "unknown": "خطأ غير متوقع"
+        },
+        "step": {
+            "init": {
+                "menu_options": {
+                    "account_settings": "إعدادات الحساب"
+                }
+            },
+            "account_settings": {
+                "title": "إعدادات الحساب",
+                "description": "للحساب: {email}",
+                "data": {
+                    "nickname": "الاسم المستعار",
+                    "gender": "الجنس"
+                },
+                "sections": {
+                    "measurement_unit": {
+                        "name": "وحدات القياس",
+                        "data": {
+                            "feedUnitType": "المغذي/التغذية",
+                            "waterUnitType": "النافورة/الشرب",
+                            "weightUnitType": "الوزن",
+                            "update_all_units": "تحديث وحدة القياس لجميع كيانات أجهزة استشعار Petlibro"
+                        },
+                        "data_description": {
+                            "update_all_units": "بشكل افتراضي، تغيير الوحدة هنا يحدّث فقط كيانات المستشعر من هذا النوع."
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "selector": {
+        "member_gender": {
+            "options": {
+                "male": "ذكر",
+                "female": "أنثى",
+                "none": "أفضل عدم القول"
+            }
+        },
+        "pet_sex": {
+            "options": {
+                "male": "ذكر",
+                "female": "أنثى",
+                "none": "لم يتم الاختيار"
+            }
+        }
+    },
     "entity": {
         "sensor": {
             "device_sn": {
@@ -48,8 +105,17 @@
             "electric_quantity": {
                 "name": "البطارية / AC ٪"
             },
-            "today_feeding_quantity": {
-                "name": "كمية التغذية اليوم"
+            "today_feeding_quantity_weight": {
+                "name": "كمية التغذية اليوم (وزن)"
+            },
+            "today_feeding_quantity_volume": {
+                "name": "كمية التغذية اليوم (حجم)"
+            },
+            "last_feed_quantity_weight": {
+                "name": "كمية آخر وجبة (وزن)"
+            },
+            "last_feed_quantity_volume": {
+                "name": "كمية آخر وجبة (حجم)"
             },
             "today_feeding_times": {
                 "name": "أوقات التغذية اليوم"
@@ -70,6 +136,9 @@
                 "name": "الوزن الحالي"
             },
             "weight_percent": {
+                "name": "الماء المتبقي (%)"
+            },
+            "remaining_water": {
                 "name": "الماء المتبقي"
             },
             "use_water_interval": {
@@ -214,6 +283,9 @@
             },
             "lid_close_time": {
                 "name": "غطاء قرب الوقت"
+            },
+            "manual_feed_quantity": {
+                "name": "كمية التغذية اليدوية"
             }
         },
         "select": {

--- a/custom_components/petlibro/translations/ar.json
+++ b/custom_components/petlibro/translations/ar.json
@@ -27,19 +27,29 @@
     },
     "options": {
         "abort": {
-            "account_update_success": "تم تحديث الحساب",
-            "account_update_nomember": "لم يتم تحميل بيانات العضو، يرجى التحقق من السجلات",
-            "account_update_nochanges": "لم يتم تغيير أي إعدادات",
-            "account_update_nochanges_update_sensors": "لم يتم تغيير أي إعدادات\nتم تحديث كيانات المستشعر",
+            "no_member_data": "لم يتم تحميل بيانات العضو، يرجى التحقق من السجلات",
+            "account_settings_abort": "{account_settings_abort}",
+            "integration_settings_abort": "{integration_settings_abort}",
+            "no_settings_changed": "لم يتم تغيير أي إعدادات",
             "error_check_logs": "خطأ، يرجى التحقق من السجلات"
         },
         "error": {
             "unknown": "خطأ غير متوقع"
         },
         "step": {
-            "init": {
+			"init": {
                 "menu_options": {
+                    "integration_settings": "إعدادات التكامل",
                     "account_settings": "إعدادات الحساب"
+                }
+			},
+            "integration_settings": {
+                "title": "إعدادات التكامل",
+                "data": {
+                    "manual_feed_portions": "تعيين كمية التغذية اليدوية حسب الحصص"
+                },
+                "data_description": {
+                    "manual_feed_portions": "الافتراضي: التعيين حسب الوحدة التي اخترتها لطعام الحيوانات الأليفة ({uom})."
                 }
             },
             "account_settings": {
@@ -65,6 +75,13 @@
                 }
             }
         }
+    },
+    "common": {
+        "reloading_integration": "يتم إعادة تحميل التكامل",
+        "settings_updated": "تم تحديث الإعدادات",
+        "no_settings_changed": "لم يتم تغيير أي إعدادات",
+        "sensors_updated": "تم تحديث كيانات المستشعر",
+        "account_updated": "تم تحديث الحساب بنجاح"
     },
     "selector": {
         "member_gender": {
@@ -297,6 +314,9 @@
             },
             "display_icon": {
                 "name": "أيقونة معروضة"
+            },
+            "manual_feed_quantity_cups": {
+                "name": "كمية التغذية اليدوية"
             }
         },
         "text": {

--- a/custom_components/petlibro/translations/bn.json
+++ b/custom_components/petlibro/translations/bn.json
@@ -27,19 +27,29 @@
     },
     "options": {
         "abort": {
-            "account_update_success": "অ্যাকাউন্ট আপডেট হয়েছে",
-            "account_update_nomember": "সদস্য তথ্য লোড করা হয়নি, অনুগ্রহ করে লগ পরীক্ষা করুন",
-            "account_update_nochanges": "কোনও সেটিংস পরিবর্তন করা হয়নি",
-            "account_update_nochanges_update_sensors": "কোনও সেটিংস পরিবর্তন করা হয়নি\nসেন্সর এন্টিটিগুলি আপডেট হয়েছে",
+            "no_member_data": "সদস্য তথ্য লোড করা হয়নি, অনুগ্রহ করে লগ পরীক্ষা করুন",
+            "account_settings_abort": "{account_settings_abort}",
+            "integration_settings_abort": "{integration_settings_abort}",
+            "no_settings_changed": "কোনও সেটিংস পরিবর্তন করা হয়নি",
             "error_check_logs": "ত্রুটি, অনুগ্রহ করে লগ পরীক্ষা করুন"
         },
         "error": {
             "unknown": "অপ্রত্যাশিত ত্রুটি"
         },
         "step": {
-            "init": {
+			"init": {
                 "menu_options": {
+                    "integration_settings": "ইন্টিগ্রেশন সেটিংস",
                     "account_settings": "অ্যাকাউন্ট সেটিংস"
+                }
+			},
+            "integration_settings": {
+                "title": "ইন্টিগ্রেশন সেটিংস",
+                "data": {
+                    "manual_feed_portions": "পরিমাণ অনুযায়ী ম্যানুয়াল ফিড সেট করুন"
+                },
+                "data_description": {
+                    "manual_feed_portions": "ডিফল্ট: আপনার নির্বাচিত পোষা খাবারের এককের দ্বারা নির্ধারণ করুন ({uom})।"
                 }
             },
             "account_settings": {
@@ -65,6 +75,13 @@
                 }
             }
         }
+    },
+    "common": {
+        "reloading_integration": "ইন্টিগ্রেশন পুনরায় লোড হচ্ছে",
+        "settings_updated": "সেটিংস আপডেট হয়েছে",
+        "no_settings_changed": "কোনও সেটিংস পরিবর্তন করা হয়নি",
+        "sensors_updated": "সেন্সর এন্টিটিগুলি আপডেট হয়েছে",
+        "account_updated": "অ্যাকাউন্ট আপডেট সফল হয়েছে"
     },
     "selector": {
         "member_gender": {
@@ -297,6 +314,9 @@
             },
             "display_icon": {
                 "name": "প্রদর্শনে আইকন"
+            },
+            "manual_feed_quantity_cups": {
+                "name": "ম্যানুয়াল খাবারের পরিমাণ"
             }
         },
         "text": {

--- a/custom_components/petlibro/translations/bn.json
+++ b/custom_components/petlibro/translations/bn.json
@@ -25,6 +25,63 @@
             }
         }
     },
+    "options": {
+        "abort": {
+            "account_update_success": "অ্যাকাউন্ট আপডেট হয়েছে",
+            "account_update_nomember": "সদস্য তথ্য লোড করা হয়নি, অনুগ্রহ করে লগ পরীক্ষা করুন",
+            "account_update_nochanges": "কোনও সেটিংস পরিবর্তন করা হয়নি",
+            "account_update_nochanges_update_sensors": "কোনও সেটিংস পরিবর্তন করা হয়নি\nসেন্সর এন্টিটিগুলি আপডেট হয়েছে",
+            "error_check_logs": "ত্রুটি, অনুগ্রহ করে লগ পরীক্ষা করুন"
+        },
+        "error": {
+            "unknown": "অপ্রত্যাশিত ত্রুটি"
+        },
+        "step": {
+            "init": {
+                "menu_options": {
+                    "account_settings": "অ্যাকাউন্ট সেটিংস"
+                }
+            },
+            "account_settings": {
+                "title": "অ্যাকাউন্ট সেটিংস",
+                "description": "অ্যাকাউন্টের জন্য: {email}",
+                "data": {
+                    "nickname": "ডাকনাম",
+                    "gender": "লিঙ্গ"
+                },
+                "sections": {
+                    "measurement_unit": {
+                        "name": "পরিমাপের একক",
+                        "data": {
+                            "feedUnitType": "খাবার সরবরাহ/খাওয়ানো",
+                            "waterUnitType": "ফোয়ারা/পান করা",
+                            "weightUnitType": "ওজন",
+                            "update_all_units": "সমস্ত Petlibro ইউনিট সেন্সর এন্টিটির পরিমাপ একক আপডেট করুন"
+                        },
+                        "data_description": {
+                            "update_all_units": "ডিফল্টভাবে, এখানে ইউনিট পরিবর্তন করলে শুধুমাত্র সেই ধরনের সেন্সর এন্টিটি আপডেট হয়।"
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "selector": {
+        "member_gender": {
+            "options": {
+                "male": "পুরুষ",
+                "female": "মহিলা",
+                "none": "বলতে চাই না"
+            }
+        },
+        "pet_sex": {
+            "options": {
+                "male": "পুরুষ",
+                "female": "মহিলা",
+                "none": "কোনওটি নির্বাচিত হয়নি"
+            }
+        }
+    },
     "entity": {
         "sensor": {
             "device_sn": {
@@ -48,8 +105,17 @@
             "electric_quantity": {
                 "name": "ব্যাটারি / এসি %"
             },
-            "today_feeding_quantity": {
-                "name": "আজকের খাওয়ানোর পরিমাণ"
+            "today_feeding_quantity_weight": {
+                "name": "আজকের খাবারের পরিমাণ (ওজন)"
+            },
+            "today_feeding_quantity_volume": {
+                "name": "আজকের খাবারের পরিমাণ (পরিমাণ)"
+            },
+            "last_feed_quantity_weight": {
+                "name": "শেষ খাওয়ানোর পরিমাণ (ওজন)"
+            },
+            "last_feed_quantity_volume": {
+                "name": "শেষ খাওয়ানোর পরিমাণ (পরিমাণ)"
             },
             "today_feeding_times": {
                 "name": "আজকের খাওয়ানোর সময়"
@@ -70,6 +136,9 @@
                 "name": "বর্তমান ওজন"
             },
             "weight_percent": {
+                "name": "বাকি জল (%)"
+            },
+            "remaining_water": {
                 "name": "বাকি জল"
             },
             "use_water_interval": {
@@ -214,6 +283,9 @@
             },
             "lid_close_time": {
                 "name": "Lid াকনা কাছাকাছি সময়"
+            },
+            "manual_feed_quantity": {
+                "name": "ম্যানুয়াল খাবারের পরিমাণ"
             }
         },
         "select": {

--- a/custom_components/petlibro/translations/de.json
+++ b/custom_components/petlibro/translations/de.json
@@ -27,19 +27,29 @@
     },
     "options": {
         "abort": {
-            "account_update_success": "Konto aktualisiert",
-            "account_update_nomember": "Mitgliedsdaten nicht geladen, bitte Protokolle prüfen",
-            "account_update_nochanges": "Es wurden keine Einstellungen geändert",
-            "account_update_nochanges_update_sensors": "Es wurden keine Einstellungen geändert\nSensor-Entitäten aktualisiert",
+            "no_member_data": "Mitgliedsdaten nicht geladen, bitte Protokolle prüfen",
+            "account_settings_abort": "{account_settings_abort}",
+            "integration_settings_abort": "{integration_settings_abort}",
+            "no_settings_changed": "Keine Einstellungen wurden geändert",
             "error_check_logs": "Fehler, bitte Protokolle prüfen"
         },
         "error": {
             "unknown": "Unerwarteter Fehler"
         },
         "step": {
-            "init": {
+			"init": {
                 "menu_options": {
+                    "integration_settings": "Integrationseinstellungen",
                     "account_settings": "Kontoeinstellungen"
+                }
+			},
+            "integration_settings": {
+                "title": "Integrationseinstellungen",
+                "data": {
+                    "manual_feed_portions": "Manuelle Futtermenge nach Portionen festlegen"
+                },
+                "data_description": {
+                    "manual_feed_portions": "Standard: Festgelegt nach der gewählten Einheit für Tierfutter ({uom})."
                 }
             },
             "account_settings": {
@@ -65,6 +75,13 @@
                 }
             }
         }
+    },
+    "common": {
+        "reloading_integration": "Die Integration wird neu geladen",
+        "settings_updated": "Einstellungen aktualisiert",
+        "no_settings_changed": "Keine Einstellungen wurden geändert",
+        "sensors_updated": "Sensor-Entitäten aktualisiert",
+        "account_updated": "Kontoaktualisierung erfolgreich"
     },
     "selector": {
         "member_gender": {
@@ -291,6 +308,9 @@
             },
             "display_icon": {
                 "name": "Symbol auf dem Display"
+            },
+            "manual_feed_quantity_cups": {
+                "name": "Manuelle Futtermenge"
             }
         },
         "text": {

--- a/custom_components/petlibro/translations/de.json
+++ b/custom_components/petlibro/translations/de.json
@@ -25,6 +25,63 @@
             }
         }
     },
+    "options": {
+        "abort": {
+            "account_update_success": "Konto aktualisiert",
+            "account_update_nomember": "Mitgliedsdaten nicht geladen, bitte Protokolle prüfen",
+            "account_update_nochanges": "Es wurden keine Einstellungen geändert",
+            "account_update_nochanges_update_sensors": "Es wurden keine Einstellungen geändert\nSensor-Entitäten aktualisiert",
+            "error_check_logs": "Fehler, bitte Protokolle prüfen"
+        },
+        "error": {
+            "unknown": "Unerwarteter Fehler"
+        },
+        "step": {
+            "init": {
+                "menu_options": {
+                    "account_settings": "Kontoeinstellungen"
+                }
+            },
+            "account_settings": {
+                "title": "Kontoeinstellungen",
+                "description": "Für Konto: {email}",
+                "data": {
+                    "nickname": "Spitzname",
+                    "gender": "Geschlecht"
+                },
+                "sections": {
+                    "measurement_unit": {
+                        "name": "Maßeinheiten",
+                        "data": {
+                            "feedUnitType": "Futterautomat/Fütterung",
+                            "waterUnitType": "Brunnen/Trinken",
+                            "weightUnitType": "Gewicht",
+                            "update_all_units": "Maßeinheit aller Petlibro-Einheitssensor-Entitäten aktualisieren"
+                        },
+                        "data_description": {
+                            "update_all_units": "Standardmäßig aktualisiert eine Änderung der Einheit hier nur Sensor-Entitäten dieses Typs."
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "selector": {
+        "member_gender": {
+            "options": {
+                "male": "Männlich",
+                "female": "Weiblich",
+                "none": "Keine Angabe"
+            }
+        },
+        "pet_sex": {
+            "options": {
+                "male": "Männlich",
+                "female": "Weiblich",
+                "none": "Keine Auswahl"
+            }
+        }
+    },
     "entity": {
         "sensor": {
             "device_sn": {
@@ -48,8 +105,17 @@
             "electric_quantity": {
                 "name": "Batterie %"
             },
-            "today_feeding_quantity": {
-                "name": "Futtermenge heute"
+            "today_feeding_quantity_weight": {
+                "name": "Heutige Futtermenge (Gewicht)"
+            },
+            "today_feeding_quantity_volume": {
+                "name": "Heutige Futtermenge (Volumen)"
+            },
+            "last_feed_quantity_weight": {
+                "name": "Letzte Futtermenge (Gewicht)"
+            },
+            "last_feed_quantity_volume": {
+                "name": "Letzte Futtermenge (Volumen)"
             },
             "today_feeding_times": {
                 "name": "Fütterzeiten heute"
@@ -70,6 +136,9 @@
                 "name": "Aktuelles Gewicht"
             },
             "weight_percent": {
+                "name": "Verbleibendes Wasser (%)"
+            },
+            "remaining_water": {
                 "name": "Verbleibendes Wasser"
             },
             "use_water_interval": {
@@ -208,6 +277,9 @@
             },
             "lid_close_time": {
                 "name": "Deckelschließzeit"
+            },
+            "manual_feed_quantity": {
+                "name": "Manuelle Futtermenge"
             }
         },
         "select": {

--- a/custom_components/petlibro/translations/dk.json
+++ b/custom_components/petlibro/translations/dk.json
@@ -27,19 +27,29 @@
     },
     "options": {
         "abort": {
-            "account_update_success": "Konto opdateret",
-            "account_update_nomember": "Medlemsdata ikke indlæst, tjek venligst loggene",
-            "account_update_nochanges": "Ingen indstillinger blev ændret",
-            "account_update_nochanges_update_sensors": "Ingen indstillinger blev ændret\nSensor-entiteter opdateret",
+            "no_member_data": "Medlemsdata ikke indlæst, tjek venligst loggene",
+            "account_settings_abort": "{account_settings_abort}",
+            "integration_settings_abort": "{integration_settings_abort}",
+            "no_settings_changed": "Ingen indstillinger blev ændret",
             "error_check_logs": "Fejl, tjek venligst loggene"
         },
         "error": {
             "unknown": "Uventet fejl"
         },
         "step": {
-            "init": {
+			"init": {
                 "menu_options": {
+                    "integration_settings": "Integrationsindstillinger",
                     "account_settings": "Kontoindstillinger"
+                }
+			},
+            "integration_settings": {
+                "title": "Integrationsindstillinger",
+                "data": {
+                    "manual_feed_portions": "Indstil manuel fodermængde efter portioner"
+                },
+                "data_description": {
+                    "manual_feed_portions": "Standard: Indstil efter den valgte enhed til dyrefoder ({uom})."
                 }
             },
             "account_settings": {
@@ -65,6 +75,13 @@
                 }
             }
         }
+    },
+    "common": {
+        "reloading_integration": "Integrationen genindlæses",
+        "settings_updated": "Indstillinger opdateret",
+        "no_settings_changed": "Ingen indstillinger blev ændret",
+        "sensors_updated": "Sensor-entiteter opdateret",
+        "account_updated": "Konto opdateret med succes"
     },
     "selector": {
         "member_gender": {
@@ -300,6 +317,9 @@
             },
             "display_icon": {
                 "name": "Ikon på Skærmen"
+            },
+            "manual_feed_quantity_cups": {
+                "name": "Manuel fodermængde"
             }
         },
         "text": {

--- a/custom_components/petlibro/translations/dk.json
+++ b/custom_components/petlibro/translations/dk.json
@@ -25,6 +25,63 @@
             }
         }
     },
+    "options": {
+        "abort": {
+            "account_update_success": "Konto opdateret",
+            "account_update_nomember": "Medlemsdata ikke indlæst, tjek venligst loggene",
+            "account_update_nochanges": "Ingen indstillinger blev ændret",
+            "account_update_nochanges_update_sensors": "Ingen indstillinger blev ændret\nSensor-entiteter opdateret",
+            "error_check_logs": "Fejl, tjek venligst loggene"
+        },
+        "error": {
+            "unknown": "Uventet fejl"
+        },
+        "step": {
+            "init": {
+                "menu_options": {
+                    "account_settings": "Kontoindstillinger"
+                }
+            },
+            "account_settings": {
+                "title": "Kontoindstillinger",
+                "description": "For konto: {email}",
+                "data": {
+                    "nickname": "Kaldenavn",
+                    "gender": "Køn"
+                },
+                "sections": {
+                    "measurement_unit": {
+                        "name": "Måleenheder",
+                        "data": {
+                            "feedUnitType": "Foderautomat/Fodring",
+                            "waterUnitType": "Fontæne/Drikke",
+                            "weightUnitType": "Vægt",
+                            "update_all_units": "Opdater måleenheden for alle Petlibro-enhedssensor-entiteter"
+                        },
+                        "data_description": {
+                            "update_all_units": "Som standard opdaterer en ændring af enheden her kun sensor-entiteter af den type."
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "selector": {
+        "member_gender": {
+            "options": {
+                "male": "Mand",
+                "female": "Kvinde",
+                "none": "Ønsker ikke at oplyse"
+            }
+        },
+        "pet_sex": {
+            "options": {
+                "male": "Han",
+                "female": "Hun",
+                "none": "Ingen valgt"
+            }
+        }
+    },
     "entity": {
         "sensor": {
             "device_sn": {
@@ -48,8 +105,17 @@
             "electric_quantity": {
                 "name": "Batteri %"
             },
-            "today_feeding_quantity": {
-                "name": "Dagens Fodermængde"
+            "today_feeding_quantity_weight": {
+                "name": "Dagens Fodermængde (Vægt)"
+            },
+            "today_feeding_quantity_volume": {
+                "name": "Dagens Fodermængde (Volumen)"
+            },
+            "last_feed_quantity_weight": {
+                "name": "Sidste fodermængde (Vægt)"
+            },
+            "last_feed_quantity_volume": {
+                "name": "Sidste fodermængde (Volumen)"
             },
             "today_feeding_times": {
                 "name": "Dagens Fodertælling"
@@ -70,6 +136,9 @@
                 "name": "Nuværende Vægt"
             },
             "weight_percent": {
+                "name": "Resterende Vand (%)"
+            },
+            "remaining_water": {
                 "name": "Resterende Vand"
             },
             "use_water_interval": {
@@ -217,6 +286,9 @@
             },
             "lid_close_time": {
                 "name": "Lågets Lukketid"
+            },
+            "manual_feed_quantity": {
+                "name": "Manuel fodermængde"
             }
         },
         "select": {

--- a/custom_components/petlibro/translations/en.json
+++ b/custom_components/petlibro/translations/en.json
@@ -27,10 +27,9 @@
     },
 	"options": {
         "abort": {
-            "account_update_success": "Account updated",
-            "account_update_nomember": "Member data not loaded, please check logs",
-            "account_update_nochanges": "No settings were changed",
-            "account_update_nochanges_update_sensors": "No settings were changed\nSensor entities updated",
+            "no_member_data": "Member data not loaded, please check logs",
+            "account_settings_abort": "{account_settings_abort}",
+            "integration_settings_abort": "{integration_settings_abort}",
             "error_check_logs": "Error, please check logs"
         },
         "error": {
@@ -39,9 +38,19 @@
 		"step": {
 			"init": {
                 "menu_options": {
+                    "integration_settings": "Integration settings",
                     "account_settings": "Account settings"
                 }
 			},
+            "integration_settings": {
+                "title": "Integration Settings",
+                "data": {
+                    "manual_feed_portions": "Set Manual Feed amount by Portions"
+                },
+                "data_description": {
+                    "manual_feed_portions": "Default: Set by your chosen unit for pet feed ({uom})."
+                }
+            },
             "account_settings": {
                 "title": "Account Settings",
                 "description": "For account: {email}",
@@ -65,6 +74,13 @@
                 }
             }
         }
+    },
+    "common": {
+        "reloading_integration": "The integration is being reloaded",
+        "settings_updated": "Settings updated",
+        "no_settings_changed": "No settings were changed",
+        "sensors_updated": "Sensor entities were updated",
+        "account_updated": "Account update successful"
     },
     "selector": {
         "member_gender": {
@@ -390,6 +406,9 @@
             },
             "plate_position": {
                 "name": "Plate Position"
+            },
+            "manual_feed_quantity_cups": {
+                "name": "Manual Feed Quantity"
             }
         },
         "text": {

--- a/custom_components/petlibro/translations/en.json
+++ b/custom_components/petlibro/translations/en.json
@@ -30,6 +30,7 @@
             "account_update_success": "Account updated",
             "account_update_nomember": "Member data not loaded, please check logs",
             "account_update_nochanges": "No settings were changed",
+            "account_update_nochanges_update_sensors": "No settings were changed\nSensor entities updated",
             "error_check_logs": "Error, please check logs"
         },
         "error": {
@@ -54,10 +55,13 @@
                         "data": {
                             "feedUnitType": "Feeder/Feeding",
                             "waterUnitType": "Fountain/Drinking",
-                            "weightUnitType": "Weight"
+                            "weightUnitType": "Weight",
+                            "update_all_units": "Update measurement unit of all Petlibro unit sensor entities"
+                        },
+                        "data_description": {
+                            "update_all_units": "By default, changing a unit here only updates sensor entities of that type."
                         }
                     }
-
                 }
             }
         }
@@ -84,7 +88,9 @@
                 "grams": "g (gram)",
                 "milliliters": "ml (milliliter)",
                 "kilograms": "kg (kilogram)",
-                "pounds": "lb (pound)"
+                "pounds": "lb (pound)",
+                "water_ounces": "fl oz (fluid ounce)",
+                "water_milliliters": "ml (milliliter)"
             }
         }
     },
@@ -111,8 +117,11 @@
             "electric_quantity": {
                 "name": "Battery / AC %"
             },
-            "today_feeding_quantity": {
-                "name": "Today's Feeding Quantity"
+            "today_feeding_quantity_weight": {
+                "name": "Today's Feeding Quantity (Weight)"
+            },
+            "today_feeding_quantity_volume": {
+                "name": "Today's Feeding Quantity (Volume)"
             },
             "today_feeding_times": {
                 "name": "Today's Feeding Times"
@@ -126,8 +135,11 @@
             "last_feed_time": {
                 "name": "Last Feed Time"
             },
-            "last_feed_quantity": {
-                "name": "Last Feed Quantity"
+            "last_feed_quantity_weight": {
+                "name": "Last Feed Quantity (Weight)"
+            },
+            "last_feed_quantity_volume": {
+                "name": "Last Feed Quantity (Volume)"
             },
             "feeding_plan_state": {
                 "name": "Today's Feeding Plan"
@@ -139,6 +151,9 @@
                 "name": "Current Weight"
             },
             "weight_percent": {
+                "name": "Remaining Water (%)"
+            },
+            "remaining_water": {
                 "name": "Remaining Water"
             },
             "use_water_interval": {
@@ -355,6 +370,9 @@
             },
             "filter_cycle": {
                 "name": "Filter Cycle"
+            },
+            "manual_feed_quantity": {
+                "name": "Manual Feed Quantity"
             }
         },
         "select": {

--- a/custom_components/petlibro/translations/es.json
+++ b/custom_components/petlibro/translations/es.json
@@ -25,6 +25,63 @@
             }
         }
     },
+    "options": {
+        "abort": {
+            "account_update_success": "Cuenta actualizada",
+            "account_update_nomember": "Datos de miembro no cargados, por favor revise los registros",
+            "account_update_nochanges": "No se cambiaron configuraciones",
+            "account_update_nochanges_update_sensors": "No se cambiaron configuraciones\nEntidades de sensores actualizadas",
+            "error_check_logs": "Error, por favor revise los registros"
+        },
+        "error": {
+            "unknown": "Error inesperado"
+        },
+        "step": {
+            "init": {
+                "menu_options": {
+                    "account_settings": "Configuración de la cuenta"
+                }
+            },
+            "account_settings": {
+                "title": "Configuración de la cuenta",
+                "description": "Para la cuenta: {email}",
+                "data": {
+                    "nickname": "Apodo",
+                    "gender": "Género"
+                },
+                "sections": {
+                    "measurement_unit": {
+                        "name": "Unidades de medida",
+                        "data": {
+                            "feedUnitType": "Comedero/Alimentación",
+                            "waterUnitType": "Fuente/Bebida",
+                            "weightUnitType": "Peso",
+                            "update_all_units": "Actualizar la unidad de medida de todas las entidades de sensores de unidad Petlibro"
+                        },
+                        "data_description": {
+                            "update_all_units": "De forma predeterminada, cambiar una unidad aquí solo actualiza las entidades de sensores de ese tipo."
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "selector": {
+        "member_gender": {
+            "options": {
+                "male": "Masculino",
+                "female": "Femenino",
+                "none": "Prefiero no decirlo"
+            }
+        },
+        "pet_sex": {
+            "options": {
+                "male": "Macho",
+                "female": "Hembra",
+                "none": "Ninguno seleccionado"
+            }
+        }
+    },
     "entity": {
         "sensor": {
             "device_sn": {
@@ -48,8 +105,17 @@
             "electric_quantity": {
                 "name": "Batería / AC %"
             },
-            "today_feeding_quantity": {
-                "name": "La cantidad de alimentación de hoy"
+            "today_feeding_quantity_weight": {
+                "name": "Cantidad de alimento de hoy (Peso)"
+            },
+            "today_feeding_quantity_volume": {
+                "name": "Cantidad de alimento de hoy (Volumen)"
+            },
+            "last_feed_quantity_weight": {
+                "name": "Cantidad de última alimentación (Peso)"
+            },
+            "last_feed_quantity_volume": {
+                "name": "Cantidad de última alimentación (Volumen)|"
             },
             "today_feeding_times": {
                 "name": "Los tiempos de alimentación de hoy"
@@ -70,6 +136,9 @@
                 "name": "Peso actual"
             },
             "weight_percent": {
+                "name": "Agua restante (%)"
+            },
+            "remaining_water": {
                 "name": "Agua restante"
             },
             "use_water_interval": {
@@ -214,6 +283,9 @@
             },
             "lid_close_time": {
                 "name": "Tapa de tiempo cercano"
+            },
+            "manual_feed_quantity": {
+                "name": "Cantidad de alimento manual"
             }
         },
         "select": {

--- a/custom_components/petlibro/translations/es.json
+++ b/custom_components/petlibro/translations/es.json
@@ -27,19 +27,29 @@
     },
     "options": {
         "abort": {
-            "account_update_success": "Cuenta actualizada",
-            "account_update_nomember": "Datos de miembro no cargados, por favor revise los registros",
-            "account_update_nochanges": "No se cambiaron configuraciones",
-            "account_update_nochanges_update_sensors": "No se cambiaron configuraciones\nEntidades de sensores actualizadas",
+            "no_member_data": "Datos de miembro no cargados, por favor revise los registros",
+            "account_settings_abort": "{account_settings_abort}",
+            "integration_settings_abort": "{integration_settings_abort}",
+            "no_settings_changed": "No se cambiaron configuraciones",
             "error_check_logs": "Error, por favor revise los registros"
         },
         "error": {
             "unknown": "Error inesperado"
         },
         "step": {
-            "init": {
+			"init": {
                 "menu_options": {
+                    "integration_settings": "Configuración de la integración",
                     "account_settings": "Configuración de la cuenta"
+                }
+			},
+            "integration_settings": {
+                "title": "Configuración de la integración",
+                "data": {
+                    "manual_feed_portions": "Establecer alimentación manual por porciones"
+                },
+                "data_description": {
+                    "manual_feed_portions": "Predeterminado: establecer según la unidad seleccionada para comida de mascotas ({uom})."
                 }
             },
             "account_settings": {
@@ -65,6 +75,13 @@
                 }
             }
         }
+    },
+    "common": {
+        "reloading_integration": "La integración se está recargando",
+        "settings_updated": "Configuraciones actualizadas",
+        "no_settings_changed": "No se cambiaron configuraciones",
+        "sensors_updated": "Entidades de sensores actualizadas",
+        "account_updated": "Actualización de cuenta exitosa"
     },
     "selector": {
         "member_gender": {
@@ -297,6 +314,9 @@
             },
             "display_icon": {
                 "name": "Icono en la pantalla"
+            },
+            "manual_feed_quantity_cups": {
+                "name": "Cantidad de alimento manual"
             }
         },
         "text": {

--- a/custom_components/petlibro/translations/fr.json
+++ b/custom_components/petlibro/translations/fr.json
@@ -27,19 +27,29 @@
     },
     "options": {
         "abort": {
-            "account_update_success": "Compte mis à jour",
-            "account_update_nomember": "Données du membre non chargées, veuillez vérifier les journaux",
-            "account_update_nochanges": "Aucun paramètre n'a été modifié",
-            "account_update_nochanges_update_sensors": "Aucun paramètre n'a été modifié\nEntités de capteurs mises à jour",
+            "no_member_data": "Données du membre non chargées, veuillez vérifier les journaux",
+            "account_settings_abort": "{account_settings_abort}",
+            "integration_settings_abort": "{integration_settings_abort}",
+            "no_settings_changed": "Aucun paramètre n'a été modifié",
             "error_check_logs": "Erreur, veuillez vérifier les journaux"
         },
         "error": {
             "unknown": "Erreur inattendue"
         },
         "step": {
-            "init": {
+			"init": {
                 "menu_options": {
+                    "integration_settings": "Paramètres d’intégration",
                     "account_settings": "Paramètres du compte"
+                }
+			},
+            "integration_settings": {
+                "title": "Paramètres d’intégration",
+                "data": {
+                    "manual_feed_portions": "Définir la quantité de nourriture manuelle par portions"
+                },
+                "data_description": {
+                    "manual_feed_portions": "Par défaut : défini selon l’unité choisie pour la nourriture de l’animal ({uom})."
                 }
             },
             "account_settings": {
@@ -65,6 +75,13 @@
                 }
             }
         }
+    },
+    "common": {
+        "reloading_integration": "L’intégration est en cours de rechargement",
+        "settings_updated": "Paramètres mis à jour",
+        "no_settings_changed": "Aucun paramètre n’a été modifié",
+        "sensors_updated": "Entités de capteurs mises à jour",
+        "account_updated": "Mise à jour du compte réussie"
     },
     "selector": {
         "member_gender": {
@@ -297,6 +314,9 @@
             },
             "display_icon": {
                 "name": "Icône exposée"
+            },
+            "manual_feed_quantity_cups": {
+                "name": "Quantité de nourriture manuelle"
             }
         },
         "text": {

--- a/custom_components/petlibro/translations/fr.json
+++ b/custom_components/petlibro/translations/fr.json
@@ -25,6 +25,63 @@
             }
         }
     },
+    "options": {
+        "abort": {
+            "account_update_success": "Compte mis à jour",
+            "account_update_nomember": "Données du membre non chargées, veuillez vérifier les journaux",
+            "account_update_nochanges": "Aucun paramètre n'a été modifié",
+            "account_update_nochanges_update_sensors": "Aucun paramètre n'a été modifié\nEntités de capteurs mises à jour",
+            "error_check_logs": "Erreur, veuillez vérifier les journaux"
+        },
+        "error": {
+            "unknown": "Erreur inattendue"
+        },
+        "step": {
+            "init": {
+                "menu_options": {
+                    "account_settings": "Paramètres du compte"
+                }
+            },
+            "account_settings": {
+                "title": "Paramètres du compte",
+                "description": "Pour le compte : {email}",
+                "data": {
+                    "nickname": "Surnom",
+                    "gender": "Genre"
+                },
+                "sections": {
+                    "measurement_unit": {
+                        "name": "Unités de mesure",
+                        "data": {
+                            "feedUnitType": "Distributeur/Alimentation",
+                            "waterUnitType": "Fontaine/Boisson",
+                            "weightUnitType": "Poids",
+                            "update_all_units": "Mettre à jour l'unité de mesure de toutes les entités de capteurs d’unité Petlibro"
+                        },
+                        "data_description": {
+                            "update_all_units": "Par défaut, changer une unité ici met seulement à jour les entités de capteurs de ce type."
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "selector": {
+        "member_gender": {
+            "options": {
+                "male": "Homme",
+                "female": "Femme",
+                "none": "Préférer ne pas dire"
+            }
+        },
+        "pet_sex": {
+            "options": {
+                "male": "Mâle",
+                "female": "Femelle",
+                "none": "Aucun sélectionné"
+            }
+        }
+    },
     "entity": {
         "sensor": {
             "device_sn": {
@@ -48,8 +105,17 @@
             "electric_quantity": {
                 "name": "Batterie / AC%"
             },
-            "today_feeding_quantity": {
-                "name": "La quantité d'alimentation d'aujourd'hui"
+            "today_feeding_quantity_weight": {
+                "name": "Quantité de nourriture aujourd’hui (Poids)"
+            },
+            "today_feeding_quantity_volume": {
+                "name": "Quantité de nourriture aujourd’hui (Volume)"
+            },
+            "last_feed_quantity_weight": {
+                "name": "Quantité de dernière alimentation (Poids)"
+            },
+            "last_feed_quantity_volume": {
+                "name": "Quantité de dernière alimentation (Volume)"
             },
             "today_feeding_times": {
                 "name": "Les temps d'alimentation d'aujourd'hui"
@@ -70,6 +136,9 @@
                 "name": "Poids actuel"
             },
             "weight_percent": {
+                "name": "Eau restante (%)"
+            },
+            "remaining_water": {
                 "name": "Eau restante"
             },
             "use_water_interval": {
@@ -214,6 +283,9 @@
             },
             "lid_close_time": {
                 "name": "Couvercle de la couvercle"
+            },
+            "manual_feed_quantity": {
+                "name": "Quantité de nourriture manuelle"
             }
         },
         "select": {

--- a/custom_components/petlibro/translations/hi.json
+++ b/custom_components/petlibro/translations/hi.json
@@ -27,19 +27,29 @@
     },
     "options": {
         "abort": {
-            "account_update_success": "खाता अपडेट किया गया",
-            "account_update_nomember": "सदस्य डेटा लोड नहीं हुआ, कृपया लॉग जांचें",
-            "account_update_nochanges": "कोई सेटिंग्स नहीं बदली गईं",
-            "account_update_nochanges_update_sensors": "कोई सेटिंग्स नहीं बदली गईं\nसेंसर एंटिटीज़ अपडेट की गईं",
+            "no_member_data": "सदस्य डेटा लोड नहीं हुआ, कृपया लॉग जांचें",
+            "account_settings_abort": "{account_settings_abort}",
+            "integration_settings_abort": "{integration_settings_abort}",
+            "no_settings_changed": "कोई सेटिंग्स नहीं बदली गईं",
             "error_check_logs": "त्रुटि, कृपया लॉग जांचें"
         },
         "error": {
             "unknown": "अप्रत्याशित त्रुटि"
         },
         "step": {
-            "init": {
+			"init": {
                 "menu_options": {
+                    "integration_settings": "इंटीग्रेशन सेटिंग्स",
                     "account_settings": "खाता सेटिंग्स"
+                }
+			},
+            "integration_settings": {
+                "title": "इंटीग्रेशन सेटिंग्स",
+                "data": {
+                    "manual_feed_portions": "पोरशन के अनुसार मैनुअल फीड मात्रा सेट करें"
+                },
+                "data_description": {
+                    "manual_feed_portions": "डिफ़ॉल्ट: आपके द्वारा चुनी गई पालतू भोजन इकाई के अनुसार सेट करें ({uom})।"
                 }
             },
             "account_settings": {
@@ -65,6 +75,13 @@
                 }
             }
         }
+    },
+    "common": {
+        "reloading_integration": "इंटीग्रेशन पुनः लोड किया जा रहा है",
+        "settings_updated": "सेटिंग्स अपडेट की गईं",
+        "no_settings_changed": "कोई सेटिंग्स नहीं बदली गईं",
+        "sensors_updated": "सेंसर एंटिटीज़ अपडेट की गईं",
+        "account_updated": "खाता अपडेट सफल रहा"
     },
     "selector": {
         "member_gender": {
@@ -297,6 +314,9 @@
             },
             "display_icon": {
                 "name": "प्रदर्शन पर आइकन"
+            },
+            "manual_feed_quantity_cups": {
+                "name": "मैनुअल खिलाने की मात्रा"
             }
         },
         "text": {

--- a/custom_components/petlibro/translations/hi.json
+++ b/custom_components/petlibro/translations/hi.json
@@ -25,6 +25,63 @@
             }
         }
     },
+    "options": {
+        "abort": {
+            "account_update_success": "खाता अपडेट किया गया",
+            "account_update_nomember": "सदस्य डेटा लोड नहीं हुआ, कृपया लॉग जांचें",
+            "account_update_nochanges": "कोई सेटिंग्स नहीं बदली गईं",
+            "account_update_nochanges_update_sensors": "कोई सेटिंग्स नहीं बदली गईं\nसेंसर एंटिटीज़ अपडेट की गईं",
+            "error_check_logs": "त्रुटि, कृपया लॉग जांचें"
+        },
+        "error": {
+            "unknown": "अप्रत्याशित त्रुटि"
+        },
+        "step": {
+            "init": {
+                "menu_options": {
+                    "account_settings": "खाता सेटिंग्स"
+                }
+            },
+            "account_settings": {
+                "title": "खाता सेटिंग्स",
+                "description": "खाते के लिए: {email}",
+                "data": {
+                    "nickname": "उपनाम",
+                    "gender": "लिंग"
+                },
+                "sections": {
+                    "measurement_unit": {
+                        "name": "माप की इकाइयाँ",
+                        "data": {
+                            "feedUnitType": "फीडर/खिलाना",
+                            "waterUnitType": "फव्वारा/पेय",
+                            "weightUnitType": "वज़न",
+                            "update_all_units": "सभी Petlibro यूनिट सेंसर एंटिटी की माप इकाई अपडेट करें"
+                        },
+                        "data_description": {
+                            "update_all_units": "डिफ़ॉल्ट रूप से, यहां एक इकाई बदलने से केवल उसी प्रकार की सेंसर एंटिटी अपडेट होती है।"
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "selector": {
+        "member_gender": {
+            "options": {
+                "male": "पुरुष",
+                "female": "महिला",
+                "none": "नहीं बताना चाहता"
+            }
+        },
+        "pet_sex": {
+            "options": {
+                "male": "नर",
+                "female": "मादा",
+                "none": "कोई चयन नहीं"
+            }
+        }
+    },
     "entity": {
         "sensor": {
             "device_sn": {
@@ -48,8 +105,17 @@
             "electric_quantity": {
                 "name": "बैटरी / एसी %"
             },
-            "today_feeding_quantity": {
-                "name": "आज की फीडिंग की मात्रा"
+            "today_feeding_quantity_weight": {
+                "name": "आज की खिलाने की मात्रा (वज़न)"
+            },
+            "today_feeding_quantity_volume": {
+                "name": "आज की खिलाने की मात्रा (आयतन)"
+            },
+            "last_feed_quantity_weight": {
+                "name": "अंतिम खिलाने की मात्रा (वज़न)"
+            },
+            "last_feed_quantity_volume": {
+                "name": "अंतिम खिलाने की मात्रा (आयतन)"
             },
             "today_feeding_times": {
                 "name": "आज का खिला समय"
@@ -70,6 +136,9 @@
                 "name": "वर्तमान वजन"
             },
             "weight_percent": {
+                "name": "शेष पानी (%)"
+            },
+            "remaining_water": {
                 "name": "शेष पानी"
             },
             "use_water_interval": {
@@ -214,6 +283,9 @@
             },
             "lid_close_time": {
                 "name": "ढक्कन करीबी समय"
+            },
+            "manual_feed_quantity": {
+                "name": "मैनुअल खिलाने की मात्रा"
             }
         },
         "select": {

--- a/custom_components/petlibro/translations/ja.json
+++ b/custom_components/petlibro/translations/ja.json
@@ -25,6 +25,63 @@
             }
         }
     },
+    "options": {
+        "abort": {
+            "account_update_success": "アカウントを更新しました",
+            "account_update_nomember": "メンバーデータが読み込まれていません。ログを確認してください",
+            "account_update_nochanges": "設定は変更されませんでした",
+            "account_update_nochanges_update_sensors": "設定は変更されませんでした\nセンサーエンティティが更新されました",
+            "error_check_logs": "エラー、ログを確認してください"
+        },
+        "error": {
+            "unknown": "予期しないエラー"
+        },
+        "step": {
+            "init": {
+                "menu_options": {
+                    "account_settings": "アカウント設定"
+                }
+            },
+            "account_settings": {
+                "title": "アカウント設定",
+                "description": "アカウント: {email}",
+                "data": {
+                    "nickname": "ニックネーム",
+                    "gender": "性別"
+                },
+                "sections": {
+                    "measurement_unit": {
+                        "name": "測定単位",
+                        "data": {
+                            "feedUnitType": "給餌機/給餌",
+                            "waterUnitType": "給水器/飲水",
+                            "weightUnitType": "重量",
+                            "update_all_units": "すべてのPetlibroユニットセンサーエンティティの測定単位を更新"
+                        },
+                        "data_description": {
+                            "update_all_units": "デフォルトでは、ここで単位を変更すると、その種類のセンサーエンティティのみが更新されます。"
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "selector": {
+        "member_gender": {
+            "options": {
+                "male": "男性",
+                "female": "女性",
+                "none": "答えたくない"
+            }
+        },
+        "pet_sex": {
+            "options": {
+                "male": "オス",
+                "female": "メス",
+                "none": "未選択"
+            }
+        }
+    },
     "entity": {
         "sensor": {
             "device_sn": {
@@ -48,8 +105,17 @@
             "electric_quantity": {
                 "name": "バッテリー / AC％"
             },
-            "today_feeding_quantity": {
-                "name": "今日の給餌量"
+            "today_feeding_quantity_weight": {
+                "name": "今日の給餌量（重量）"
+            },
+            "today_feeding_quantity_volume": {
+                "name": "今日の給餌量（容量）"
+            },
+            "last_feed_quantity_weight": {
+                "name": "最後の給餌量（重量）"
+            },
+            "last_feed_quantity_volume": {
+                "name": "最後の給餌量（容量）"
             },
             "today_feeding_times": {
                 "name": "今日の給餌時間"
@@ -70,6 +136,9 @@
                 "name": "現在の重量"
             },
             "weight_percent": {
+                "name": "残りの水 (%)"
+            },
+            "remaining_water": {
                 "name": "残りの水"
             },
             "use_water_interval": {
@@ -214,6 +283,9 @@
             },
             "lid_close_time": {
                 "name": "ふたの近い時間"
+            },
+            "manual_feed_quantity": {
+                "name": "手動給餌量"
             }
         },
         "select": {

--- a/custom_components/petlibro/translations/ja.json
+++ b/custom_components/petlibro/translations/ja.json
@@ -27,19 +27,29 @@
     },
     "options": {
         "abort": {
-            "account_update_success": "アカウントを更新しました",
-            "account_update_nomember": "メンバーデータが読み込まれていません。ログを確認してください",
-            "account_update_nochanges": "設定は変更されませんでした",
-            "account_update_nochanges_update_sensors": "設定は変更されませんでした\nセンサーエンティティが更新されました",
+            "no_member_data": "メンバーデータが読み込まれていません。ログを確認してください",
+            "account_settings_abort": "{account_settings_abort}",
+            "integration_settings_abort": "{integration_settings_abort}",
+            "no_settings_changed": "設定は変更されませんでした",
             "error_check_logs": "エラー、ログを確認してください"
         },
         "error": {
             "unknown": "予期しないエラー"
         },
         "step": {
-            "init": {
+			"init": {
                 "menu_options": {
+                    "integration_settings": "統合設定",
                     "account_settings": "アカウント設定"
+                }
+			},
+            "integration_settings": {
+                "title": "統合設定",
+                "data": {
+                    "manual_feed_portions": "手動給餌量をポーション単位で設定"
+                },
+                "data_description": {
+                    "manual_feed_portions": "デフォルト: ペットフードの選択単位に基づいて設定します ({uom})。"
                 }
             },
             "account_settings": {
@@ -65,6 +75,13 @@
                 }
             }
         }
+    },
+    "common": {
+        "reloading_integration": "統合を再読み込みしています",
+        "settings_updated": "設定が更新されました",
+        "no_settings_changed": "設定は変更されませんでした",
+        "sensors_updated": "センサーエンティティが更新されました",
+        "account_updated": "アカウントの更新に成功しました"
     },
     "selector": {
         "member_gender": {
@@ -297,6 +314,9 @@
             },
             "display_icon": {
                 "name": "展示されているアイコン"
+            },
+            "manual_feed_quantity_cups": {
+                "name": "手動給餌量"
             }
         },
         "text": {

--- a/custom_components/petlibro/translations/nl-be.json
+++ b/custom_components/petlibro/translations/nl-be.json
@@ -25,6 +25,63 @@
             }
         }
     },
+    "options": {
+        "abort": {
+            "account_update_success": "Account bijgewerkt",
+            "account_update_nomember": "Lidgegevens niet geladen, controleer de logboeken",
+            "account_update_nochanges": "Er zijn geen instellingen gewijzigd",
+            "account_update_nochanges_update_sensors": "Er zijn geen instellingen gewijzigd\nSensor-entiteiten bijgewerkt",
+            "error_check_logs": "Fout, controleer de logboeken"
+        },
+        "error": {
+            "unknown": "Onverwachte fout"
+        },
+        "step": {
+            "init": {
+                "menu_options": {
+                    "account_settings": "Accountinstellingen"
+                }
+            },
+            "account_settings": {
+                "title": "Accountinstellingen",
+                "description": "Voor account: {email}",
+                "data": {
+                    "nickname": "Bijnaam",
+                    "gender": "Geslacht"
+                },
+                "sections": {
+                    "measurement_unit": {
+                        "name": "Meeteenheden",
+                        "data": {
+                            "feedUnitType": "Voederautomaat/Voeren",
+                            "waterUnitType": "Fontein/Drinken",
+                            "weightUnitType": "Gewicht",
+                            "update_all_units": "Werk de meeteenheid van alle Petlibro-eenheidssensor-entiteiten bij"
+                        },
+                        "data_description": {
+                            "update_all_units": "Standaard werkt een wijziging van een eenheid hier alleen sensoren van dat type bij."
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "selector": {
+        "member_gender": {
+            "options": {
+                "male": "Man",
+                "female": "Vrouw",
+                "none": "Geen voorkeur"
+            }
+        },
+        "pet_sex": {
+            "options": {
+                "male": "Mannetje",
+                "female": "Vrouwtje",
+                "none": "Geen geselecteerd"
+            }
+        }
+    },
     "entity": {
         "sensor": {
             "device_sn": {
@@ -48,8 +105,17 @@
             "electric_quantity": {
                 "name": "Batterij %"
             },
-            "today_feeding_quantity": {
-                "name": "Totale Voedingshoeveelheid van vandaag"
+            "today_feeding_quantity_weight": {
+                "name": "Vandaag gevoerde hoeveelheid (Gewicht)"
+            },
+            "today_feeding_quantity_volume": {
+                "name": "Vandaag gevoerde hoeveelheid (Volume)"
+            },
+            "last_feed_quantity_weight": {
+                "name": "Laatste gevoerde hoeveelheid (Gewicht)"
+            },
+            "last_feed_quantity_volume": {
+                "name": "Laatste gevoerde hoeveelheid (Volume)"
             },
             "today_feeding_times": {
                 "name": "Totale voedermomenten van vandaag"
@@ -70,6 +136,9 @@
                 "name": "Huidig ​​gewicht"
             },
             "weight_percent": {
+                "name": "Resterend water (%)"
+            },
+            "remaining_water": {
                 "name": "Resterend water"
             },
             "use_water_interval": {
@@ -217,6 +286,9 @@
             },
             "lid_close_time": {
                 "name": "Sluittijd deksel"
+            },
+            "manual_feed_quantity": {
+                "name": "Handmatige voederhoeveelheid"
             }
         },
         "select": {

--- a/custom_components/petlibro/translations/nl-be.json
+++ b/custom_components/petlibro/translations/nl-be.json
@@ -27,19 +27,29 @@
     },
     "options": {
         "abort": {
-            "account_update_success": "Account bijgewerkt",
-            "account_update_nomember": "Lidgegevens niet geladen, controleer de logboeken",
-            "account_update_nochanges": "Er zijn geen instellingen gewijzigd",
-            "account_update_nochanges_update_sensors": "Er zijn geen instellingen gewijzigd\nSensor-entiteiten bijgewerkt",
+            "no_member_data": "Lidgegevens niet geladen, controleer de logboeken",
+            "account_settings_abort": "{account_settings_abort}",
+            "integration_settings_abort": "{integration_settings_abort}",
+            "no_settings_changed": "Er zijn geen instellingen gewijzigd",
             "error_check_logs": "Fout, controleer de logboeken"
         },
         "error": {
             "unknown": "Onverwachte fout"
         },
         "step": {
-            "init": {
+			"init": {
                 "menu_options": {
+                    "integration_settings": "Integratie-instellingen",
                     "account_settings": "Accountinstellingen"
+                }
+			},
+            "integration_settings": {
+                "title": "Integratie-instellingen",
+                "data": {
+                    "manual_feed_portions": "Handmatige voerhoeveelheid instellen per portie"
+                },
+                "data_description": {
+                    "manual_feed_portions": "Standaard: ingesteld volgens de gekozen eenheid voor dierenvoer ({uom})."
                 }
             },
             "account_settings": {
@@ -65,6 +75,13 @@
                 }
             }
         }
+    },
+    "common": {
+        "reloading_integration": "De integratie wordt opnieuw geladen",
+        "settings_updated": "Instellingen bijgewerkt",
+        "no_settings_changed": "Er zijn geen instellingen gewijzigd",
+        "sensors_updated": "Sensor-entiteiten bijgewerkt",
+        "account_updated": "Account succesvol bijgewerkt"
     },
     "selector": {
         "member_gender": {
@@ -300,6 +317,9 @@
             },
             "display_icon": {
                 "name": "Symbol op het scherm"
+            },
+            "manual_feed_quantity_cups": {
+                "name": "Handmatige voederhoeveelheid"
             }
         },
         "text": {

--- a/custom_components/petlibro/translations/pt.json
+++ b/custom_components/petlibro/translations/pt.json
@@ -27,19 +27,29 @@
     },
     "options": {
         "abort": {
-            "account_update_success": "Conta atualizada",
-            "account_update_nomember": "Dados do membro não carregados, verifique os registros",
-            "account_update_nochanges": "Nenhuma configuração foi alterada",
-            "account_update_nochanges_update_sensors": "Nenhuma configuração foi alterada\nEntidades de sensores atualizadas",
+            "no_member_data": "Dados do membro não carregados, verifique os registros",
+            "account_settings_abort": "{account_settings_abort}",
+            "integration_settings_abort": "{integration_settings_abort}",
+            "no_settings_changed": "Nenhuma configuração foi alterada",
             "error_check_logs": "Erro, verifique os registros"
         },
         "error": {
             "unknown": "Erro inesperado"
         },
         "step": {
-            "init": {
+			"init": {
                 "menu_options": {
+                    "integration_settings": "Configurações da integração",
                     "account_settings": "Configurações da conta"
+                }
+			},
+            "integration_settings": {
+                "title": "Configurações da integração",
+                "data": {
+                    "manual_feed_portions": "Definir quantidade de alimentação manual por porções"
+                },
+                "data_description": {
+                    "manual_feed_portions": "Padrão: definido pela unidade escolhida para a ração do animal ({uom})."
                 }
             },
             "account_settings": {
@@ -65,6 +75,13 @@
                 }
             }
         }
+    },
+    "common": {
+        "reloading_integration": "A integração está sendo recarregada",
+        "settings_updated": "Configurações atualizadas",
+        "no_settings_changed": "Nenhuma configuração foi alterada",
+        "sensors_updated": "Entidades de sensores atualizadas",
+        "account_updated": "Atualização de conta bem-sucedida"
     },
     "selector": {
         "member_gender": {
@@ -297,6 +314,9 @@
             },
             "display_icon": {
                 "name": "Ícone em exibição"
+            },
+            "manual_feed_quantity_cups": {
+                "name": "Quantidade de ração manual"
             }
         },
         "text": {

--- a/custom_components/petlibro/translations/pt.json
+++ b/custom_components/petlibro/translations/pt.json
@@ -25,6 +25,63 @@
             }
         }
     },
+    "options": {
+        "abort": {
+            "account_update_success": "Conta atualizada",
+            "account_update_nomember": "Dados do membro não carregados, verifique os registros",
+            "account_update_nochanges": "Nenhuma configuração foi alterada",
+            "account_update_nochanges_update_sensors": "Nenhuma configuração foi alterada\nEntidades de sensores atualizadas",
+            "error_check_logs": "Erro, verifique os registros"
+        },
+        "error": {
+            "unknown": "Erro inesperado"
+        },
+        "step": {
+            "init": {
+                "menu_options": {
+                    "account_settings": "Configurações da conta"
+                }
+            },
+            "account_settings": {
+                "title": "Configurações da conta",
+                "description": "Para a conta: {email}",
+                "data": {
+                    "nickname": "Apelido",
+                    "gender": "Gênero"
+                },
+                "sections": {
+                    "measurement_unit": {
+                        "name": "Unidades de medida",
+                        "data": {
+                            "feedUnitType": "Comedouro/Alimentação",
+                            "waterUnitType": "Fonte/Bebida",
+                            "weightUnitType": "Peso",
+                            "update_all_units": "Atualizar a unidade de medida de todas as entidades de sensores de unidade Petlibro"
+                        },
+                        "data_description": {
+                            "update_all_units": "Por padrão, alterar uma unidade aqui atualiza apenas as entidades de sensores desse tipo."
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "selector": {
+        "member_gender": {
+            "options": {
+                "male": "Masculino",
+                "female": "Feminino",
+                "none": "Prefiro não informar"
+            }
+        },
+        "pet_sex": {
+            "options": {
+                "male": "Macho",
+                "female": "Fêmea",
+                "none": "Nenhum selecionado"
+            }
+        }
+    },
     "entity": {
         "sensor": {
             "device_sn": {
@@ -48,8 +105,17 @@
             "electric_quantity": {
                 "name": "Bateria / CA %"
             },
-            "today_feeding_quantity": {
-                "name": "Quantidade de alimentação de hoje"
+            "today_feeding_quantity_weight": {
+                "name": "Quantidade de ração de hoje (Peso)"
+            },
+            "today_feeding_quantity_volume": {
+                "name": "Quantidade de ração de hoje (Volume)"
+            },
+            "last_feed_quantity_weight": {
+                "name": "Quantidade da última alimentação (Peso)"
+            },
+            "last_feed_quantity_volume": {
+                "name": "Quantidade da última alimentação (Volume)"
             },
             "today_feeding_times": {
                 "name": "Os tempos de alimentação de hoje"
@@ -70,6 +136,9 @@
                 "name": "Peso atual"
             },
             "weight_percent": {
+                "name": "Água restante (%)"
+            },
+            "remaining_water": {
                 "name": "Água restante"
             },
             "use_water_interval": {
@@ -214,6 +283,9 @@
             },
             "lid_close_time": {
                 "name": "Tampa de tempo fechado"
+            },
+            "manual_feed_quantity": {
+                "name": "Quantidade de ração manual"
             }
         },
         "select": {

--- a/custom_components/petlibro/translations/ru.json
+++ b/custom_components/petlibro/translations/ru.json
@@ -25,6 +25,63 @@
             }
         }
     },
+    "options": {
+        "abort": {
+            "account_update_success": "Аккаунт обновлен",
+            "account_update_nomember": "Данные участника не загружены, проверьте логи",
+            "account_update_nochanges": "Настройки не были изменены",
+            "account_update_nochanges_update_sensors": "Настройки не были изменены\nСущности датчиков обновлены",
+            "error_check_logs": "Ошибка, пожалуйста, проверьте логи"
+        },
+        "error": {
+            "unknown": "Неожиданная ошибка"
+        },
+        "step": {
+            "init": {
+                "menu_options": {
+                    "account_settings": "Настройки аккаунта"
+                }
+            },
+            "account_settings": {
+                "title": "Настройки аккаунта",
+                "description": "Для аккаунта: {email}",
+                "data": {
+                    "nickname": "Никнейм",
+                    "gender": "Пол"
+                },
+                "sections": {
+                    "measurement_unit": {
+                        "name": "Единицы измерения",
+                        "data": {
+                            "feedUnitType": "Кормушка/Кормление",
+                            "waterUnitType": "Фонтан/Питьё",
+                            "weightUnitType": "Вес",
+                            "update_all_units": "Обновить единицу измерения для всех сущностей датчиков Petlibro"
+                        },
+                        "data_description": {
+                            "update_all_units": "По умолчанию изменение единицы здесь обновляет только сущности датчиков этого типа."
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "selector": {
+        "member_gender": {
+            "options": {
+                "male": "Мужской",
+                "female": "Женский",
+                "none": "Не указывать"
+            }
+        },
+        "pet_sex": {
+            "options": {
+                "male": "Самец",
+                "female": "Самка",
+                "none": "Не выбрано"
+            }
+        }
+    },
     "entity": {
         "sensor": {
             "device_sn": {
@@ -48,8 +105,17 @@
             "electric_quantity": {
                 "name": "Батарея / AC %"
             },
-            "today_feeding_quantity": {
-                "name": "Сегодняшнее количество кормления"
+            "today_feeding_quantity_weight": {
+                "name": "Сегодняшнее количество корма (Вес)"
+            },
+            "today_feeding_quantity_volume": {
+                "name": "Сегодняшнее количество корма (Объем)"
+            },
+            "last_feed_quantity_weight": {
+                "name": "Последнее количество корма (Вес)"
+            },
+            "last_feed_quantity_volume": {
+                "name": "Последнее количество корма (Объем)"
             },
             "today_feeding_times": {
                 "name": "Сегодняшнее время кормления"
@@ -70,6 +136,9 @@
                 "name": "Текущий вес"
             },
             "weight_percent": {
+                "name": "Оставшаяся вода (%)"
+            },
+            "remaining_water": {
                 "name": "Оставшаяся вода"
             },
             "use_water_interval": {
@@ -214,6 +283,9 @@
             },
             "lid_close_time": {
                 "name": "Крышка близко время"
+            },
+            "manual_feed_quantity": {
+                "name": "Ручное количество корма"
             }
         },
         "select": {

--- a/custom_components/petlibro/translations/ru.json
+++ b/custom_components/petlibro/translations/ru.json
@@ -27,19 +27,29 @@
     },
     "options": {
         "abort": {
-            "account_update_success": "Аккаунт обновлен",
-            "account_update_nomember": "Данные участника не загружены, проверьте логи",
-            "account_update_nochanges": "Настройки не были изменены",
-            "account_update_nochanges_update_sensors": "Настройки не были изменены\nСущности датчиков обновлены",
+            "no_member_data": "Данные участника не загружены, проверьте логи",
+            "account_settings_abort": "{account_settings_abort}",
+            "integration_settings_abort": "{integration_settings_abort}",
+            "no_settings_changed": "Настройки не были изменены",
             "error_check_logs": "Ошибка, пожалуйста, проверьте логи"
         },
         "error": {
             "unknown": "Неожиданная ошибка"
         },
         "step": {
-            "init": {
+			"init": {
                 "menu_options": {
+                    "integration_settings": "Настройки интеграции",
                     "account_settings": "Настройки аккаунта"
+                }
+			},
+            "integration_settings": {
+                "title": "Настройки интеграции",
+                "data": {
+                    "manual_feed_portions": "Задать ручную подачу по порциям"
+                },
+                "data_description": {
+                    "manual_feed_portions": "По умолчанию: устанавливается согласно выбранной единице измерения корма ({uom})."
                 }
             },
             "account_settings": {
@@ -65,6 +75,13 @@
                 }
             }
         }
+    },
+    "common": {
+        "reloading_integration": "Интеграция перезагружается",
+        "settings_updated": "Настройки обновлены",
+        "no_settings_changed": "Настройки не были изменены",
+        "sensors_updated": "Сущности датчиков обновлены",
+        "account_updated": "Аккаунт успешно обновлен"
     },
     "selector": {
         "member_gender": {
@@ -297,6 +314,9 @@
             },
             "display_icon": {
                 "name": "Значок на дисплее"
+            },
+            "manual_feed_quantity_cups": {
+                "name": "Ручное количество корма"
             }
         },
         "text": {

--- a/custom_components/petlibro/translations/zh-cn.json
+++ b/custom_components/petlibro/translations/zh-cn.json
@@ -27,19 +27,29 @@
     },
     "options": {
         "abort": {
-            "account_update_success": "账户已更新",
-            "account_update_nomember": "未加载成员数据，请检查日志",
-            "account_update_nochanges": "未更改任何设置",
-            "account_update_nochanges_update_sensors": "未更改任何设置\n传感器实体已更新",
+            "no_member_data": "未加载成员数据，请检查日志",
+            "account_settings_abort": "{account_settings_abort}",
+            "integration_settings_abort": "{integration_settings_abort}",
+            "no_settings_changed": "未更改任何设置",
             "error_check_logs": "错误，请检查日志"
         },
         "error": {
             "unknown": "意外错误"
         },
         "step": {
-            "init": {
+			"init": {
                 "menu_options": {
+                    "integration_settings": "集成设置",
                     "account_settings": "账户设置"
+                }
+			},
+            "integration_settings": {
+                "title": "集成设置",
+                "data": {
+                    "manual_feed_portions": "按份量设置手动喂食量"
+                },
+                "data_description": {
+                    "manual_feed_portions": "默认：根据您选择的宠物饲料单位设置 ({uom})。"
                 }
             },
             "account_settings": {
@@ -65,6 +75,13 @@
                 }
             }
         }
+    },
+    "common": {
+        "reloading_integration": "正在重新加载集成",
+        "settings_updated": "设置已更新",
+        "no_settings_changed": "未更改任何设置",
+        "sensors_updated": "传感器实体已更新",
+        "account_updated": "账户更新成功"
     },
     "selector": {
         "member_gender": {
@@ -297,6 +314,9 @@
             },
             "display_icon": {
                 "name": "显示的图标"
+            },
+            "manual_feed_quantity_cups": {
+                "name": "手动喂食量"
             }
         },
         "text": {

--- a/custom_components/petlibro/translations/zh-cn.json
+++ b/custom_components/petlibro/translations/zh-cn.json
@@ -25,6 +25,63 @@
             }
         }
     },
+    "options": {
+        "abort": {
+            "account_update_success": "账户已更新",
+            "account_update_nomember": "未加载成员数据，请检查日志",
+            "account_update_nochanges": "未更改任何设置",
+            "account_update_nochanges_update_sensors": "未更改任何设置\n传感器实体已更新",
+            "error_check_logs": "错误，请检查日志"
+        },
+        "error": {
+            "unknown": "意外错误"
+        },
+        "step": {
+            "init": {
+                "menu_options": {
+                    "account_settings": "账户设置"
+                }
+            },
+            "account_settings": {
+                "title": "账户设置",
+                "description": "账户：{email}",
+                "data": {
+                    "nickname": "昵称",
+                    "gender": "性别"
+                },
+                "sections": {
+                    "measurement_unit": {
+                        "name": "计量单位",
+                        "data": {
+                            "feedUnitType": "喂食器/喂食",
+                            "waterUnitType": "饮水机/饮用",
+                            "weightUnitType": "重量",
+                            "update_all_units": "更新所有 Petlibro 单位传感器实体的计量单位"
+                        },
+                        "data_description": {
+                            "update_all_units": "默认情况下，在此更改单位只会更新该类型的传感器实体。"
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "selector": {
+        "member_gender": {
+            "options": {
+                "male": "男",
+                "female": "女",
+                "none": "不愿透露"
+            }
+        },
+        "pet_sex": {
+            "options": {
+                "male": "公",
+                "female": "母",
+                "none": "未选择"
+            }
+        }
+    },
     "entity": {
         "sensor": {
             "device_sn": {
@@ -48,8 +105,17 @@
             "electric_quantity": {
                 "name": "电池 / AC％"
             },
-            "today_feeding_quantity": {
-                "name": "今天的喂养数量"
+            "today_feeding_quantity_weight": {
+                "name": "今日喂食量（重量）"
+            },
+            "today_feeding_quantity_volume": {
+                "name": "今日喂食量（体积）"
+            },
+            "last_feed_quantity_weight": {
+                "name": "上次喂食量（重量）"
+            },
+            "last_feed_quantity_volume": {
+                "name": "上次喂食量（体积）"
             },
             "today_feeding_times": {
                 "name": "今天的喂养时间"
@@ -70,6 +136,9 @@
                 "name": "当前重量"
             },
             "weight_percent": {
+                "name": "剩余的水 (%)"
+            },
+            "remaining_water": {
                 "name": "剩余的水"
             },
             "use_water_interval": {
@@ -214,6 +283,9 @@
             },
             "lid_close_time": {
                 "name": "盖关闭时间"
+            },
+            "manual_feed_quantity": {
+                "name": "手动喂食量"
             }
         },
         "select": {


### PR DESCRIPTION
Apologies for the issues from the last PR. 🙏

## Proposed change:

Each sensor entity relating to pet feed now has a Volume entity and Weight entity. Separating them like this allows for long-term statistics. 
![Screenshot_1](https://github.com/user-attachments/assets/e1e88033-09dd-4ebf-b77f-848937bf40da)

When a user changes a unit of measurement in Account Settings, the relevant entities will update to reflect their choice. Note that 'cups' are not supported in Home Assistant .
The user can also choose "Update measurement unit of all Petlibro sensor entities" to update the measurement unit of _all_ of their feed, weight and water entities regardless of what units are or aren't changed. This can be useful if the user changes a measurement unit outside of Home Assistant (like in the app).
![Screenshot_20](https://github.com/user-attachments/assets/ff3c6bf0-641f-4b85-a55c-418aaa65bbd2)

These entities also have the values for the 4 Petlibro feed unit options plus a "portion" unit (API "grain") in the extra attributes.
![Screenshot_11](https://github.com/user-attachments/assets/ad873ad6-16e1-4ee7-8443-8bfa70018361)

The Manual Feed Quantity number entities will use the feed unit chosen by the user in their settings. 
![Screenshot_7](https://github.com/user-attachments/assets/2b802f34-a064-43e8-902c-7ebd07f4d58d)

If the user has their feed unit set to cups, the Manual Feed Quantity entity will be a Select (dropdown) instead.
![Screenshot_5](https://github.com/user-attachments/assets/ec84a98f-3d48-4c72-a28f-a8a43fa39133)

Also added an option to switch the Manual Feed Quantity entity to use 'portions' instead of the measurement unit.
![Screenshot_1](https://github.com/user-attachments/assets/ef887e7e-4754-465b-ac7b-a70c5995e657)
![Screenshot_2](https://github.com/user-attachments/assets/bd1fff53-0caa-4005-aa9d-c203ac459210)
![Screenshot_4](https://github.com/user-attachments/assets/cbddd6c6-58f5-4ae5-bfe5-3dfee78dea5c)

Replaced "Current Weight" with "Remaining Water" for fountains. Slightly renamed the percentage entity from "Remaining Water" to "Remaining Water (%)" and changed the icon from "mdi:water" to "mdi:water-percent"
![Screenshot_8](https://github.com/user-attachments/assets/42547a05-9aae-4dd8-a56e-39848aaeafc4)

Closes #141 #133 #131 #8  (issue)

## Type of change:

- [ ] New device.
- [x] Bug fix (non-breaking change which fixes an issue).
- [x] New feature or enhancement (non-breaking change which adds functionality).
- [ ] Documentation only.
- [ ] Other (please explain).

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature / enhancement](https://github.com/jjjonesjr33/petlibro/wiki/Feature-&-Enhancement-Guidelines) guidlines before submitting my request.
- [x] If applicable, I have tested my code for new features & regressions on the latest version of Home Assistant.

## Additional notes:
