### PR TITLE
Hotfix / Disabled feeding schedule preventing hub refresh

### DIFF
--- a/custom_components/petlibro/devices/feeders/air_smart_feeder.py
+++ b/custom_components/petlibro/devices/feeders/air_smart_feeder.py
@@ -31,8 +31,9 @@ class AirSmartFeeder(Device):  # Inherit directly from Device
             get_upgrade = await self.api.get_device_upgrade(self.serial)
             attribute_settings = await self.api.device_attribute_settings(self.serial)
             get_feeding_plan_today = await self.api.device_feeding_plan_today_new(self.serial)
-            feeding_plan_list = await self.api.device_feeding_plan_list(self.serial)
             get_work_record = await self.api.get_device_work_record(self.serial)
+            feeding_plan_list = (await self.api.device_feeding_plan_list(self.serial)
+                if self._data.get("enableFeedingPlan") else [])
     
             # Update internal data with fetched API data
             self.update_data({

--- a/custom_components/petlibro/devices/feeders/granary_smart_camera_feeder.py
+++ b/custom_components/petlibro/devices/feeders/granary_smart_camera_feeder.py
@@ -28,8 +28,9 @@ class GranarySmartCameraFeeder(Device):  # Inherit directly from Device
             attribute_settings = await self.api.device_attribute_settings(self.serial)
             get_upgrade = await self.api.get_device_upgrade(self.serial)
             get_feeding_plan_today = await self.api.device_feeding_plan_today_new(self.serial)
-            feeding_plan_list = await self.api.device_feeding_plan_list(self.serial)
             get_work_record = await self.api.get_device_work_record(self.serial)
+            feeding_plan_list = (await self.api.device_feeding_plan_list(self.serial)
+                if self._data.get("enableFeedingPlan") else [])
     
             # Update internal data with fetched API data
             self.update_data({

--- a/custom_components/petlibro/devices/feeders/granary_smart_feeder.py
+++ b/custom_components/petlibro/devices/feeders/granary_smart_feeder.py
@@ -30,7 +30,8 @@ class GranarySmartFeeder(Device):  # Inherit directly from Device
             get_work_record = await self.api.get_device_work_record(self.serial)
             get_default_matrix = await self.api.get_default_matrix(self.serial)
             get_feeding_plan_today = await self.api.device_feeding_plan_today_new(self.serial)
-            feeding_plan_list = await self.api.device_feeding_plan_list(self.serial)
+            feeding_plan_list = (await self.api.device_feeding_plan_list(self.serial)
+                if self._data.get("enableFeedingPlan") else [])
 
             # Update internal data with fetched API data
             self.update_data({

--- a/custom_components/petlibro/devices/feeders/one_rfid_smart_feeder.py
+++ b/custom_components/petlibro/devices/feeders/one_rfid_smart_feeder.py
@@ -32,7 +32,8 @@ class OneRFIDSmartFeeder(Device):
             get_default_matrix = await self.api.get_default_matrix(self.serial)
             get_work_record = await self.api.get_device_work_record(self.serial)
             get_feeding_plan_today = await self.api.device_feeding_plan_today_new(self.serial)
-            feeding_plan_list = await self.api.device_feeding_plan_list(self.serial)
+            feeding_plan_list = (await self.api.device_feeding_plan_list(self.serial)
+                if self._data.get("enableFeedingPlan") else [])
     
             # Update internal data with fetched API data
             self.update_data({

--- a/custom_components/petlibro/devices/feeders/space_smart_feeder.py
+++ b/custom_components/petlibro/devices/feeders/space_smart_feeder.py
@@ -28,9 +28,10 @@ class SpaceSmartFeeder(Device):  # Inherit directly from Device
             attribute_settings = await self.api.device_attribute_settings(self.serial)
             get_upgrade = await self.api.get_device_upgrade(self.serial)
             get_feeding_plan_today = await self.api.device_feeding_plan_today_new(self.serial)
-            feeding_plan_list = await self.api.device_feeding_plan_list(self.serial)
             get_work_record = await self.api.get_device_work_record(self.serial)
             get_device_events = await self.api.device_events(self.serial)
+            feeding_plan_list = (await self.api.device_feeding_plan_list(self.serial)
+                if self._data.get("enableFeedingPlan") else [])
     
             # Update internal data with fetched API data
             self.update_data({


### PR DESCRIPTION
## Proposed change:
The change checks if the feeding plan is enabled before making the `/device/feedingPlan/list` API call.
Disabled feeding plans were causing API error code `1218` `DEVICE_FEEDING_PLAN_NOT_AVAILABLE`, preventing hub refreshes.

Closes #169  (issue)

## Type of change:

- [ ] New device.
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature or enhancement (non-breaking change which adds functionality).
- [ ] Documentation only.
- [ ] Other (please explain).

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature / enhancement](https://github.com/jjjonesjr33/petlibro/wiki/Feature-&-Enhancement-Guidelines) guidlines before submitting my request.
- [x] If applicable, I have tested my code for new features & regressions on the latest version of Home Assistant.

## Additional notes:
