### PR TITLE
Update Volume and Weight Sensors #173

### DIFF
--- a/custom_components/petlibro/sensor.py
+++ b/custom_components/petlibro/sensor.py
@@ -257,16 +257,23 @@ class PetLibroSensorEntity(PetLibroEntity[_DeviceT], SensorEntity):
                     }
             case key if key in (
                 "today_feeding_quantity_weight",
-                "today_feeding_quantity_volume",
-                "last_feed_quantity_weight",
-                "last_feed_quantity_volume",
+                "last_feed_quantity_weight", 
                 "next_feed_quantity_weight",
+            ):
+                portion = getattr(self.device, key.removesuffix("_weight"), 0)
+                return {
+                    unit.symbol: Unit.convert_feed(portion * self.device.feed_conv_factor, None, unit, True)
+                    for unit in (Unit.GRAMS, Unit.OUNCES)
+                }
+            case key if key in (
+                "today_feeding_quantity_volume",
+                "last_feed_quantity_volume",
                 "next_feed_quantity_volume"
             ):
-                portion = getattr(self.device, key.removesuffix(f"_{self.device_class}"), 0)
-                return {"portion": portion} | {
+                portion = getattr(self.device, key.removesuffix("_volume"), 0)
+                return {
                     unit.symbol: Unit.convert_feed(portion * self.device.feed_conv_factor, None, unit, True)
-                    for unit in VALID_UNIT_TYPES[API.FEED_UNIT] if unit
+                    for unit in (Unit.CUPS, Unit.MILLILITERS)
                 }
             case key if key in (
                 "remaining_water", 


### PR DESCRIPTION
<!--
Before opening this pull request please review the guidelines in the checklist below. If this PR does not meet those guidelines it will not be accepted, and everyone will be sad.

Please include a summary of the change. Screenshots and/or videos can also be helpful if appropriate. New devices or enhancements should include example(s) of relevant information.
-->
## Proposed change:

Removed `Portion`, `Cups` and `Milliliters` from the extra state attributes of:
`Today's Feeding Quantity (Weight)`
`Next Feed Quantity (Weight)`
`Last Feed Quantity (Weight)`

Removed `Portion`, `Ounces` and `Grams` from the extra state attributes of:
`Today's Feeding Quantity (Volume)`
`Next Feed Quantity (Volume)`
`Last Feed Quantity (Volume)`

Aligns with Volume and Weight metrics per sensor.

![Screenshot_11](https://github.com/user-attachments/assets/8a8f87f1-19b9-4f5b-9279-1862a6481ee7)
![Screenshot_12](https://github.com/user-attachments/assets/ef1d6294-609f-4069-a25e-aed0d1ab3409)


Closes #173  (issue)

## Type of change:

- [ ] New device.
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature or enhancement (non-breaking change which adds functionality).
- [ ] Documentation only.
- [ ] Other (please explain).

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature / enhancement](https://github.com/jjjonesjr33/petlibro/wiki/Feature-&-Enhancement-Guidelines) guidlines before submitting my request.
- [x] If applicable, I have tested my code for new features & regressions on the latest version of Home Assistant.

## Additional notes:
