### PR TITLE
Add additional device info attributes

### DIFF
--- a/custom_components/petlibro/entity.py
+++ b/custom_components/petlibro/entity.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Generic, TypeVar
 from functools import cached_property
 
-from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
 from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.update_coordinator import CoordinatorEntity, DataUpdateCoordinator
 
@@ -42,11 +42,13 @@ class PetLibroEntity(
         assert self.device.serial
         return DeviceInfo(
             identifiers={(DOMAIN, self.device.serial)},
+            connections={(CONNECTION_NETWORK_MAC, self.device.mac)},
             manufacturer="PETLIBRO",
             model=self.device.model,
             name=self.device.name,
             sw_version=self.device.software_version,
-            hw_version=self.device.hardware_version
+            hw_version=self.device.hardware_version,
+            serial_number=self.device.serial,
         )
 
     async def async_added_to_hass(self) -> None:

--- a/custom_components/petlibro/sensor.py
+++ b/custom_components/petlibro/sensor.py
@@ -292,18 +292,6 @@ DEVICE_SENSOR_MAP: dict[type[Device], list[PetLibroSensorEntityDescription]] = {
     ],
     AirSmartFeeder: [
         PetLibroSensorEntityDescription[AirSmartFeeder](
-            key="device_sn",
-            translation_key="device_sn",
-            icon="mdi:identifier",
-            name="Device SN"
-        ),
-        PetLibroSensorEntityDescription[AirSmartFeeder](
-            key="mac",
-            translation_key="mac_address",
-            icon="mdi:network",
-            name="MAC Address"
-        ),
-        PetLibroSensorEntityDescription[AirSmartFeeder](
             key="wifi_ssid",
             translation_key="wifi_ssid",
             icon="mdi:wifi",
@@ -421,18 +409,6 @@ DEVICE_SENSOR_MAP: dict[type[Device], list[PetLibroSensorEntityDescription]] = {
         ),
     ],
     GranarySmartFeeder: [
-        PetLibroSensorEntityDescription[GranarySmartFeeder](
-            key="device_sn",
-            translation_key="device_sn",
-            icon="mdi:identifier",
-            name="Device SN"
-        ),
-        PetLibroSensorEntityDescription[GranarySmartFeeder](
-            key="mac",
-            translation_key="mac_address",
-            icon="mdi:network",
-            name="MAC Address"
-        ),
         PetLibroSensorEntityDescription[GranarySmartFeeder](
             key="wifi_ssid",
             translation_key="wifi_ssid",
@@ -560,18 +536,6 @@ DEVICE_SENSOR_MAP: dict[type[Device], list[PetLibroSensorEntityDescription]] = {
         ),
     ],
     GranarySmartCameraFeeder: [
-        PetLibroSensorEntityDescription[GranarySmartCameraFeeder](
-            key="device_sn",
-            translation_key="device_sn",
-            icon="mdi:identifier",
-            name="Device SN"
-        ),
-        PetLibroSensorEntityDescription[GranarySmartCameraFeeder](
-            key="mac_address",
-            translation_key="mac_address",
-            icon="mdi:network",
-            name="MAC Address"
-        ),
         PetLibroSensorEntityDescription[GranarySmartCameraFeeder](
             key="wifi_ssid",
             translation_key="wifi_ssid",
@@ -735,18 +699,6 @@ DEVICE_SENSOR_MAP: dict[type[Device], list[PetLibroSensorEntityDescription]] = {
     ],
     OneRFIDSmartFeeder: [
         PetLibroSensorEntityDescription[OneRFIDSmartFeeder](
-            key="device_sn",
-            translation_key="device_sn",
-            icon="mdi:identifier",
-            name="Device SN"
-        ),
-        PetLibroSensorEntityDescription[OneRFIDSmartFeeder](
-            key="mac",
-            translation_key="mac_address",
-            icon="mdi:network",
-            name="MAC Address"
-        ),
-        PetLibroSensorEntityDescription[OneRFIDSmartFeeder](
             key="wifi_ssid",
             translation_key="wifi_ssid",
             icon="mdi:wifi",
@@ -887,18 +839,6 @@ DEVICE_SENSOR_MAP: dict[type[Device], list[PetLibroSensorEntityDescription]] = {
     ],
     PolarWetFoodFeeder: [
         PetLibroSensorEntityDescription[PolarWetFoodFeeder](
-            key="device_sn",
-            translation_key="device_sn",
-            icon="mdi:identifier",
-            name="Device SN"
-        ),
-        PetLibroSensorEntityDescription[PolarWetFoodFeeder](
-            key="mac",
-            translation_key="mac_address",
-            icon="mdi:network",
-            name="MAC Address"
-        ),
-        PetLibroSensorEntityDescription[PolarWetFoodFeeder](
             key="wifi_rssi",
             translation_key="wifi_rssi",
             icon="mdi:wifi",
@@ -969,18 +909,6 @@ DEVICE_SENSOR_MAP: dict[type[Device], list[PetLibroSensorEntityDescription]] = {
         ),
     ],
     SpaceSmartFeeder: [
-        PetLibroSensorEntityDescription[SpaceSmartFeeder](
-            key="device_sn",
-            translation_key="device_sn",
-            icon="mdi:identifier",
-            name="Device SN"
-        ),
-        PetLibroSensorEntityDescription[SpaceSmartFeeder](
-            key="mac",
-            translation_key="mac_address",
-            icon="mdi:network",
-            name="MAC Address"
-        ),
         PetLibroSensorEntityDescription[SpaceSmartFeeder](
             key="wifi_ssid",
             translation_key="wifi_ssid",
@@ -1106,18 +1034,6 @@ DEVICE_SENSOR_MAP: dict[type[Device], list[PetLibroSensorEntityDescription]] = {
     ],
     DockstreamSmartFountain: [
         PetLibroSensorEntityDescription[DockstreamSmartFountain](
-            key="device_sn",
-            translation_key="device_sn",
-            icon="mdi:identifier",
-            name="Device SN"
-        ),
-        PetLibroSensorEntityDescription[DockstreamSmartFountain](
-            key="mac",
-            translation_key="mac_address",
-            icon="mdi:network",
-            name="MAC Address"
-        ),
-        PetLibroSensorEntityDescription[DockstreamSmartFountain](
             key="wifi_ssid",
             translation_key="wifi_ssid",
             icon="mdi:wifi",
@@ -1228,18 +1144,6 @@ DEVICE_SENSOR_MAP: dict[type[Device], list[PetLibroSensorEntityDescription]] = {
     ],
     DockstreamSmartRFIDFountain: [
         PetLibroSensorEntityDescription[DockstreamSmartRFIDFountain](
-            key="device_sn",
-            translation_key="device_sn",
-            icon="mdi:identifier",
-            name="Device SN"
-        ),
-        PetLibroSensorEntityDescription[DockstreamSmartRFIDFountain](
-            key="mac",
-            translation_key="mac_address",
-            icon="mdi:network",
-            name="MAC Address"
-        ),
-        PetLibroSensorEntityDescription[DockstreamSmartRFIDFountain](
             key="wifi_ssid",
             translation_key="wifi_ssid",
             icon="mdi:wifi",
@@ -1317,18 +1221,6 @@ DEVICE_SENSOR_MAP: dict[type[Device], list[PetLibroSensorEntityDescription]] = {
         ),
     ],
     Dockstream2SmartCordlessFountain: [
-        PetLibroSensorEntityDescription[Dockstream2SmartCordlessFountain](
-            key="device_sn",
-            translation_key="device_sn",
-            icon="mdi:identifier",
-            name="Device SN"
-        ),
-        PetLibroSensorEntityDescription[Dockstream2SmartCordlessFountain](
-            key="mac",
-            translation_key="mac_address",
-            icon="mdi:network",
-            name="MAC Address"
-        ),
         PetLibroSensorEntityDescription[Dockstream2SmartCordlessFountain](
             key="wifi_ssid",
             translation_key="wifi_ssid",
@@ -1446,18 +1338,6 @@ DEVICE_SENSOR_MAP: dict[type[Device], list[PetLibroSensorEntityDescription]] = {
         ),
     ],
     Dockstream2SmartFountain: [
-        PetLibroSensorEntityDescription[Dockstream2SmartFountain](
-            key="device_sn",
-            translation_key="device_sn",
-            icon="mdi:identifier",
-            name="Device SN"
-        ),
-        PetLibroSensorEntityDescription[Dockstream2SmartFountain](
-            key="mac",
-            translation_key="mac_address",
-            icon="mdi:network",
-            name="MAC Address"
-        ),
         PetLibroSensorEntityDescription[Dockstream2SmartFountain](
             key="wifi_ssid",
             translation_key="wifi_ssid",

--- a/custom_components/petlibro/translations/ar.json
+++ b/custom_components/petlibro/translations/ar.json
@@ -102,12 +102,6 @@
     },
     "entity": {
         "sensor": {
-            "device_sn": {
-                "name": "جهاز SN"
-            },
-            "mac_address": {
-                "name": "عنوان MAC"
-            },
             "wifi_ssid": {
                 "name": "Wi-fi ssid"
             },

--- a/custom_components/petlibro/translations/bn.json
+++ b/custom_components/petlibro/translations/bn.json
@@ -102,12 +102,6 @@
     },
     "entity": {
         "sensor": {
-            "device_sn": {
-                "name": "ডিভাইস এসএন"
-            },
-            "mac_address": {
-                "name": "ম্যাক ঠিকানা"
-            },
             "wifi_ssid": {
                 "name": "Wi-Fi ssid"
             },

--- a/custom_components/petlibro/translations/de.json
+++ b/custom_components/petlibro/translations/de.json
@@ -102,12 +102,6 @@
     },
     "entity": {
         "sensor": {
-            "device_sn": {
-                "name": "Seriennummer"
-            },
-            "mac_address": {
-                "name": "MAC Adresse"
-            },
             "wifi_ssid": {
                 "name": "Wi-Fi SSID"
             },

--- a/custom_components/petlibro/translations/dk.json
+++ b/custom_components/petlibro/translations/dk.json
@@ -102,12 +102,6 @@
     },
     "entity": {
         "sensor": {
-            "device_sn": {
-                "name": "Serienummer"
-            },
-            "mac_address": {
-                "name": "MAC Address"
-            },
             "wifi_ssid": {
                 "name": "Wi-Fi SSID"
             },

--- a/custom_components/petlibro/translations/en.json
+++ b/custom_components/petlibro/translations/en.json
@@ -113,12 +113,6 @@
     },
     "entity": {
         "sensor": {
-            "device_sn": {
-                "name": "Device SN"
-            },
-            "mac_address": {
-                "name": "MAC Address"
-            },
             "wifi_ssid": {
                 "name": "Wi-Fi SSID"
             },

--- a/custom_components/petlibro/translations/es.json
+++ b/custom_components/petlibro/translations/es.json
@@ -102,12 +102,6 @@
     },
     "entity": {
         "sensor": {
-            "device_sn": {
-                "name": "Dispositivo SN"
-            },
-            "mac_address": {
-                "name": "Dirección MAC"
-            },
             "wifi_ssid": {
                 "name": "Wi-Fi SSID"
             },

--- a/custom_components/petlibro/translations/fr.json
+++ b/custom_components/petlibro/translations/fr.json
@@ -102,12 +102,6 @@
     },
     "entity": {
         "sensor": {
-            "device_sn": {
-                "name": "Appareil Sn"
-            },
-            "mac_address": {
-                "name": "Adresse MAC"
-            },
             "wifi_ssid": {
                 "name": "Wi-Fi SSID"
             },

--- a/custom_components/petlibro/translations/hi.json
+++ b/custom_components/petlibro/translations/hi.json
@@ -102,12 +102,6 @@
     },
     "entity": {
         "sensor": {
-            "device_sn": {
-                "name": "युक्ति एसएन"
-            },
-            "mac_address": {
-                "name": "मैक पता"
-            },
             "wifi_ssid": {
                 "name": "वाई-फाई ssid"
             },

--- a/custom_components/petlibro/translations/ja.json
+++ b/custom_components/petlibro/translations/ja.json
@@ -102,12 +102,6 @@
     },
     "entity": {
         "sensor": {
-            "device_sn": {
-                "name": "デバイスSN"
-            },
-            "mac_address": {
-                "name": "Macアドレス"
-            },
             "wifi_ssid": {
                 "name": "wi-fi ssid"
             },

--- a/custom_components/petlibro/translations/nl-be.json
+++ b/custom_components/petlibro/translations/nl-be.json
@@ -102,12 +102,6 @@
     },
     "entity": {
         "sensor": {
-            "device_sn": {
-                "name": "Serienummer"
-            },
-            "mac_address": {
-                "name": "MAC Address"
-            },
             "wifi_ssid": {
                 "name": "Wi-Fi SSID"
             },

--- a/custom_components/petlibro/translations/pt.json
+++ b/custom_components/petlibro/translations/pt.json
@@ -102,12 +102,6 @@
     },
     "entity": {
         "sensor": {
-            "device_sn": {
-                "name": "Dispositivo sn"
-            },
-            "mac_address": {
-                "name": "Endereço MAC"
-            },
             "wifi_ssid": {
                 "name": "Wi-fi ssid"
             },

--- a/custom_components/petlibro/translations/ru.json
+++ b/custom_components/petlibro/translations/ru.json
@@ -102,12 +102,6 @@
     },
     "entity": {
         "sensor": {
-            "device_sn": {
-                "name": "Устройство Sn"
-            },
-            "mac_address": {
-                "name": "MAC -адрес"
-            },
             "wifi_ssid": {
                 "name": "Wi-Fi Ssid"
             },

--- a/custom_components/petlibro/translations/zh-cn.json
+++ b/custom_components/petlibro/translations/zh-cn.json
@@ -102,12 +102,6 @@
     },
     "entity": {
         "sensor": {
-            "device_sn": {
-                "name": "设备SN"
-            },
-            "mac_address": {
-                "name": "MAC地址"
-            },
             "wifi_ssid": {
                 "name": "Wi-Fi SSID"
             },


### PR DESCRIPTION
<!--
Before opening this pull request please review the guidelines in the checklist below. If this PR does not meet those guidelines it will not be accepted, and everyone will be sad.

Please include a summary of the change. Screenshots and/or videos can also be helpful if appropriate. New devices or enhancements should include example(s) of relevant information.
-->
## Proposed change:
Adds serial number and mac address to device info.
<img width="323" height="355" alt="Petlibro DeviceInfo" src="https://github.com/user-attachments/assets/520356c8-6228-422a-9d36-4c58ee5aff6b" />



Closes #186 (issue)

## Type of change:

- [ ] New device.
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature or enhancement (non-breaking change which adds functionality).
- [ ] Documentation only.
- [ ] Other (please explain).

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature / enhancement](https://github.com/jjjonesjr33/petlibro/wiki/Feature-&-Enhancement-Guidelines) guidlines before submitting my request.
- [x] If applicable, I have tested my code for new features & regressions on the latest version of Home Assistant.

## Additional notes:
