### PR TITLE
Hotfix/Safeguards for device number properties

### DIFF
--- a/custom_components/petlibro/devices/feeders/air_smart_feeder.py
+++ b/custom_components/petlibro/devices/feeders/air_smart_feeder.py
@@ -58,12 +58,14 @@ class AirSmartFeeder(Device):  # Inherit directly from Device
         return self._data.get("grainStatus", {}).get("todayFeedingQuantities", [])
 
     @property
-    def today_feeding_quantity(self) -> int:
-        return self._data.get("grainStatus", {}).get("todayFeedingQuantity", 0)
+    def today_feeding_quantity(self) -> float:
+        quantity = self._data.get("grainStatus", {}).get("todayFeedingQuantity")
+        return quantity if isinstance(quantity, (int, float)) else 0
 
     @property
     def today_feeding_times(self) -> int:
-        return self._data.get("grainStatus", {}).get("todayFeedingTimes", 0)
+        times = self._data.get("grainStatus", {}).get("todayFeedingTimes")
+        return times if isinstance(times, int) else 0
 
     @property
     def feeding_plan_state(self) -> bool:
@@ -135,11 +137,13 @@ class AirSmartFeeder(Device):  # Inherit directly from Device
 
     @property
     def wifi_rssi(self) -> int:
-        return self._data.get("realInfo", {}).get("wifiRssi", -100)
+        wifi_rssi = self._data.get("realInfo", {}).get("wifiRssi")
+        return wifi_rssi if isinstance(wifi_rssi, int) else -100
 
     @property
-    def electric_quantity(self) -> int:
-        return self._data.get("realInfo", {}).get("electricQuantity", 0)
+    def electric_quantity(self) -> float:
+        quantity = self._data.get("realInfo", {}).get("electricQuantity")
+        return quantity if isinstance(quantity, (float, int)) else 0
 
     @property
     def enable_feeding_plan(self) -> bool:
@@ -180,7 +184,8 @@ class AirSmartFeeder(Device):  # Inherit directly from Device
 
     @property
     def close_door_time_sec(self) -> int:
-        return self._data.get("realInfo", {}).get("closeDoorTimeSec", 0)
+        time_sec = self._data.get("realInfo", {}).get("closeDoorTimeSec")
+        return time_sec if isinstance(time_sec, int) else 0
 
     @property
     def screen_display_switch(self) -> bool:
@@ -217,7 +222,7 @@ class AirSmartFeeder(Device):  # Inherit directly from Device
         return None
 
     @property
-    def last_feed_quantity(self) -> int | None:
+    def last_feed_quantity(self) -> int:
         """Return the last feed amount."""
         raw = self._data.get("workRecord", [])
         if raw and isinstance(raw, list):
@@ -225,7 +230,8 @@ class AirSmartFeeder(Device):  # Inherit directly from Device
                 for record in day_entry.get("workRecords", []):
                     _LOGGER.debug("Evaluating record type: %s", record.get("type"))
                     if record.get("type") == "GRAIN_OUTPUT_SUCCESS":
-                        return record.get("actualGrainNum") or 0
+                        actualGrainNum = record.get("actualGrainNum")
+                        return actualGrainNum if isinstance(actualGrainNum, int) else 0
         return 0
 
     @property
@@ -303,13 +309,14 @@ class AirSmartFeeder(Device):  # Inherit directly from Device
         return None
 
     @property
-    def next_feed_quantity(self) -> int | None:
+    def next_feed_quantity(self) -> int:
         """Return the next scheduled feed amount."""
         next_feed = self.get_next_feed.copy()
         if next_feed and (plan_id := next_feed.get("id")):
             feeding_plan = self.feeding_plan_data.get(str(plan_id), {})
             if feeding_plan:
-                return feeding_plan.get("grainNum", 0)
+                grainNum = feeding_plan.get("grainNum")
+                return grainNum if isinstance(grainNum, int) else 0
         return 0
 
     @property

--- a/custom_components/petlibro/devices/feeders/granary_smart_camera_feeder.py
+++ b/custom_components/petlibro/devices/feeders/granary_smart_camera_feeder.py
@@ -55,12 +55,14 @@ class GranarySmartCameraFeeder(Device):  # Inherit directly from Device
         return self._data.get("grainStatus", {}).get("todayFeedingQuantities", [])
 
     @property
-    def today_feeding_quantity(self) -> int:
-        return self._data.get("grainStatus", {}).get("todayFeedingQuantity", 0)
+    def today_feeding_quantity(self) -> float:
+        quantity = self._data.get("grainStatus", {}).get("todayFeedingQuantity")
+        return quantity if isinstance(quantity, (int, float)) else 0
 
     @property
     def today_feeding_times(self) -> int:
-        return self._data.get("grainStatus", {}).get("todayFeedingTimes", 0)
+        times = self._data.get("grainStatus", {}).get("todayFeedingTimes")
+        return times if isinstance(times, int) else 0
 
     @property
     def feeding_plan_state(self) -> bool:
@@ -132,11 +134,13 @@ class GranarySmartCameraFeeder(Device):  # Inherit directly from Device
 
     @property
     def wifi_rssi(self) -> int:
-        return self._data.get("realInfo", {}).get("wifiRssi", -100)
+        wifi_rssi = self._data.get("realInfo", {}).get("wifiRssi")
+        return wifi_rssi if isinstance(wifi_rssi, int) else -100
 
     @property
-    def electric_quantity(self) -> int:
-        return self._data.get("realInfo", {}).get("electricQuantity", 0)
+    def electric_quantity(self) -> float:
+        quantity = self._data.get("realInfo", {}).get("electricQuantity")
+        return quantity if isinstance(quantity, (float, int)) else 0
 
     @property
     def enable_feeding_plan(self) -> bool:
@@ -177,7 +181,8 @@ class GranarySmartCameraFeeder(Device):  # Inherit directly from Device
 
     @property
     def close_door_time_sec(self) -> int:
-        return self._data.get("realInfo", {}).get("closeDoorTimeSec", 0)
+        time_sec = self._data.get("realInfo", {}).get("closeDoorTimeSec")
+        return time_sec if isinstance(time_sec, int) else 0
 
     @property
     def screen_display_switch(self) -> bool:
@@ -239,7 +244,7 @@ class GranarySmartCameraFeeder(Device):  # Inherit directly from Device
         return None
 
     @property
-    def last_feed_quantity(self) -> int | None:
+    def last_feed_quantity(self) -> int:
         """Return the last feed amount."""
         raw = self._data.get("workRecord", [])
         if raw and isinstance(raw, list):
@@ -247,7 +252,8 @@ class GranarySmartCameraFeeder(Device):  # Inherit directly from Device
                 for record in day_entry.get("workRecords", []):
                     _LOGGER.debug("Evaluating record type: %s", record.get("type"))
                     if record.get("type") == "GRAIN_OUTPUT_SUCCESS":
-                        return record.get("actualGrainNum") or 0
+                        actualGrainNum = record.get("actualGrainNum")
+                        return actualGrainNum if isinstance(actualGrainNum, int) else 0
         return 0
 
     @property
@@ -325,13 +331,14 @@ class GranarySmartCameraFeeder(Device):  # Inherit directly from Device
         return None
 
     @property
-    def next_feed_quantity(self) -> int | None:
+    def next_feed_quantity(self) -> int:
         """Return the next scheduled feed amount."""
         next_feed = self.get_next_feed.copy()
         if next_feed and (plan_id := next_feed.get("id")):
             feeding_plan = self.feeding_plan_data.get(str(plan_id), {})
             if feeding_plan:
-                return feeding_plan.get("grainNum", 0)
+                grainNum = feeding_plan.get("grainNum")
+                return grainNum if isinstance(grainNum, int) else 0
         return 0
 
     @property

--- a/custom_components/petlibro/devices/feeders/granary_smart_feeder.py
+++ b/custom_components/petlibro/devices/feeders/granary_smart_feeder.py
@@ -57,12 +57,14 @@ class GranarySmartFeeder(Device):  # Inherit directly from Device
         return self._data.get("grainStatus", {}).get("todayFeedingQuantities", [])
 
     @property
-    def today_feeding_quantity(self) -> int:
-        return self._data.get("grainStatus", {}).get("todayFeedingQuantity", 0)
+    def today_feeding_quantity(self) -> float:
+        quantity = self._data.get("grainStatus", {}).get("todayFeedingQuantity")
+        return quantity if isinstance(quantity, (int, float)) else 0
 
     @property
     def today_feeding_times(self) -> int:
-        return self._data.get("grainStatus", {}).get("todayFeedingTimes", 0)
+        times = self._data.get("grainStatus", {}).get("todayFeedingTimes")
+        return times if isinstance(times, (int)) else 0
 
     @property
     def feeding_plan_state(self) -> bool:
@@ -134,11 +136,13 @@ class GranarySmartFeeder(Device):  # Inherit directly from Device
 
     @property
     def wifi_rssi(self) -> int:
-        return self._data.get("realInfo", {}).get("wifiRssi", -100)
+        wifi_rssi = self._data.get("realInfo", {}).get("wifiRssi")
+        return wifi_rssi if isinstance(wifi_rssi, int) else -100
 
     @property
-    def electric_quantity(self) -> int:
-        return self._data.get("realInfo", {}).get("electricQuantity", 0)
+    def electric_quantity(self) -> float:
+        quantity = self._data.get("realInfo", {}).get("electricQuantity")
+        return quantity if isinstance(quantity, (float, int)) else 0
 
     @property
     def enable_feeding_plan(self) -> bool:
@@ -179,7 +183,8 @@ class GranarySmartFeeder(Device):  # Inherit directly from Device
 
     @property
     def close_door_time_sec(self) -> int:
-        return self._data.get("realInfo", {}).get("closeDoorTimeSec", 0)
+        time_sec = self._data.get("realInfo", {}).get("closeDoorTimeSec")
+        return time_sec if isinstance(time_sec, int) else 0
 
     @property
     def screen_display_switch(self) -> bool:
@@ -215,7 +220,7 @@ class GranarySmartFeeder(Device):  # Inherit directly from Device
         return None
 
     @property
-    def last_feed_quantity(self) -> int | None:
+    def last_feed_quantity(self) -> int:
         """Return the last feed amount."""
         raw = self._data.get("workRecord", [])
         if raw and isinstance(raw, list):
@@ -223,7 +228,8 @@ class GranarySmartFeeder(Device):  # Inherit directly from Device
                 for record in day_entry.get("workRecords", []):
                     _LOGGER.debug("Evaluating record type: %s", record.get("type"))
                     if record.get("type") == "GRAIN_OUTPUT_SUCCESS":
-                        return record.get("actualGrainNum") or 0
+                        actualGrainNum = record.get("actualGrainNum")
+                        return actualGrainNum if isinstance(actualGrainNum, int) else 0
         return 0
 
     @property
@@ -301,13 +307,14 @@ class GranarySmartFeeder(Device):  # Inherit directly from Device
         return None
 
     @property
-    def next_feed_quantity(self) -> int | None:
+    def next_feed_quantity(self) -> int:
         """Return the next scheduled feed amount."""
         next_feed = self.get_next_feed.copy()
         if next_feed and (plan_id := next_feed.get("id")):
             feeding_plan = self.feeding_plan_data.get(str(plan_id), {})
             if feeding_plan:
-                return feeding_plan.get("grainNum", 0)
+                grainNum = feeding_plan.get("grainNum")
+                return grainNum if isinstance(grainNum, int) else 0
         return 0
 
     @property
@@ -319,7 +326,8 @@ class GranarySmartFeeder(Device):  # Inherit directly from Device
 
     @property
     def desiccant_frequency(self) -> float:
-        return self._data.get("realInfo", {}).get("changeDesiccantFrequency", 0)
+        frequency = self._data.get("realInfo", {}).get("changeDesiccantFrequency")
+        return frequency if isinstance(frequency, (float, int)) else 0
 
     # Error-handling updated for set_feeding_plan
     async def set_feeding_plan(self, value: bool) -> None:

--- a/custom_components/petlibro/devices/feeders/one_rfid_smart_feeder.py
+++ b/custom_components/petlibro/devices/feeders/one_rfid_smart_feeder.py
@@ -59,12 +59,14 @@ class OneRFIDSmartFeeder(Device):
         return self._data.get("grainStatus", {}).get("todayFeedingQuantities", [])
 
     @property
-    def today_feeding_quantity(self) -> int:
-        return self._data.get("grainStatus", {}).get("todayFeedingQuantity", 0)
+    def today_feeding_quantity(self) -> float:
+        quantity = self._data.get("grainStatus", {}).get("todayFeedingQuantity")
+        return quantity if isinstance(quantity, (int, float)) else 0
 
     @property
     def today_feeding_times(self) -> int:
-        return self._data.get("grainStatus", {}).get("todayFeedingTimes", 0)
+        times = self._data.get("grainStatus", {}).get("todayFeedingTimes")
+        return times if isinstance(times, int) else 0
 
     @property
     def today_eating_times(self) -> int:
@@ -152,11 +154,13 @@ class OneRFIDSmartFeeder(Device):
 
     @property
     def wifi_rssi(self) -> int:
-        return self._data.get("realInfo", {}).get("wifiRssi", -100)
+        wifi_rssi = self._data.get("realInfo", {}).get("wifiRssi")
+        return wifi_rssi if isinstance(wifi_rssi, int) else -100
 
     @property
-    def electric_quantity(self) -> int:
-        return self._data.get("realInfo", {}).get("electricQuantity", 0)
+    def electric_quantity(self) -> float:
+        quantity = self._data.get("realInfo", {}).get("electricQuantity")
+        return quantity if isinstance(quantity, (float, int)) else 0
 
     @property
     def enable_feeding_plan(self) -> bool:
@@ -197,7 +201,8 @@ class OneRFIDSmartFeeder(Device):
 
     @property
     def close_door_time_sec(self) -> int:
-        return self._data.get("realInfo", {}).get("closeDoorTimeSec", 0)
+        time_sec = self._data.get("realInfo", {}).get("closeDoorTimeSec")
+        return time_sec if isinstance(time_sec, int) else 0
 
     @property
     def display_switch(self) -> bool:
@@ -242,7 +247,7 @@ class OneRFIDSmartFeeder(Device):
         return None
 
     @property
-    def last_feed_quantity(self) -> int | None:
+    def last_feed_quantity(self) -> int:
         """Return the last feed amount."""
         raw = self._data.get("workRecord", [])
         if raw and isinstance(raw, list):
@@ -250,7 +255,8 @@ class OneRFIDSmartFeeder(Device):
                 for record in day_entry.get("workRecords", []):
                     _LOGGER.debug("Evaluating record type: %s", record.get("type"))
                     if record.get("type") == "GRAIN_OUTPUT_SUCCESS":
-                        return record.get("actualGrainNum") or 0
+                        actualGrainNum = record.get("actualGrainNum")
+                        return actualGrainNum if isinstance(actualGrainNum, int) else 0
         return 0
 
     @property
@@ -327,13 +333,14 @@ class OneRFIDSmartFeeder(Device):
         return None
 
     @property
-    def next_feed_quantity(self) -> int | None:
+    def next_feed_quantity(self) -> int:
         """Return the next scheduled feed amount."""
         next_feed = self.get_next_feed.copy()
         if next_feed and (plan_id := next_feed.get("id")):
             feeding_plan = self.feeding_plan_data.get(str(plan_id), {})
             if feeding_plan:
-                return feeding_plan.get("grainNum", 0)
+                grainNum = feeding_plan.get("grainNum")
+                return grainNum if isinstance(grainNum, int) else 0
         return 0
 
     @property

--- a/custom_components/petlibro/devices/feeders/polar_wet_food_feeder.py
+++ b/custom_components/petlibro/devices/feeders/polar_wet_food_feeder.py
@@ -67,9 +67,10 @@ class PolarWetFoodFeeder(Device):
         return bool(self._data.get("realInfo", {}).get("barnDoorError", False))
 
     @property
-    def electric_quantity(self) -> int:
+    def electric_quantity(self) -> float:
         """Electric quantity (battery percentage or power state)."""
-        return self._data.get("electricQuantity", 0)
+        quantity = self._data.get("electricQuantity")
+        return quantity if isinstance(quantity, (float, int)) else 0
 
     @property
     def feeding_plan_state(self) -> bool:
@@ -162,7 +163,8 @@ class PolarWetFoodFeeder(Device):
     
     @property
     def wifi_rssi(self) -> int:
-        return self._data.get("wifiRssi", -100)  # WiFi signal strength
+        wifi_rssi = self._data.get("wifiRssi")
+        return wifi_rssi if isinstance(wifi_rssi, int) else -100  # WiFi signal strength
 
     @property
     def wifi_ssid(self) -> str:

--- a/custom_components/petlibro/devices/feeders/space_smart_feeder.py
+++ b/custom_components/petlibro/devices/feeders/space_smart_feeder.py
@@ -57,12 +57,14 @@ class SpaceSmartFeeder(Device):  # Inherit directly from Device
         return self._data.get("grainStatus", {}).get("todayFeedingQuantities", [])
 
     @property
-    def today_feeding_quantity(self) -> int:
-        return self._data.get("grainStatus", {}).get("todayFeedingQuantity", 0)
+    def today_feeding_quantity(self) -> float:
+        quantity = self._data.get("grainStatus", {}).get("todayFeedingQuantity")
+        return quantity if isinstance(quantity, (int, float)) else 0
 
     @property
     def today_feeding_times(self) -> int:
-        return self._data.get("grainStatus", {}).get("todayFeedingTimes", 0)
+        times = self._data.get("grainStatus", {}).get("todayFeedingTimes")
+        return times if isinstance(times, int) else 0
 
     @property
     def feeding_plan_state(self) -> bool:
@@ -130,11 +132,13 @@ class SpaceSmartFeeder(Device):  # Inherit directly from Device
 
     @property
     def wifi_rssi(self) -> int:
-        return self._data.get("realInfo", {}).get("wifiRssi", -100)
+        wifi_rssi = self._data.get("realInfo", {}).get("wifiRssi")
+        return wifi_rssi if isinstance(wifi_rssi, int) else -100
 
     @property
-    def electric_quantity(self) -> int:
-        return self._data.get("realInfo", {}).get("electricQuantity", 0)
+    def electric_quantity(self) -> float:
+        quantity = self._data.get("realInfo", {}).get("electricQuantity")
+        return quantity if isinstance(quantity, (float, int)) else 0
 
     @property
     def enable_feeding_plan(self) -> bool:
@@ -171,7 +175,8 @@ class SpaceSmartFeeder(Device):  # Inherit directly from Device
 
     @property
     def close_door_time_sec(self) -> int:
-        return self._data.get("realInfo", {}).get("closeDoorTimeSec", 0)
+        time_sec = self._data.get("realInfo", {}).get("closeDoorTimeSec")
+        return time_sec if isinstance(time_sec, int) else 0
 
     @property
     def screen_display_switch(self) -> bool:
@@ -227,7 +232,7 @@ class SpaceSmartFeeder(Device):  # Inherit directly from Device
         return None
 
     @property
-    def last_feed_quantity(self) -> int | None:
+    def last_feed_quantity(self) -> int:
         """Return the last feed amount in raw grain count."""
         raw = self._data.get("workRecord", [])
         if not raw or not isinstance(raw, list):
@@ -237,7 +242,8 @@ class SpaceSmartFeeder(Device):  # Inherit directly from Device
             for record in day_entry.get("workRecords", []):
                 _LOGGER.debug("Evaluating record type: %s", record.get("type"))
                 if record.get("type") == "GRAIN_OUTPUT_SUCCESS":
-                    return record.get("actualGrainNum") or 0
+                    actualGrainNum = record.get("actualGrainNum")
+                    return actualGrainNum if isinstance(actualGrainNum, int) else 0
         return 0
 
     @property
@@ -315,13 +321,14 @@ class SpaceSmartFeeder(Device):  # Inherit directly from Device
         return None
 
     @property
-    def next_feed_quantity(self) -> int | None:
+    def next_feed_quantity(self) -> int:
         """Return the next scheduled feed amount."""
         next_feed = self.get_next_feed.copy()
         if next_feed and (plan_id := next_feed.get("id")):
             feeding_plan = self.feeding_plan_data.get(str(plan_id), {})
             if feeding_plan:
-                return feeding_plan.get("grainNum", 0)
+                grainNum = feeding_plan.get("grainNum")
+                return grainNum if isinstance(grainNum, int) else 0
         return 0
 
     @property

--- a/custom_components/petlibro/devices/fountains/dockstream_2_smart_cordless_fountain.py
+++ b/custom_components/petlibro/devices/fountains/dockstream_2_smart_cordless_fountain.py
@@ -63,17 +63,20 @@ class Dockstream2SmartCordlessFountain(Device):
     @property
     def wifi_rssi(self) -> int:
         """Get the Wi-Fi signal strength."""
-        return self._data.get("realInfo", {}).get("wifiRssi", -100)
+        wifi_rssi = self._data.get("realInfo", {}).get("wifiRssi")
+        return wifi_rssi if isinstance(wifi_rssi, int) else -100
     
     @property
     def weight(self) -> float:
         """Get the current weight of the water (in grams)."""
-        return self._data.get("realInfo", {}).get("weight", 0.0)
+        weight = self._data.get("realInfo", {}).get("weight")
+        return weight if isinstance(weight, (int, float)) else 0
     
     @property
-    def weight_percent(self) -> int:
+    def weight_percent(self) -> int | float:
         """Get the current weight percentage of water."""
-        return self._data.get("realInfo", {}).get("weightPercent", 0)
+        weight_percent = self._data.get("realInfo", {}).get("weightPercent")
+        return weight_percent if isinstance(weight_percent, (int, float)) else 0
     
     @property
     def remaining_filter_days(self) -> int:
@@ -112,10 +115,12 @@ class Dockstream2SmartCordlessFountain(Device):
 
     @property
     def water_interval(self) -> float:
-        return self._data.get("realInfo", {}).get("useWaterInterval", 0)
+        water_interval = self._data.get("realInfo", {}).get("useWaterInterval")
+        return water_interval if isinstance(water_interval, (int, float)) else 0
     @property
     def water_dispensing_duration(self) -> float:
-        return self._data.get("realInfo", {}).get("useWaterDuration", 0)
+        duration = self._data.get("realInfo", {}).get("useWaterDuration")
+        return duration if isinstance(duration, (int, float)) else 0
 
     @property
     def water_state(self) -> bool:
@@ -174,7 +179,8 @@ class Dockstream2SmartCordlessFountain(Device):
 
     @property
     def water_low_threshold(self) -> float:
-        return self._data.get("dataRealInfo", {}).get("lowWater", 0)
+        threshold = self._data.get("dataRealInfo", {}).get("lowWater")
+        return threshold if isinstance(threshold, (int, float)) else 0
 
     async def set_water_low_threshold(self, value: float) -> None:
         _LOGGER.debug(f"Setting water low threshold to {value} for {self.serial}")
@@ -187,7 +193,8 @@ class Dockstream2SmartCordlessFountain(Device):
 
     @property
     def cleaning_cycle(self) -> float:
-        return self._data.get("realInfo", {}).get("machineCleaningFrequency", 0)
+        cleaning_cycle = self._data.get("realInfo", {}).get("machineCleaningFrequency")
+        return cleaning_cycle if isinstance(cleaning_cycle, (int, float)) else 0
 
     async def set_cleaning_cycle(self, value: float) -> None:
         _LOGGER.debug(f"Setting machine cleaning cycle to {value} for {self.serial}")
@@ -201,7 +208,8 @@ class Dockstream2SmartCordlessFountain(Device):
 
     @property
     def filter_cycle(self) -> float:
-        return self._data.get("realInfo", {}).get("filterReplacementFrequency", 0)
+        filter_cycle = self._data.get("realInfo", {}).get("filterReplacementFrequency")
+        return filter_cycle if isinstance(filter_cycle, (int, float)) else 0
 
     async def set_filter_cycle(self, value: float) -> None:
         _LOGGER.debug(f"Setting filter cycle to {value} for {self.serial}")
@@ -264,44 +272,52 @@ class Dockstream2SmartCordlessFountain(Device):
         return self._data.get("realInfo", {}).get("electricQuantity", 0)
 
     @property
-    def today_drinking_amount(self) -> int:
+    def today_drinking_amount(self) -> float:
         """Get the total milliliters of water used today."""
-        return self._data.get("getDrinkWater", {}).get("todayTotalMl", 0)
+        amount = self._data.get("getDrinkWater", {}).get("todayTotalMl")
+        return amount if isinstance(amount, (int, float)) else 0
     
     @property
     def today_drinking_count(self) -> int:
         """Get the total count of times drank today."""
-        return self._data.get("getDrinkWater", {}).get("todayTotalTimes", 0)
+        drinking_count = self._data.get("getDrinkWater", {}).get("todayTotalTimes")
+        return drinking_count if isinstance(drinking_count, int) else 0
 
     @property
     def today_drinking_time(self) -> int:
         """Get the total time spent drinking today."""
-        return self._data.get("getDrinkWater", {}).get("petEatingTime", 0)
+        drinking_time = self._data.get("getDrinkWater", {}).get("petEatingTime")
+        return drinking_time if isinstance(drinking_time, int) else 0
 
     @property
     def today_avg_time(self) -> int:
         """Get the average time spent drinking in a session today."""
-        return self._data.get("getDrinkWater", {}).get("avgDrinkDuration", 0)
+        avg_time = self._data.get("getDrinkWater", {}).get("avgDrinkDuration")
+        return avg_time if isinstance(avg_time, int) else 0
 
     @property
-    def yesterday_drinking_amount(self) -> int:
+    def yesterday_drinking_amount(self) -> float:
         """Get the total milliliters of water used yesterday."""
-        return self._data.get("getDrinkWater", {}).get("yesterdayTotalMl", 0)
+        amount = self._data.get("getDrinkWater", {}).get("yesterdayTotalMl")
+        return amount if isinstance(amount, (int, float)) else 0
     
     @property
     def yesterday_drinking_count(self) -> int:
         """Get the total count of times drank yesterday."""
-        return self._data.get("getDrinkWater", {}).get("yesterdayTotalTimes", 0)
+        drinking_count = self._data.get("getDrinkWater", {}).get("yesterdayTotalTimes")
+        return drinking_count if isinstance(drinking_count, int) else 0
 
     @property
     def filter_replacement_frequency(self) -> int:
         """Get the filter replacement frequency."""
-        return self._data.get("realInfo", {}).get("filterReplacementFrequency", 0)
+        frequency = self._data.get("realInfo", {}).get("filterReplacementFrequency")
+        return frequency if isinstance(frequency, int) else 0
     
     @property
     def machine_cleaning_frequency(self) -> int:
         """Get the machine cleaning frequency."""
-        return self._data.get("realInfo", {}).get("machineCleaningFrequency", 0)
+        frequency = self._data.get("realInfo", {}).get("machineCleaningFrequency")
+        return frequency if isinstance(frequency, int) else 0
 
     # Method for indicator turn on
     async def set_light_on(self) -> None:

--- a/custom_components/petlibro/devices/fountains/dockstream_2_smart_fountain.py
+++ b/custom_components/petlibro/devices/fountains/dockstream_2_smart_fountain.py
@@ -63,17 +63,20 @@ class Dockstream2SmartFountain(Device):
     @property
     def wifi_rssi(self) -> int:
         """Get the Wi-Fi signal strength."""
-        return self._data.get("realInfo", {}).get("wifiRssi", -100)
+        wifi_rssi = self._data.get("realInfo", {}).get("wifiRssi")
+        return wifi_rssi if isinstance(wifi_rssi, int) else -100
     
     @property
     def weight(self) -> float:
         """Get the current weight of the water (in grams)."""
-        return self._data.get("realInfo", {}).get("weight", 0.0)
+        weight = self._data.get("realInfo", {}).get("weight")
+        return weight if isinstance(weight, (int, float)) else 0
     
     @property
-    def weight_percent(self) -> int:
+    def weight_percent(self) -> int | float:
         """Get the current weight percentage of water."""
-        return self._data.get("realInfo", {}).get("weightPercent", 0)
+        weight_percent = self._data.get("realInfo", {}).get("weightPercent")
+        return weight_percent if isinstance(weight_percent, (int, float)) else 0
     
     @property
     def remaining_filter_days(self) -> int:
@@ -140,7 +143,8 @@ class Dockstream2SmartFountain(Device):
 
     @property
     def water_interval(self) -> float:
-        return self._data.get("realInfo", {}).get("useWaterInterval", 0)
+        water_interval = self._data.get("realInfo", {}).get("useWaterInterval")
+        return water_interval if isinstance(water_interval, (int, float)) else 0
 
     async def set_water_interval(self, value: float) -> None:
         _LOGGER.debug(f"Setting water interval to {value} for {self.serial}")
@@ -155,7 +159,8 @@ class Dockstream2SmartFountain(Device):
 
     @property
     def water_dispensing_duration(self) -> float:
-        return self._data.get("realInfo", {}).get("useWaterDuration", 0)
+        duration = self._data.get("realInfo", {}).get("useWaterDuration")
+        return duration if isinstance(duration, (int, float)) else 0
 
     async def set_water_dispensing_duration(self, value: float) -> None:
         _LOGGER.debug(f"Setting water dispensing duration to {value} for {self.serial}")
@@ -185,7 +190,8 @@ class Dockstream2SmartFountain(Device):
 
     @property
     def water_low_threshold(self) -> float:
-        return self._data.get("dataRealInfo", {}).get("lowWater", 0)
+        threshold = self._data.get("dataRealInfo", {}).get("lowWater")
+        return threshold if isinstance(threshold, (int, float)) else 0
 
     async def set_water_low_threshold(self, value: float) -> None:
         _LOGGER.debug(f"Setting water low threshold to {value} for {self.serial}")
@@ -198,7 +204,8 @@ class Dockstream2SmartFountain(Device):
 
     @property
     def cleaning_cycle(self) -> float:
-        return self._data.get("realInfo", {}).get("machineCleaningFrequency", 0)
+        cleaning_cycle = self._data.get("realInfo", {}).get("machineCleaningFrequency")
+        return cleaning_cycle if isinstance(cleaning_cycle, (int, float)) else 0
 
     async def set_cleaning_cycle(self, value: float) -> None:
         _LOGGER.debug(f"Setting machine cleaning cycle to {value} for {self.serial}")
@@ -212,7 +219,8 @@ class Dockstream2SmartFountain(Device):
 
     @property
     def filter_cycle(self) -> float:
-        return self._data.get("realInfo", {}).get("filterReplacementFrequency", 0)
+        filter_cycle = self._data.get("realInfo", {}).get("filterReplacementFrequency")
+        return filter_cycle if isinstance(filter_cycle, (int, float)) else 0
 
     async def set_filter_cycle(self, value: float) -> None:
         _LOGGER.debug(f"Setting filter cycle to {value} for {self.serial}")
@@ -255,44 +263,52 @@ class Dockstream2SmartFountain(Device):
             return "Unknown"
 
     @property
-    def today_drinking_amount(self) -> int:
+    def today_drinking_amount(self) -> float:
         """Get the total milliliters of water used today."""
-        return self._data.get("getDrinkWater", {}).get("todayTotalMl", 0)
+        amount = self._data.get("getDrinkWater", {}).get("todayTotalMl")
+        return amount if isinstance(amount, (int, float)) else 0
     
     @property
     def today_drinking_count(self) -> int:
         """Get the total count of times drank today."""
-        return self._data.get("getDrinkWater", {}).get("todayTotalTimes", 0)
+        drinking_count = self._data.get("getDrinkWater", {}).get("todayTotalTimes")
+        return drinking_count if isinstance(drinking_count, int) else 0
 
     @property
     def today_drinking_time(self) -> int:
         """Get the total time spent drinking today."""
-        return self._data.get("getDrinkWater", {}).get("petEatingTime", 0)
+        drinking_time = self._data.get("getDrinkWater", {}).get("petEatingTime")
+        return drinking_time if isinstance(drinking_time, int) else 0
 
     @property
     def today_avg_time(self) -> int:
         """Get the average time spent drinking in a session today."""
-        return self._data.get("getDrinkWater", {}).get("avgDrinkDuration", 0)
+        avg_time = self._data.get("getDrinkWater", {}).get("avgDrinkDuration")
+        return avg_time if isinstance(avg_time, int) else 0
 
     @property
-    def yesterday_drinking_amount(self) -> int:
+    def yesterday_drinking_amount(self) -> float:
         """Get the total milliliters of water used yesterday."""
-        return self._data.get("getDrinkWater", {}).get("yesterdayTotalMl", 0)
+        amount = self._data.get("getDrinkWater", {}).get("yesterdayTotalMl")
+        return amount if isinstance(amount, (int, float)) else 0
     
     @property
     def yesterday_drinking_count(self) -> int:
         """Get the total count of times drank yesterday."""
-        return self._data.get("getDrinkWater", {}).get("yesterdayTotalTimes", 0)
+        drinking_count = self._data.get("getDrinkWater", {}).get("yesterdayTotalTimes")
+        return drinking_count if isinstance(drinking_count, int) else 0
 
     @property
     def filter_replacement_frequency(self) -> int:
         """Get the filter replacement frequency."""
-        return self._data.get("realInfo", {}).get("filterReplacementFrequency", 0)
+        frequency = self._data.get("realInfo", {}).get("filterReplacementFrequency")
+        return frequency if isinstance(frequency, int) else 0
     
     @property
     def machine_cleaning_frequency(self) -> int:
         """Get the machine cleaning frequency."""
-        return self._data.get("realInfo", {}).get("machineCleaningFrequency", 0)
+        frequency = self._data.get("realInfo", {}).get("machineCleaningFrequency")
+        return frequency if isinstance(frequency, int) else 0
 
     # Method for indicator turn on
     async def set_light_on(self) -> None:

--- a/custom_components/petlibro/devices/fountains/dockstream_smart_fountain.py
+++ b/custom_components/petlibro/devices/fountains/dockstream_smart_fountain.py
@@ -73,17 +73,20 @@ class DockstreamSmartFountain(Device):
     @property
     def wifi_rssi(self) -> int:
         """Get the Wi-Fi signal strength."""
-        return self._data.get("realInfo", {}).get("wifiRssi", -100)
+        wifi_rssi = self._data.get("realInfo", {}).get("wifiRssi")
+        return wifi_rssi if isinstance(wifi_rssi, int) else -100
     
     @property
     def weight(self) -> float:
         """Get the current weight of the water (in grams)."""
-        return self._data.get("realInfo", {}).get("weight", 0.0)
+        weight = self._data.get("realInfo", {}).get("weight")
+        return weight if isinstance(weight, (int, float)) else 0
     
     @property
-    def weight_percent(self) -> int:
+    def weight_percent(self) -> int | float:
         """Get the current weight percentage of water."""
-        return self._data.get("realInfo", {}).get("weightPercent", 0)
+        weight_percent = self._data.get("realInfo", {}).get("weightPercent")
+        return weight_percent if isinstance(weight_percent, (int, float)) else 0
     
     @property
     def remaining_filter_days(self) -> float | None:
@@ -149,7 +152,7 @@ class DockstreamSmartFountain(Device):
         await self.refresh()
 
     @property
-    def water_dispensing_mode(self) -> int:
+    def water_dispensing_mode(self) -> str:
         """Return the user-friendly water dispensing mode (mapped directly from the API value)."""
         api_value = self._data.get("realInfo", {}).get("useWaterType", 0)
         
@@ -163,7 +166,8 @@ class DockstreamSmartFountain(Device):
 
     @property
     def water_interval(self) -> float:
-        return self._data.get("realInfo", {}).get("useWaterInterval", 0)
+        water_interval = self._data.get("realInfo", {}).get("useWaterInterval")
+        return water_interval if isinstance(water_interval, (int, float)) else 0
 
     async def set_water_interval(self, value: float) -> None:
         _LOGGER.debug(f"Setting water interval to {value} for {self.serial}")
@@ -178,7 +182,8 @@ class DockstreamSmartFountain(Device):
 
     @property
     def water_dispensing_duration(self) -> float:
-        return self._data.get("realInfo", {}).get("useWaterDuration", 0)
+        duration = self._data.get("realInfo", {}).get("useWaterDuration")
+        return duration if isinstance(duration, (int, float)) else 0
 
     async def set_water_dispensing_duration(self, value: float) -> None:
         _LOGGER.debug(f"Setting water dispensing duration to {value} for {self.serial}")
@@ -193,7 +198,8 @@ class DockstreamSmartFountain(Device):
 
     @property
     def cleaning_cycle(self) -> float:
-        return self._data.get("realInfo", {}).get("machineCleaningFrequency", 0)
+        cleaning_cycle = self._data.get("realInfo", {}).get("machineCleaningFrequency")
+        return cleaning_cycle if isinstance(cleaning_cycle, (int, float)) else 0
 
     async def set_cleaning_cycle(self, value: float) -> None:
         _LOGGER.debug(f"Setting cleaning cycle to {value} for {self.serial}")
@@ -207,7 +213,8 @@ class DockstreamSmartFountain(Device):
 
     @property
     def filter_cycle(self) -> float:
-        return self._data.get("realInfo", {}).get("filterReplacementFrequency", 0)
+        filter_cycle = self._data.get("realInfo", {}).get("filterReplacementFrequency")
+        return filter_cycle if isinstance(filter_cycle, (int, float)) else 0
 
     async def set_filter_cycle(self, value: float) -> None:
         _LOGGER.debug(f"Setting filter cycle to {value} for {self.serial}")
@@ -238,54 +245,64 @@ class DockstreamSmartFountain(Device):
             raise PetLibroAPIError(f"Error triggering filter reset: {err}")
 
     @property
-    def today_drinking_amount(self) -> int:
+    def today_drinking_amount(self) -> float:
         """Get the total milliliters of water used today."""
-        return self._data.get("getDrinkWater", {}).get("todayTotalMl", 0)
+        amount = self._data.get("getDrinkWater", {}).get("todayTotalMl")
+        return amount if isinstance(amount, (int, float)) else 0
     
     @property
     def today_drinking_count(self) -> int:
         """Get the total count of times drank today."""
-        return self._data.get("getDrinkWater", {}).get("todayTotalTimes", 0)
+        drinking_count = self._data.get("getDrinkWater", {}).get("todayTotalTimes")
+        return drinking_count if isinstance(drinking_count, int) else 0
 
     @property
     def today_drinking_time(self) -> int:
         """Get the total time spent drinking today."""
-        return self._data.get("getDrinkWater", {}).get("petEatingTime", 0)
+        drinking_time = self._data.get("getDrinkWater", {}).get("petEatingTime")
+        return drinking_time if isinstance(drinking_time, int) else 0
 
     @property
     def today_avg_time(self) -> int:
         """Get the average time spent drinking in a session today."""
-        return self._data.get("getDrinkWater", {}).get("avgDrinkDuration", 0)
+        avg_time = self._data.get("getDrinkWater", {}).get("avgDrinkDuration")
+        return avg_time if isinstance(avg_time, int) else 0
 
     @property
-    def yesterday_drinking_amount(self) -> int:
+    def yesterday_drinking_amount(self) -> float:
         """Get the total milliliters of water used yesterday."""
-        return self._data.get("getDrinkWater", {}).get("yesterdayTotalMl", 0)
+        amount = self._data.get("getDrinkWater", {}).get("yesterdayTotalMl")
+        return amount if isinstance(amount, (int, float)) else 0
     
     @property
     def yesterday_drinking_count(self) -> int:
         """Get the total count of times drank yesterday."""
-        return self._data.get("getDrinkWater", {}).get("yesterdayTotalTimes", 0)
+        drinking_count = self._data.get("getDrinkWater", {}).get("yesterdayTotalTimes")
+        return drinking_count if isinstance(drinking_count, int) else 0
 
     @property
     def use_water_interval(self) -> int:
         """Get the water usage interval."""
-        return self._data.get("realInfo", {}).get("useWaterInterval", 0)
+        water_interval = self._data.get("realInfo", {}).get("useWaterInterval")
+        return water_interval if isinstance(water_interval, int) else 0
     
     @property
     def use_water_duration(self) -> int:
         """Get the water usage duration."""
-        return self._data.get("realInfo", {}).get("useWaterDuration", 0)
+        water_duration = self._data.get("realInfo", {}).get("useWaterDuration", 0)
+        return water_duration if isinstance(water_duration, int) else 0
     
     @property
     def filter_replacement_frequency(self) -> int:
         """Get the filter replacement frequency."""
-        return self._data.get("realInfo", {}).get("filterReplacementFrequency", 0)
+        frequency = self._data.get("realInfo", {}).get("filterReplacementFrequency")
+        return frequency if isinstance(frequency, int) else 0
     
     @property
     def machine_cleaning_frequency(self) -> int:
         """Get the machine cleaning frequency."""
-        return self._data.get("realInfo", {}).get("machineCleaningFrequency", 0)
+        frequency = self._data.get("realInfo", {}).get("machineCleaningFrequency")
+        return frequency if isinstance(frequency, int) else 0
 
     # Method for indicator turn on
     async def set_light_on(self) -> None:

--- a/custom_components/petlibro/devices/fountains/dockstream_smart_rfid_fountain.py
+++ b/custom_components/petlibro/devices/fountains/dockstream_smart_rfid_fountain.py
@@ -69,17 +69,20 @@ class DockstreamSmartRFIDFountain(Device):
     @property
     def wifi_rssi(self) -> int:
         """Get the Wi-Fi signal strength."""
-        return self._data.get("realInfo", {}).get("wifiRssi", -100)
+        wifi_rssi = self._data.get("realInfo", {}).get("wifiRssi")
+        return wifi_rssi if isinstance(wifi_rssi, int) else -100
     
     @property
     def weight(self) -> float:
         """Get the current weight of the water (in grams)."""
-        return self._data.get("realInfo", {}).get("weight", 0.0)
+        weight = self._data.get("realInfo", {}).get("weight")
+        return weight if isinstance(weight, (int, float)) else 0
     
     @property
-    def weight_percent(self) -> int:
+    def weight_percent(self) -> int | float:
         """Get the current weight percentage of water."""
-        return self._data.get("realInfo", {}).get("weightPercent", 0)
+        weight_percent = self._data.get("realInfo", {}).get("weightPercent")
+        return weight_percent if isinstance(weight_percent, (int, float)) else 0
     
     @property
     def remaining_filter_days(self) -> float | None:
@@ -145,7 +148,7 @@ class DockstreamSmartRFIDFountain(Device):
         await self.refresh()
 
     @property
-    def water_dispensing_mode(self) -> int:
+    def water_dispensing_mode(self) -> str:
         """Return the user-friendly water dispensing mode (mapped directly from the API value)."""
         api_value = self._data.get("realInfo", {}).get("useWaterType", 0)
         
@@ -159,7 +162,8 @@ class DockstreamSmartRFIDFountain(Device):
 
     @property
     def water_interval(self) -> float:
-        return self._data.get("realInfo", {}).get("useWaterInterval", 0)
+        water_interval = self._data.get("realInfo", {}).get("useWaterInterval")
+        return water_interval if isinstance(water_interval, (int, float)) else 0
 
     async def set_water_interval(self, value: float) -> None:
         _LOGGER.debug(f"Setting water interval to {value} for {self.serial}")
@@ -174,7 +178,8 @@ class DockstreamSmartRFIDFountain(Device):
 
     @property
     def water_dispensing_duration(self) -> float:
-        return self._data.get("realInfo", {}).get("useWaterDuration", 0)
+        duration = self._data.get("realInfo", {}).get("useWaterDuration")
+        return duration if isinstance(duration, (int, float)) else 0
 
     async def set_water_dispensing_duration(self, value: float) -> None:
         _LOGGER.debug(f"Setting water dispensing duration to {value} for {self.serial}")
@@ -189,7 +194,8 @@ class DockstreamSmartRFIDFountain(Device):
 
     @property
     def cleaning_cycle(self) -> float:
-        return self._data.get("realInfo", {}).get("machineCleaningFrequency", 0)
+        cleaning_cycle = self._data.get("realInfo", {}).get("machineCleaningFrequency")
+        return cleaning_cycle if isinstance(cleaning_cycle, (int, float)) else 0
 
     async def set_cleaning_cycle(self, value: float) -> None:
         _LOGGER.debug(f"Setting machine cleaning cycle to {value} for {self.serial}")
@@ -203,7 +209,8 @@ class DockstreamSmartRFIDFountain(Device):
 
     @property
     def filter_cycle(self) -> float:
-        return self._data.get("realInfo", {}).get("filterReplacementFrequency", 0)
+        filter_cycle = self._data.get("realInfo", {}).get("filterReplacementFrequency")
+        return filter_cycle if isinstance(filter_cycle, (int, float)) else 0
 
     async def set_filter_cycle(self, value: float) -> None:
         _LOGGER.debug(f"Setting filter cycle to {value} for {self.serial}")
@@ -236,22 +243,26 @@ class DockstreamSmartRFIDFountain(Device):
     @property
     def use_water_interval(self) -> int:
         """Get the water usage interval."""
-        return self._data.get("realInfo", {}).get("useWaterInterval", 0)
+        water_interval = self._data.get("realInfo", {}).get("useWaterInterval")
+        return water_interval if isinstance(water_interval, int) else 0
     
     @property
     def use_water_duration(self) -> int:
         """Get the water usage duration."""
-        return self._data.get("realInfo", {}).get("useWaterDuration", 0)
+        water_duration = self._data.get("realInfo", {}).get("useWaterDuration")
+        return water_duration if isinstance(water_duration, int) else 0
     
     @property
     def filter_replacement_frequency(self) -> int:
         """Get the filter replacement frequency."""
-        return self._data.get("realInfo", {}).get("filterReplacementFrequency", 0)
+        frequency = self._data.get("realInfo", {}).get("filterReplacementFrequency")
+        return frequency if isinstance(frequency, int) else 0
     
     @property
     def machine_cleaning_frequency(self) -> int:
         """Get the machine cleaning frequency."""
-        return self._data.get("realInfo", {}).get("machineCleaningFrequency", 0)
+        frequency = self._data.get("realInfo", {}).get("machineCleaningFrequency")
+        return frequency if isinstance(frequency, int) else 0
 
     # Method for indicator turn on
     async def set_light_on(self) -> None:


### PR DESCRIPTION
<!--
Before opening this pull request please review the guidelines in the checklist below. If this PR does not meet those guidelines it will not be accepted, and everyone will be sad.

Please include a summary of the change. Screenshots and/or videos can also be helpful if appropriate. New devices or enhancements should include example(s) of relevant information.
-->
## Proposed change:
User was getting a TypeError when VolumeConverter was trying to convert value `None`


```python
  File "/usr/src/homeassistant/homeassistant/util/unit_conversion.py", line 131, in <lambda>
    return lambda val: (val / from_ratio) * to_ratio
                        ~~~~^~~~~~~~~~~~
TypeError: unsupported operand type(s) for /: 'NoneType' and 'float'
```

The change adds a safeguard to a bunch of device properties that should return numbers. Before, they only checked if the value exists, now it checks that it's a number.

For example:
```python
    @property
    def today_feeding_quantity(self) -> int:
        return self._data.get("grainStatus", {}).get("todayFeedingQuantity", 0)
```

becomes:

```python
    @property
    def today_feeding_quantity(self) -> float:
        quantity = self._data.get("grainStatus", {}).get("todayFeedingQuantity")
        return quantity if isinstance(quantity, (int, float)) else 0
```

Closes #183  (issue)

## Type of change:

- [ ] New device.
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature or enhancement (non-breaking change which adds functionality).
- [ ] Documentation only.
- [ ] Other (please explain).

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature / enhancement](https://github.com/jjjonesjr33/petlibro/wiki/Feature-&-Enhancement-Guidelines) guidlines before submitting my request.
- [x] If applicable, I have tested my code for new features & regressions on the latest version of Home Assistant.

## Additional notes:
