### PR TITLE
Feature/Schedule-Control-Dry-Feeders

### DIFF
--- a/custom_components/petlibro/__init__.py
+++ b/custom_components/petlibro/__init__.py
@@ -22,6 +22,7 @@ from .devices.litterboxes.litter_box import LitterBox
 from .devices.litterboxes.luma_smart_litter_box import LumaSmartLitterBox
 from .const import DOMAIN, CONF_EMAIL, CONF_PASSWORD, PLATFORMS, UPDATE_INTERVAL_SECONDS  # Assuming UPDATE_INTERVAL_SECONDS is defined in const
 from .hub import PetLibroHub
+from .services import async_setup_services, async_unload_services
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -197,6 +198,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         # Forward entry setups for each platform
         await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
+        await async_setup_services(hass)
+
         _LOGGER.info(f"Successfully set up PetLibro integration for {email}")
         return True
 
@@ -220,6 +223,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if unload_ok:
         _LOGGER.info(f"Successfully unloaded PetLibro entry for {entry.data.get(CONF_EMAIL)}")
         await hub.async_unload()  # If you have any cleanup to do in the hub
+        await async_unload_services(hass)
     else:
         _LOGGER.error(f"Failed to unload PetLibro entry for {entry.data.get(CONF_EMAIL)}")
 

--- a/custom_components/petlibro/api.py
+++ b/custom_components/petlibro/api.py
@@ -1520,6 +1520,65 @@ class PetLibroAPI:
 
         return success
 
+    async def feeding_plan_toggle(self, serial: str, plan: dict) -> None:
+        """Enable or disable an existing feeding plan via the /enable endpoint."""
+        await self.session.post("/device/feedingPlan/enable", json={
+            "deviceSn": serial,
+            "planId": plan["id"],
+            "enable": plan["enable"],
+        })
+
+    async def feeding_plan_delete(self, serial: str, plan_id: int) -> None:
+        """Permanently remove a feeding plan."""
+        await self.session.post("/device/feedingPlan/remove", json={
+            "deviceSn": serial,
+            "planId": plan_id,
+        })
+
+    async def feeding_plan_add(self, serial: str, plan: dict) -> None:
+        """Create a new feeding plan."""
+        await self.session.post("/device/feedingPlan/add", json={
+            "id": 0,
+            "deviceSn": serial,
+            "executionTime": plan.get("executionTime"),
+            "repeatDay": plan.get("repeatDay", "[]"),
+            "label": plan.get("label", ""),
+            "enable": True,
+            "enableAudio": plan.get("enableAudio", False),
+            "audioTimes": 2,
+            "grainNum": plan.get("grainNum"),
+            "petIds": [],
+        })
+
+    async def feeding_plan_today_skip(self, serial: str, plan_id: int, skip: bool) -> None:
+        """Skip or un-skip a single feeding plan event for today only."""
+        await self.session.post("/device/feedingPlan/enableTodaySingle", json={
+            "deviceSn": serial,
+            "planId": plan_id,
+            "enable": not skip,
+        })
+        
+    async def feeding_plan_update(self, serial: str, plan: dict) -> None:
+        """Enable, disable, or edit an existing feeding plan."""
+        await self.session.post("/device/feedingPlan/update", json={
+            "id": plan["id"],
+            "deviceSn": serial,
+            "executionTime": plan.get("executionTime"),
+            "repeatDay": plan.get("repeatDay", "[]"),
+            "label": plan.get("label", ""),
+            "enable": plan.get("enable", True),
+            "enableAudio": plan.get("enableAudio", False),
+            "audioTimes": plan.get("audioTimes", 2),
+            "grainNum": plan.get("grainNum"),
+            "petIds": [],
+        })
+
+    async def feeding_plan_today_all(self, serial: str, enable: bool) -> None:
+        """Enable or disable ALL feeding plan events for today."""
+        await self.session.post("/device/feedingPlan/enableTodayAll", json={
+            "deviceSn": serial,
+            "enable": enable,
+        })
 
 ## Added this to fix dupe logs
 class PetLibroDataCoordinator(DataUpdateCoordinator):

--- a/custom_components/petlibro/binary_sensor.py
+++ b/custom_components/petlibro/binary_sensor.py
@@ -8,7 +8,7 @@ from collections.abc import Callable
 from functools import cached_property
 from typing import Optional
 import logging
-from .const import DOMAIN
+from .const import DOMAIN, Unit, APIKey as API, VALID_UNIT_TYPES
 from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
     BinarySensorEntityDescription,
@@ -16,9 +16,8 @@ from homeassistant.components.binary_sensor import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.config_entries import ConfigEntry  # Added ConfigEntry import
-from .hub import PetLibroHub  # Adjust the import path as necessary
-
+from homeassistant.config_entries import ConfigEntry
+from .hub import PetLibroHub
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -46,9 +45,12 @@ class PetLibroBinarySensorEntityDescription(BinarySensorEntityDescription, PetLi
     device_class_fn: Callable[[_DeviceT], BinarySensorDeviceClass | None] = lambda _: None
     should_report: Callable[[_DeviceT], bool] = lambda _: True
     device_class: Optional[BinarySensorDeviceClass] = None
+    # Optional override for is_on — use when the entity key differs from the device property
+    value_fn: Callable | None = None
+
 
 class PetLibroBinarySensorEntity(PetLibroEntity[_DeviceT], BinarySensorEntity):
-    """PETLIBRO sensor entity."""
+    """PETLIBRO binary sensor entity."""
 
     entity_description: PetLibroBinarySensorEntityDescription[_DeviceT]
 
@@ -60,33 +62,78 @@ class PetLibroBinarySensorEntity(PetLibroEntity[_DeviceT], BinarySensorEntity):
     @property
     def is_on(self) -> bool:
         """Return True if the binary sensor is on."""
-        # Check if the binary sensor should report its state
         if not self.entity_description.should_report(self.device):
             return False
 
-        # Retrieve the state using getattr, defaulting to None if the attribute is missing
+        # Use value_fn override when the key doesn't match a device property directly
+        if self.entity_description.value_fn is not None:
+            return bool(self.entity_description.value_fn(self.device))
+
         state = getattr(self.device, self.entity_description.key, None)
 
-        # Check if this is the first time the sensor is being refreshed by checking if _last_state exists
         last_state = getattr(self, '_last_state', None)
-        initial_log_done = getattr(self, '_initial_log_done', False)  # Track if we've logged the initial state
+        initial_log_done = getattr(self, '_initial_log_done', False)
 
-        # If this is the initial boot, don't log anything but track the state
         if not initial_log_done:
-            # Mark the initial log as done without logging
-            self._initial_log_done = True  
+            self._initial_log_done = True
         elif last_state != state:
-            # Log state changes: log online with INFO and offline with WARNING
             if state:
                 _LOGGER.info(f"Device {self.device.name} is online.")
             else:
                 _LOGGER.warning(f"Device {self.device.name} is offline.")
 
-        # Store the last state for future comparisons
         self._last_state = state
-
-        # Return the state, ensuring it's a boolean
         return bool(state)
+
+    @property
+    def extra_state_attributes(self):
+        """Return entity specific state attributes."""
+        match self.key:
+            case "feeding_plan_state":
+                # Today's feeding plan events with formatted amounts
+                today_data = getattr(self.device, "feeding_plan_today_data", {})
+                plans = today_data.get("plans", []) if isinstance(today_data, dict) else []
+                if not plans:
+                    return {}
+                plan_data = getattr(self.device, "feeding_plan_data", {})
+                conv = getattr(self.device, "feed_conv_factor", 1)
+                unit = self.member.feedUnitType
+                weight = unit if unit in (Unit.GRAMS, Unit.OUNCES) else Unit.GRAMS
+                volume = unit if unit in (Unit.MILLILITERS, Unit.CUPS) else Unit.MILLILITERS
+                return {
+                    plan_data.get(str(plan["planId"]), {}).get("label") or f"plan_{plan.get('index', plan['planId'])}": {
+                        "time": plan.get("time"),
+                        "amount (weight)": f"{Unit.convert_feed(plan.get('grainNum', 0) * conv, None, weight, True)} {weight.symbol}",
+                        "amount (volume)": f"{Unit.convert_feed(plan.get('grainNum', 0) * conv, None, volume, True)} {volume.symbol}",
+                        "state": {1: "Pending", 2: "Skipped", 3: "Completed", 4: "Skipped, Time Passed"}.get(plan.get("state"), "Unknown"),
+                        "repeat": plan.get("repeat"),
+                        "planID": plan.get("planId"),
+                    }
+                    for plan in plans
+                } or {}
+            case "feeding_schedule":
+                # Full recurring schedule with formatted amounts
+                plans = getattr(self.device, "feeding_plan_data", {})
+                if not plans:
+                    return {}
+                conv = getattr(self.device, "feed_conv_factor", 1)
+                unit = self.member.feedUnitType
+                weight = unit if unit in (Unit.GRAMS, Unit.OUNCES) else Unit.GRAMS
+                volume = unit if unit in (Unit.MILLILITERS, Unit.CUPS) else Unit.MILLILITERS
+                return {
+                    plan.get("label") or f"plan_{plan_id}": {
+                        "planID": int(plan_id),
+                        "time": plan.get("executionTime"),
+                        "amount (weight)": f"{Unit.convert_feed(plan.get('grainNum', 0) * conv, None, weight, True)} {weight.symbol}",
+                        "amount (volume)": f"{Unit.convert_feed(plan.get('grainNum', 0) * conv, None, volume, True)} {volume.symbol}",
+                        "enabled": plan.get("enable", False),
+                        "repeat_days": plan.get("repeatDay", "[]"),
+                        "sound": plan.get("enableAudio", False),
+                    }
+                    for plan_id, plan in plans.items()
+                } or {}
+        return {}
+
 
 DEVICE_BINARY_SENSOR_MAP: dict[type[Device], list[PetLibroBinarySensorEntityDescription]] = {
     Feeder: [
@@ -138,6 +185,21 @@ DEVICE_BINARY_SENSOR_MAP: dict[type[Device], list[PetLibroBinarySensorEntityDesc
             should_report=lambda device: device.light_switch is not None,
             name="Indicator"
         ),
+        PetLibroBinarySensorEntityDescription[AirSmartFeeder](
+            key="feeding_plan_state",
+            translation_key="feeding_plan_state",
+            icon="mdi:calendar-check",
+            should_report=lambda device: device.feeding_plan_state is not None,
+            name="Today's Feeding Schedule"
+        ),
+        PetLibroBinarySensorEntityDescription[AirSmartFeeder](
+            key="feeding_schedule",
+            translation_key="feeding_schedule",
+            icon="mdi:calendar-clock",
+            should_report=lambda device: bool(getattr(device, "feeding_plan_data", {})),
+            value_fn=lambda device: device.feeding_plan_state,
+            name="Feeding Schedule"
+        ),
     ],
     GranarySmartFeeder: [
         PetLibroBinarySensorEntityDescription[GranarySmartFeeder](
@@ -186,6 +248,21 @@ DEVICE_BINARY_SENSOR_MAP: dict[type[Device], list[PetLibroBinarySensorEntityDesc
             should_report=lambda device: device.light_switch is not None,
             name="Indicator"
         ),
+        PetLibroBinarySensorEntityDescription[GranarySmartFeeder](
+            key="feeding_plan_state",
+            translation_key="feeding_plan_state",
+            icon="mdi:calendar-check",
+            should_report=lambda device: device.feeding_plan_state is not None,
+            name="Today's Feeding Schedule"
+        ),
+        PetLibroBinarySensorEntityDescription[GranarySmartFeeder](
+            key="feeding_schedule",
+            translation_key="feeding_schedule",
+            icon="mdi:calendar-clock",
+            should_report=lambda device: bool(getattr(device, "feeding_plan_data", {})),
+            value_fn=lambda device: device.feeding_plan_state,
+            name="Feeding Schedule"
+        ),
     ],
     GranarySmartCameraFeeder: [
         PetLibroBinarySensorEntityDescription[GranarySmartCameraFeeder](
@@ -233,6 +310,21 @@ DEVICE_BINARY_SENSOR_MAP: dict[type[Device], list[PetLibroBinarySensorEntityDesc
             icon="mdi:lightbulb",
             should_report=lambda device: device.light_switch is not None,
             name="Indicator"
+        ),
+        PetLibroBinarySensorEntityDescription[GranarySmartCameraFeeder](
+            key="feeding_plan_state",
+            translation_key="feeding_plan_state",
+            icon="mdi:calendar-check",
+            should_report=lambda device: device.feeding_plan_state is not None,
+            name="Today's Feeding Schedule"
+        ),
+        PetLibroBinarySensorEntityDescription[GranarySmartCameraFeeder](
+            key="feeding_schedule",
+            translation_key="feeding_schedule",
+            icon="mdi:calendar-clock",
+            should_report=lambda device: bool(getattr(device, "feeding_plan_data", {})),
+            value_fn=lambda device: device.feeding_plan_state,
+            name="Feeding Schedule"
         ),
     ],
     OneRFIDSmartFeeder: [
@@ -313,6 +405,21 @@ DEVICE_BINARY_SENSOR_MAP: dict[type[Device], list[PetLibroBinarySensorEntityDesc
             should_report=lambda device: device.display_switch is not None,
             name="Display Status"
         ),
+        PetLibroBinarySensorEntityDescription[OneRFIDSmartFeeder](
+            key="feeding_plan_state",
+            translation_key="feeding_plan_state",
+            icon="mdi:calendar-check",
+            should_report=lambda device: device.feeding_plan_state is not None,
+            name="Today's Feeding Schedule"
+        ),
+        PetLibroBinarySensorEntityDescription[OneRFIDSmartFeeder](
+            key="feeding_schedule",
+            translation_key="feeding_schedule",
+            icon="mdi:calendar-clock",
+            should_report=lambda device: bool(getattr(device, "feeding_plan_data", {})),
+            value_fn=lambda device: device.feeding_plan_state,
+            name="Feeding Schedule"
+        ),
     ],
     PolarWetFoodFeeder: [
         PetLibroBinarySensorEntityDescription[PolarWetFoodFeeder](
@@ -360,6 +467,13 @@ DEVICE_BINARY_SENSOR_MAP: dict[type[Device], list[PetLibroBinarySensorEntityDesc
             icon="mdi:lightbulb",
             should_report=lambda device: device.light_switch is not None,
             name="Indicator"
+        ),
+        PetLibroBinarySensorEntityDescription[PolarWetFoodFeeder](
+            key="feeding_plan_state",
+            translation_key="feeding_plan_state",
+            icon="mdi:calendar-check",
+            should_report=lambda device: device.feeding_plan_state is not None,
+            name="Feeding Plan"
         ),
     ],
     SpaceSmartFeeder: [
@@ -431,6 +545,21 @@ DEVICE_BINARY_SENSOR_MAP: dict[type[Device], list[PetLibroBinarySensorEntityDesc
             icon="mdi:lightbulb",
             should_report=lambda device: device.light_switch is not None,
             name="Indicator"
+        ),
+        PetLibroBinarySensorEntityDescription[SpaceSmartFeeder](
+            key="feeding_plan_state",
+            translation_key="feeding_plan_state",
+            icon="mdi:calendar-check",
+            should_report=lambda device: device.feeding_plan_state is not None,
+            name="Today's Feeding Schedule"
+        ),
+        PetLibroBinarySensorEntityDescription[SpaceSmartFeeder](
+            key="feeding_schedule",
+            translation_key="feeding_schedule",
+            icon="mdi:calendar-clock",
+            should_report=lambda device: bool(getattr(device, "feeding_plan_data", {})),
+            value_fn=lambda device: device.feeding_plan_state,
+            name="Feeding Schedule"
         ),
     ],
     DockstreamSmartFountain: [
@@ -605,34 +734,30 @@ DEVICE_BINARY_SENSOR_MAP: dict[type[Device], list[PetLibroBinarySensorEntityDesc
     ],
 }
 
+
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,  # Use ConfigEntry
+    entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up PETLIBRO binary sensors using config entry."""
-    # Retrieve the hub from hass.data that was set up in __init__.py
     hub: PetLibroHub = hass.data[DOMAIN].get(entry.entry_id)
 
     if not hub:
         _LOGGER.error("Hub not found for entry: %s", entry.entry_id)
         return
 
-    # Ensure that the devices are loaded (if load_devices is not already called elsewhere)
     if not hub.devices:
         _LOGGER.warning("No devices found in hub during binary sensor setup.")
         return
 
-    # Log the contents of the hub data for debugging
     _LOGGER.debug("Hub data: %s", hub)
-
-    devices = hub.devices  # Devices should already be loaded in the hub
+    devices = hub.devices
     _LOGGER.debug("Devices in hub: %s", devices)
 
-    # Create binary sensor entities for each device based on the binary sensor map
     entities = [
         PetLibroBinarySensorEntity(device, hub, description)
-        for device in devices.values()  # Iterate through devices from the hub
+        for device in devices.values()
         for device_type, entity_descriptions in DEVICE_BINARY_SENSOR_MAP.items()
         if isinstance(device, device_type)
         for description in entity_descriptions
@@ -641,10 +766,11 @@ async def async_setup_entry(
     if not entities:
         _LOGGER.warning("No binary sensors added, entities list is empty!")
     else:
-        # Log the number of entities and their details
         _LOGGER.debug("Adding %d PetLibro binary sensors", len(entities))
         for entity in entities:
-            _LOGGER.debug("Adding binary sensor entity: %s for device %s", entity.entity_description.name, entity.device.name)
-
-        # Add binary sensor entities to Home Assistant
+            _LOGGER.debug(
+                "Adding binary sensor entity: %s for device %s",
+                entity.entity_description.name,
+                entity.device.name,
+            )
         async_add_entities(entities)

--- a/custom_components/petlibro/button.py
+++ b/custom_components/petlibro/button.py
@@ -1,5 +1,6 @@
 """Support for PETLIBRO buttons."""
 from __future__ import annotations
+import re
 from .api import make_api_call
 import aiohttp
 from aiohttp import ClientSession, ClientError
@@ -11,9 +12,11 @@ from .const import DOMAIN
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.config_entries import ConfigEntry  # Added ConfigEntry import
-from .hub import PetLibroHub  # Adjust the import path as necessary
+from homeassistant.config_entries import ConfigEntry
+from .hub import PetLibroHub
 
 _LOGGER = getLogger(__name__)
 
@@ -33,6 +36,7 @@ from .devices.fountains.dockstream_2_smart_cordless_fountain import Dockstream2S
 from .devices.fountains.dockstream_2_smart_fountain import Dockstream2SmartFountain
 from .devices.litterboxes.luma_smart_litter_box import LumaSmartLitterBox
 
+
 @dataclass(frozen=True)
 class RequiredKeysMixin(Generic[_DeviceT]):
     """A class that describes devices button entity required keys."""
@@ -43,9 +47,12 @@ class RequiredKeysMixin(Generic[_DeviceT]):
 class PetLibroButtonEntityDescription(ButtonEntityDescription, PetLibroEntityDescription[_DeviceT], RequiredKeysMixin[_DeviceT]):
     """A class that describes device button entities."""
     entity_category: EntityCategory = EntityCategory.CONFIG
+    # For feeding plan buttons: read plan_id from this select entity unique_id suffix
+    select_key: str | None = None
+    # Async callable(device, plan_id) — used when select_key is set
+    plan_fn: Callable | None = None
 
 
-# Map buttons to their respective device types
 DEVICE_BUTTON_MAP: dict[type[Device], list[PetLibroButtonEntityDescription]] = {
     Feeder: [
     ],
@@ -80,6 +87,71 @@ DEVICE_BUTTON_MAP: dict[type[Device], list[PetLibroButtonEntityDescription]] = {
             set_fn=lambda device: device.set_light_off(),
             name="Turn Off Indicator"
         ),
+        PetLibroButtonEntityDescription[AirSmartFeeder](
+            key="feeding_plan_enable",
+            translation_key="feeding_plan_enable",
+            icon="mdi:calendar-check",
+            name="Enable Selected Plan",
+            set_fn=lambda _: None,
+            select_key="feeding_plan_select",
+            plan_fn=lambda d, pid: d.api.feeding_plan_toggle(
+                d.serial,
+                {**d.feeding_plan_data.get(str(pid), {}), "id": pid, "enable": True},
+            ),
+        ),
+        PetLibroButtonEntityDescription[AirSmartFeeder](
+            key="feeding_plan_disable",
+            translation_key="feeding_plan_disable",
+            icon="mdi:calendar-remove",
+            name="Disable Selected Plan",
+            set_fn=lambda _: None,
+            select_key="feeding_plan_select",
+            plan_fn=lambda d, pid: d.api.feeding_plan_toggle(
+                d.serial,
+                {**d.feeding_plan_data.get(str(pid), {}), "id": pid, "enable": False},
+            ),
+        ),
+        PetLibroButtonEntityDescription[AirSmartFeeder](
+            key="feeding_plan_delete",
+            translation_key="feeding_plan_delete",
+            icon="mdi:calendar-minus",
+            name="Delete Selected Plan",
+            set_fn=lambda _: None,
+            select_key="feeding_plan_select",
+            plan_fn=lambda d, pid: d.api.feeding_plan_delete(d.serial, pid),
+        ),
+        PetLibroButtonEntityDescription[AirSmartFeeder](
+            key="feeding_plan_skip_today",
+            translation_key="feeding_plan_skip_today",
+            icon="mdi:calendar-today",
+            name="Skip Selected Plan Today",
+            set_fn=lambda _: None,
+            select_key="feeding_plan_today_select",
+            plan_fn=lambda d, pid: d.api.feeding_plan_today_skip(d.serial, pid, skip=True),
+        ),
+        PetLibroButtonEntityDescription[AirSmartFeeder](
+            key="feeding_plan_unskip_today",
+            translation_key="feeding_plan_unskip_today",
+            icon="mdi:calendar-today",
+            name="Un-skip Selected Plan Today",
+            set_fn=lambda _: None,
+            select_key="feeding_plan_today_select",
+            plan_fn=lambda d, pid: d.api.feeding_plan_today_skip(d.serial, pid, skip=False),
+        ),
+        PetLibroButtonEntityDescription[AirSmartFeeder](
+            key="feeding_plan_today_enable_all",
+            translation_key="feeding_plan_today_enable_all",
+            icon="mdi:calendar-check",
+            name="Enable Today's Feeding Schedule",
+            set_fn=lambda d: d.api.feeding_plan_today_all(d.serial, True),
+        ),
+        PetLibroButtonEntityDescription[AirSmartFeeder](
+            key="feeding_plan_today_disable_all",
+            translation_key="feeding_plan_today_disable_all",
+            icon="mdi:calendar-remove",
+            name="Disable Today's Feeding Schedule",
+            set_fn=lambda d: d.api.feeding_plan_today_all(d.serial, False),
+        ),
     ],
     GranarySmartFeeder: [
         PetLibroButtonEntityDescription[GranarySmartFeeder](
@@ -92,13 +164,13 @@ DEVICE_BUTTON_MAP: dict[type[Device], list[PetLibroButtonEntityDescription]] = {
             key="enable_feeding_plan",
             translation_key="enable_feeding_plan",
             set_fn=lambda device: device.set_feeding_plan(True),
-            name="Enable Feeding Plan"
+            name="Enable Feeding Schedule"
         ),
         PetLibroButtonEntityDescription[GranarySmartFeeder](
             key="disable_feeding_plan",
             translation_key="disable_feeding_plan",
             set_fn=lambda device: device.set_feeding_plan(False),
-            name="Disable Feeding Plan"
+            name="Disable Feeding Schedule"
         ),
         PetLibroButtonEntityDescription[GranarySmartFeeder](
             key="light_on",
@@ -117,6 +189,71 @@ DEVICE_BUTTON_MAP: dict[type[Device], list[PetLibroButtonEntityDescription]] = {
             translation_key="desiccant_reset",
             set_fn=lambda device: device.set_desiccant_reset(),
             name="Desiccant Replaced"
+        ),
+        PetLibroButtonEntityDescription[GranarySmartFeeder](
+            key="feeding_plan_enable",
+            translation_key="feeding_plan_enable",
+            icon="mdi:calendar-check",
+            name="Enable Selected Plan",
+            set_fn=lambda _: None,
+            select_key="feeding_plan_select",
+            plan_fn=lambda d, pid: d.api.feeding_plan_toggle(
+                d.serial,
+                {**d.feeding_plan_data.get(str(pid), {}), "id": pid, "enable": True},
+            ),
+        ),
+        PetLibroButtonEntityDescription[GranarySmartFeeder](
+            key="feeding_plan_disable",
+            translation_key="feeding_plan_disable",
+            icon="mdi:calendar-remove",
+            name="Disable Selected Plan",
+            set_fn=lambda _: None,
+            select_key="feeding_plan_select",
+            plan_fn=lambda d, pid: d.api.feeding_plan_toggle(
+                d.serial,
+                {**d.feeding_plan_data.get(str(pid), {}), "id": pid, "enable": False},
+            ),
+        ),
+        PetLibroButtonEntityDescription[GranarySmartFeeder](
+            key="feeding_plan_delete",
+            translation_key="feeding_plan_delete",
+            icon="mdi:calendar-minus",
+            name="Delete Selected Plan",
+            set_fn=lambda _: None,
+            select_key="feeding_plan_select",
+            plan_fn=lambda d, pid: d.api.feeding_plan_delete(d.serial, pid),
+        ),
+        PetLibroButtonEntityDescription[GranarySmartFeeder](
+            key="feeding_plan_skip_today",
+            translation_key="feeding_plan_skip_today",
+            icon="mdi:calendar-today",
+            name="Skip Selected Plan Today",
+            set_fn=lambda _: None,
+            select_key="feeding_plan_today_select",
+            plan_fn=lambda d, pid: d.api.feeding_plan_today_skip(d.serial, pid, skip=True),
+        ),
+        PetLibroButtonEntityDescription[GranarySmartFeeder](
+            key="feeding_plan_unskip_today",
+            translation_key="feeding_plan_unskip_today",
+            icon="mdi:calendar-today",
+            name="Un-skip Selected Plan Today",
+            set_fn=lambda _: None,
+            select_key="feeding_plan_today_select",
+            plan_fn=lambda d, pid: d.api.feeding_plan_today_skip(d.serial, pid, skip=False),
+        ),
+        PetLibroButtonEntityDescription[GranarySmartFeeder](
+            key="feeding_plan_today_enable_all",
+            translation_key="feeding_plan_today_enable_all",
+            icon="mdi:calendar-check",
+            name="Enable Today's Feeding Schedule",
+            set_fn=lambda d: d.api.feeding_plan_today_all(d.serial, True),
+        ),
+        PetLibroButtonEntityDescription[GranarySmartFeeder](
+            key="feeding_plan_today_disable_all",
+            translation_key="feeding_plan_today_disable_all",
+            icon="mdi:calendar-remove",
+            name="Disable Today's Feeding Schedule",
+            set_fn=lambda d: d.api.feeding_plan_today_all(d.serial, False),
         ),
     ],
     GranarySmartCameraFeeder: [
@@ -130,13 +267,13 @@ DEVICE_BUTTON_MAP: dict[type[Device], list[PetLibroButtonEntityDescription]] = {
             key="enable_feeding_plan",
             translation_key="enable_feeding_plan",
             set_fn=lambda device: device.set_feeding_plan(True),
-            name="Enable Feeding Plan"
+            name="Enable Feeding Schedule"
         ),
         PetLibroButtonEntityDescription[GranarySmartCameraFeeder](
             key="disable_feeding_plan",
             translation_key="disable_feeding_plan",
             set_fn=lambda device: device.set_feeding_plan(False),
-            name="Disable Feeding Plan"
+            name="Disable Feeding Schedule"
         ),
         PetLibroButtonEntityDescription[GranarySmartCameraFeeder](
             key="light_on",
@@ -156,6 +293,71 @@ DEVICE_BUTTON_MAP: dict[type[Device], list[PetLibroButtonEntityDescription]] = {
             set_fn=lambda device: device.set_desiccant_reset(),
             name="Desiccant Replaced"
         ),
+        PetLibroButtonEntityDescription[GranarySmartCameraFeeder](
+            key="feeding_plan_enable",
+            translation_key="feeding_plan_enable",
+            icon="mdi:calendar-check",
+            name="Enable Selected Plan",
+            set_fn=lambda _: None,
+            select_key="feeding_plan_select",
+            plan_fn=lambda d, pid: d.api.feeding_plan_toggle(
+                d.serial,
+                {**d.feeding_plan_data.get(str(pid), {}), "id": pid, "enable": True},
+            ),
+        ),
+        PetLibroButtonEntityDescription[GranarySmartCameraFeeder](
+            key="feeding_plan_disable",
+            translation_key="feeding_plan_disable",
+            icon="mdi:calendar-remove",
+            name="Disable Selected Plan",
+            set_fn=lambda _: None,
+            select_key="feeding_plan_select",
+            plan_fn=lambda d, pid: d.api.feeding_plan_toggle(
+                d.serial,
+                {**d.feeding_plan_data.get(str(pid), {}), "id": pid, "enable": False},
+            ),
+        ),
+        PetLibroButtonEntityDescription[GranarySmartCameraFeeder](
+            key="feeding_plan_delete",
+            translation_key="feeding_plan_delete",
+            icon="mdi:calendar-minus",
+            name="Delete Selected Plan",
+            set_fn=lambda _: None,
+            select_key="feeding_plan_select",
+            plan_fn=lambda d, pid: d.api.feeding_plan_delete(d.serial, pid),
+        ),
+        PetLibroButtonEntityDescription[GranarySmartCameraFeeder](
+            key="feeding_plan_skip_today",
+            translation_key="feeding_plan_skip_today",
+            icon="mdi:calendar-today",
+            name="Skip Selected Plan Today",
+            set_fn=lambda _: None,
+            select_key="feeding_plan_today_select",
+            plan_fn=lambda d, pid: d.api.feeding_plan_today_skip(d.serial, pid, skip=True),
+        ),
+        PetLibroButtonEntityDescription[GranarySmartCameraFeeder](
+            key="feeding_plan_unskip_today",
+            translation_key="feeding_plan_unskip_today",
+            icon="mdi:calendar-today",
+            name="Un-skip Selected Plan Today",
+            set_fn=lambda _: None,
+            select_key="feeding_plan_today_select",
+            plan_fn=lambda d, pid: d.api.feeding_plan_today_skip(d.serial, pid, skip=False),
+        ),
+        PetLibroButtonEntityDescription[GranarySmartCameraFeeder](
+            key="feeding_plan_today_enable_all",
+            translation_key="feeding_plan_today_enable_all",
+            icon="mdi:calendar-check",
+            name="Enable Today's Feeding Schedule",
+            set_fn=lambda d: d.api.feeding_plan_today_all(d.serial, True),
+        ),
+        PetLibroButtonEntityDescription[GranarySmartCameraFeeder](
+            key="feeding_plan_today_disable_all",
+            translation_key="feeding_plan_today_disable_all",
+            icon="mdi:calendar-remove",
+            name="Disable Today's Feeding Schedule",
+            set_fn=lambda d: d.api.feeding_plan_today_all(d.serial, False),
+        ),
     ],
     OneRFIDSmartFeeder: [
         PetLibroButtonEntityDescription[OneRFIDSmartFeeder](
@@ -168,13 +370,13 @@ DEVICE_BUTTON_MAP: dict[type[Device], list[PetLibroButtonEntityDescription]] = {
             key="enable_feeding_plan",
             translation_key="enable_feeding_plan",
             set_fn=lambda device: device.set_feeding_plan(True),
-            name="Enable Feeding Plan"
+            name="Enable Feeding Schedule"
         ),
         PetLibroButtonEntityDescription[OneRFIDSmartFeeder](
             key="disable_feeding_plan",
             translation_key="disable_feeding_plan",
             set_fn=lambda device: device.set_feeding_plan(False),
-            name="Disable Feeding Plan"
+            name="Disable Feeding Schedule"
         ),
         PetLibroButtonEntityDescription[OneRFIDSmartFeeder](
             key="manual_lid_open",
@@ -211,7 +413,72 @@ DEVICE_BUTTON_MAP: dict[type[Device], list[PetLibroButtonEntityDescription]] = {
             translation_key="desiccant_reset",
             set_fn=lambda device: device.set_desiccant_reset(),
             name="Desiccant Reset"
-        )
+        ),
+        PetLibroButtonEntityDescription[OneRFIDSmartFeeder](
+            key="feeding_plan_enable",
+            translation_key="feeding_plan_enable",
+            icon="mdi:calendar-check",
+            name="Enable Selected Plan",
+            set_fn=lambda _: None,
+            select_key="feeding_plan_select",
+            plan_fn=lambda d, pid: d.api.feeding_plan_toggle(
+                d.serial,
+                {**d.feeding_plan_data.get(str(pid), {}), "id": pid, "enable": True},
+            ),
+        ),
+        PetLibroButtonEntityDescription[OneRFIDSmartFeeder](
+            key="feeding_plan_disable",
+            translation_key="feeding_plan_disable",
+            icon="mdi:calendar-remove",
+            name="Disable Selected Plan",
+            set_fn=lambda _: None,
+            select_key="feeding_plan_select",
+            plan_fn=lambda d, pid: d.api.feeding_plan_toggle(
+                d.serial,
+                {**d.feeding_plan_data.get(str(pid), {}), "id": pid, "enable": False},
+            ),
+        ),
+        PetLibroButtonEntityDescription[OneRFIDSmartFeeder](
+            key="feeding_plan_delete",
+            translation_key="feeding_plan_delete",
+            icon="mdi:calendar-minus",
+            name="Delete Selected Plan",
+            set_fn=lambda _: None,
+            select_key="feeding_plan_select",
+            plan_fn=lambda d, pid: d.api.feeding_plan_delete(d.serial, pid),
+        ),
+        PetLibroButtonEntityDescription[OneRFIDSmartFeeder](
+            key="feeding_plan_skip_today",
+            translation_key="feeding_plan_skip_today",
+            icon="mdi:calendar-today",
+            name="Skip Selected Plan Today",
+            set_fn=lambda _: None,
+            select_key="feeding_plan_today_select",
+            plan_fn=lambda d, pid: d.api.feeding_plan_today_skip(d.serial, pid, skip=True),
+        ),
+        PetLibroButtonEntityDescription[OneRFIDSmartFeeder](
+            key="feeding_plan_unskip_today",
+            translation_key="feeding_plan_unskip_today",
+            icon="mdi:calendar-today",
+            name="Un-skip Selected Plan Today",
+            set_fn=lambda _: None,
+            select_key="feeding_plan_today_select",
+            plan_fn=lambda d, pid: d.api.feeding_plan_today_skip(d.serial, pid, skip=False),
+        ),
+        PetLibroButtonEntityDescription[OneRFIDSmartFeeder](
+            key="feeding_plan_today_enable_all",
+            translation_key="feeding_plan_today_enable_all",
+            icon="mdi:calendar-check",
+            name="Enable Today's Feeding Schedule",
+            set_fn=lambda d: d.api.feeding_plan_today_all(d.serial, True),
+        ),
+        PetLibroButtonEntityDescription[OneRFIDSmartFeeder](
+            key="feeding_plan_today_disable_all",
+            translation_key="feeding_plan_today_disable_all",
+            icon="mdi:calendar-remove",
+            name="Disable Today's Feeding Schedule",
+            set_fn=lambda d: d.api.feeding_plan_today_all(d.serial, False),
+        ),
     ],
     PolarWetFoodFeeder: [
         PetLibroButtonEntityDescription[PolarWetFoodFeeder](
@@ -256,13 +523,13 @@ DEVICE_BUTTON_MAP: dict[type[Device], list[PetLibroButtonEntityDescription]] = {
             key="enable_feeding_plan",
             translation_key="enable_feeding_plan",
             set_fn=lambda device: device.set_feeding_plan(True),
-            name="Enable Feeding Plan"
+            name="Enable Feeding Schedule"
         ),
         PetLibroButtonEntityDescription[SpaceSmartFeeder](
             key="disable_feeding_plan",
             translation_key="disable_feeding_plan",
             set_fn=lambda device: device.set_feeding_plan(False),
-            name="Disable Feeding Plan"
+            name="Disable Feeding Schedule"
         ),
         PetLibroButtonEntityDescription[SpaceSmartFeeder](
             key="sound_on",
@@ -299,6 +566,71 @@ DEVICE_BUTTON_MAP: dict[type[Device], list[PetLibroButtonEntityDescription]] = {
             translation_key="sleep_off",
             set_fn=lambda device: device.set_sleep_off(),
             name="Turn Off Sleep Mode"
+        ),
+        PetLibroButtonEntityDescription[SpaceSmartFeeder](
+            key="feeding_plan_enable",
+            translation_key="feeding_plan_enable",
+            icon="mdi:calendar-check",
+            name="Enable Selected Plan",
+            set_fn=lambda _: None,
+            select_key="feeding_plan_select",
+            plan_fn=lambda d, pid: d.api.feeding_plan_toggle(
+                d.serial,
+                {**d.feeding_plan_data.get(str(pid), {}), "id": pid, "enable": True},
+            ),
+        ),
+        PetLibroButtonEntityDescription[SpaceSmartFeeder](
+            key="feeding_plan_disable",
+            translation_key="feeding_plan_disable",
+            icon="mdi:calendar-remove",
+            name="Disable Selected Plan",
+            set_fn=lambda _: None,
+            select_key="feeding_plan_select",
+            plan_fn=lambda d, pid: d.api.feeding_plan_toggle(
+                d.serial,
+                {**d.feeding_plan_data.get(str(pid), {}), "id": pid, "enable": False},
+            ),
+        ),
+        PetLibroButtonEntityDescription[SpaceSmartFeeder](
+            key="feeding_plan_delete",
+            translation_key="feeding_plan_delete",
+            icon="mdi:calendar-minus",
+            name="Delete Selected Plan",
+            set_fn=lambda _: None,
+            select_key="feeding_plan_select",
+            plan_fn=lambda d, pid: d.api.feeding_plan_delete(d.serial, pid),
+        ),
+        PetLibroButtonEntityDescription[SpaceSmartFeeder](
+            key="feeding_plan_skip_today",
+            translation_key="feeding_plan_skip_today",
+            icon="mdi:calendar-today",
+            name="Skip Selected Plan Today",
+            set_fn=lambda _: None,
+            select_key="feeding_plan_today_select",
+            plan_fn=lambda d, pid: d.api.feeding_plan_today_skip(d.serial, pid, skip=True),
+        ),
+        PetLibroButtonEntityDescription[SpaceSmartFeeder](
+            key="feeding_plan_unskip_today",
+            translation_key="feeding_plan_unskip_today",
+            icon="mdi:calendar-today",
+            name="Un-skip Selected Plan Today",
+            set_fn=lambda _: None,
+            select_key="feeding_plan_today_select",
+            plan_fn=lambda d, pid: d.api.feeding_plan_today_skip(d.serial, pid, skip=False),
+        ),
+        PetLibroButtonEntityDescription[SpaceSmartFeeder](
+            key="feeding_plan_today_enable_all",
+            translation_key="feeding_plan_today_enable_all",
+            icon="mdi:calendar-check",
+            name="Enable Today's Feeding Schedule",
+            set_fn=lambda d: d.api.feeding_plan_today_all(d.serial, True),
+        ),
+        PetLibroButtonEntityDescription[SpaceSmartFeeder](
+            key="feeding_plan_today_disable_all",
+            translation_key="feeding_plan_today_disable_all",
+            icon="mdi:calendar-remove",
+            name="Disable Today's Feeding Schedule",
+            set_fn=lambda d: d.api.feeding_plan_today_all(d.serial, False),
         ),
     ],
     DockstreamSmartFountain: [
@@ -451,6 +783,7 @@ DEVICE_BUTTON_MAP: dict[type[Device], list[PetLibroButtonEntityDescription]] = {
     ],
 }
 
+
 class PetLibroButtonEntity(PetLibroEntity[_DeviceT], ButtonEntity):
     """PETLIBRO button entity."""
     entity_description: PetLibroButtonEntityDescription[_DeviceT]
@@ -460,51 +793,87 @@ class PetLibroButtonEntity(PetLibroEntity[_DeviceT], ButtonEntity):
         """Check if the device is available."""
         return getattr(self.device, 'online', False)
 
+    def _get_plan_id(self, select_key: str) -> int:
+        """Read the currently selected plan ID from the companion select entity."""
+        ent_reg = er.async_get(self.hass)
+        unique_id = f"{self.device.serial}-{select_key}"
+        entity_id = ent_reg.async_get_entity_id("select", DOMAIN, unique_id)
+
+        if not entity_id:
+            raise HomeAssistantError(
+                f"No feeding plan selector found for {self.device.name}. "
+                "Make sure the integration has loaded correctly."
+            )
+
+        state = self.hass.states.get(entity_id)
+        if not state or state.state in ("unknown", "unavailable", "No plans", "No plans today"):
+            raise HomeAssistantError(
+                f"No plan selected on {self.device.name}. "
+                "Select a plan from the feeding plan dropdown first."
+            )
+
+        match = re.search(r"-\s*(\d+)\s*$", state.state)
+        if not match:
+            raise HomeAssistantError(
+                f"Could not extract a plan ID from '{state.state}'."
+            )
+
+        return int(match.group(1))
+
     async def async_press(self) -> None:
         """Handle the button press."""
-        _LOGGER.debug("Pressing button: %s for device %s", self.entity_description.name, self.device.name)
-
-        # Log available methods for debugging
-        _LOGGER.debug("Available methods for device %s: %s", self.device.name, dir(self.device))
+        desc = self.entity_description
+        _LOGGER.debug("Pressing button: %s for device %s", desc.name, self.device.name)
 
         try:
-            await self.entity_description.set_fn(self.device)
-            await self.device.refresh()  # Refresh the device state after the button press
-            _LOGGER.debug("Successfully pressed button: %s", self.entity_description.name)
+            if desc.select_key and desc.plan_fn:
+                # Plan-specific button: read selected plan from select entity
+                plan_id = self._get_plan_id(desc.select_key)
+                await desc.plan_fn(self.device, plan_id)
+                _LOGGER.debug(
+                    "Button '%s' pressed for plan %d on %s",
+                    desc.name, plan_id, self.device.name,
+                )
+            else:
+                # Standard button
+                await desc.set_fn(self.device)
+                _LOGGER.debug("Successfully pressed button: %s", desc.name)
+
+            await self.device.refresh()
+
+        except HomeAssistantError:
+            raise
         except Exception as e:
             _LOGGER.error(
-                f"Error pressing button {self.entity_description.name} for device {self.device.name}: {e}",
-                exc_info=True  # Log full traceback for better debugging
+                "Error pressing button %s for device %s: %s",
+                desc.name, self.device.name, e,
+                exc_info=True,
             )
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,  # Use ConfigEntry
+    entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up PETLIBRO buttons using config entry."""
-    # Retrieve the hub from hass.data that was set up in __init__.py
     hub: PetLibroHub = hass.data[DOMAIN].get(entry.entry_id)
 
     if not hub:
         _LOGGER.error("Hub not found for entry: %s", entry.entry_id)
         return
 
-    # Ensure that the devices are loaded
     if not hub.devices:
         _LOGGER.warning("No devices found in hub during button setup.")
         return
 
-    # Log the contents of the hub data for debugging
     _LOGGER.debug("Hub data: %s", hub)
-
-    devices = hub.devices  # Devices should already be loaded in the hub
+    devices = hub.devices
     _LOGGER.debug("Devices in hub: %s", devices)
 
-    # Create button entities for each device based on the button map
     entities = [
         PetLibroButtonEntity(device, hub, description)
-        for device in devices.values()  # Iterate through devices from the hub
+        for device in devices.values()
         for device_type, entity_descriptions in DEVICE_BUTTON_MAP.items()
         if isinstance(device, device_type)
         for description in entity_descriptions
@@ -513,10 +882,11 @@ async def async_setup_entry(
     if not entities:
         _LOGGER.warning("No buttons added, entities list is empty!")
     else:
-        # Log the number of entities and their details
         _LOGGER.debug("Adding %d PetLibro buttons", len(entities))
         for entity in entities:
-            _LOGGER.debug("Adding button entity: %s for device %s", entity.entity_description.name, entity.device.name)
-
-        # Add button entities to Home Assistant
+            _LOGGER.debug(
+                "Adding button entity: %s for device %s",
+                entity.entity_description.name,
+                entity.device.name,
+            )
         async_add_entities(entities)

--- a/custom_components/petlibro/select.py
+++ b/custom_components/petlibro/select.py
@@ -213,6 +213,76 @@ class PetLibroSelectEntity(PetLibroEntity[_DeviceT], SelectEntity):
         return mappings.get(key, {}).get(current_selection, "unknown")
 
 
+# ---------------------------------------------------------------------------
+# Feeding plan select entities
+# Used by feeding plan services to let the user pick a plan from a dropdown.
+# Options are formatted as "Label - ID" (e.g. "MorningFeed - 3907147").
+# Selecting an option stores the choice locally — no API call is made.
+# The service handlers read the selected option to extract the plan ID.
+# ---------------------------------------------------------------------------
+
+class FeedingPlanSelectEntity(PetLibroEntity[_DeviceT], SelectEntity):
+    """Base select entity for picking a feeding plan."""
+
+    _attr_has_entity_name = True
+    _attr_icon = "mdi:calendar-clock"
+    _attr_should_poll = False
+
+    def __init__(self, device, hub, key: str, name: str) -> None:
+        desc = PetLibroEntityDescription(key=key, name=name)
+        super().__init__(device, hub, desc)
+        self._attr_unique_id = f"{device.serial}-{key}"
+        self._current: str | None = None
+
+    def _build_options(self) -> list[str]:
+        raise NotImplementedError
+
+    @property
+    def options(self) -> list[str]:
+        return self._build_options()
+
+    @property
+    def current_option(self) -> str | None:
+        opts = self.options
+        if not opts:
+            return None
+        if self._current in opts:
+            return self._current
+        return opts[0]
+
+    async def async_select_option(self, option: str) -> None:
+        """User picked a plan — store locally, no API call."""
+        self._current = option
+        self.async_write_ha_state()
+
+
+class FeedingScheduleSelectEntity(FeedingPlanSelectEntity[_DeviceT]):
+    """Select listing ALL plans in the recurring schedule."""
+
+    def _build_options(self) -> list[str]:
+        plans = getattr(self.device, "feeding_plan_data", {})
+        return [
+            f"{plan.get('label') or f'plan_{pid}'} - {pid}"
+            for pid, plan in plans.items()
+        ] or ["No plans"]
+
+
+class FeedingTodaySelectEntity(FeedingPlanSelectEntity[_DeviceT]):
+    """Select listing only TODAY's feeding plan events."""
+
+    def _build_options(self) -> list[str]:
+        today = getattr(self.device, "feeding_plan_today_data", {}).get("plans", [])
+        plan_data = getattr(self.device, "feeding_plan_data", {})
+        opts = []
+        for p in today:
+            if not p.get("planId"):
+                continue
+            plan_id = p["planId"]
+            label = plan_data.get(str(plan_id), {}).get("label") or f"plan_{p['index']}"
+            opts.append(f"{label} - {plan_id}")
+        return opts or ["No plans today"]
+
+
 DEVICE_SELECT_MAP: dict[type[Device], list[PetLibroSelectEntityDescription]] = {
     Feeder: [
     ],
@@ -421,12 +491,26 @@ async def async_setup_entry(
         entities.extend(
             [
                 PetLibroSelectEntity(device, hub, description)
-                for device in devices.values()  # Iterate through devices from the hub
+                for device in devices.values()
                 for device_type, entity_descriptions in DEVICE_SELECT_MAP.items()
                 if isinstance(device, device_type)
                 for description in entity_descriptions
             ]
         )
+
+        # Add feeding plan select entities for dry feeders
+        for device in devices.values():
+            if hasattr(device, "feeding_plan_data"):
+                entities.append(
+                    FeedingScheduleSelectEntity(
+                        device, hub, "feeding_plan_select", "Feeding Plan"
+                    )
+                )
+                entities.append(
+                    FeedingTodaySelectEntity(
+                        device, hub, "feeding_plan_today_select", "Today's Feeding Plan"
+                    )
+                )
 
     if not entities:
         _LOGGER.warning("No select entities added, entities list is empty!")

--- a/custom_components/petlibro/select.py
+++ b/custom_components/petlibro/select.py
@@ -503,12 +503,12 @@ async def async_setup_entry(
             if hasattr(device, "feeding_plan_data"):
                 entities.append(
                     FeedingScheduleSelectEntity(
-                        device, hub, "feeding_plan_select", "Feeding Plan"
+                        device, hub, "feeding_plan_select", "Feeding Schedule"
                     )
                 )
                 entities.append(
                     FeedingTodaySelectEntity(
-                        device, hub, "feeding_plan_today_select", "Today's Feeding Plan"
+                        device, hub, "feeding_plan_today_select", "Today's Feeding Schedule"
                     )
                 )
 

--- a/custom_components/petlibro/sensor.py
+++ b/custom_components/petlibro/sensor.py
@@ -60,7 +60,6 @@ class PetLibroSensorEntity(PetLibroEntity[_DeviceT], SensorEntity):
         """Initialize the sensor."""
         super().__init__(device, hub, description)
         
-        # Ensure unique_id includes the device serial, specific sensor key, and the MAC address from the device attributes
         mac_address = getattr(device, "mac", None)
         if mac_address:
             self._attr_unique_id = f"{device.serial}-{description.key}-{mac_address.replace(':', '')}"
@@ -71,38 +70,21 @@ class PetLibroSensorEntity(PetLibroEntity[_DeviceT], SensorEntity):
             device_class = self.entity_description.device_class
             self.hub.unit_entities.unique_ids[unit_type][Platform.SENSOR][device_class].append(self._attr_unique_id)
         
-        # Dictionary to keep track of the last known state for each sensor key
         self._last_sensor_state = {}
 
     @property
     def native_value(self) -> float | datetime | str | None:
         """Return the state."""        
         match self.key:
-            case "feeding_plan_state":
-                # Handle feeding_plan_state as "On" or "Off"
-                feeding_plan_active = getattr(self.device, self.key, False)
-                # Log only if the state has changed
-                if self._last_sensor_state.get(self.key) != feeding_plan_active:
-                    _LOGGER.debug(f"Raw {self.key} for device {self.device.serial}: {feeding_plan_active}")
-                    self._last_sensor_state[self.key] = feeding_plan_active
-                return "On" if feeding_plan_active else "Off"
             case "today_eating_time":
-                # Handle today_eating_time as raw seconds value
-                eating_time_seconds = getattr(self.device, self.key, 0)
-                return eating_time_seconds
+                return getattr(self.device, self.key, 0)
             case "today_drinking_time":
-                # Handle today_drinking_time as raw seconds value
-                drinking_time_seconds = getattr(self.device, self.key, 0)
-                return drinking_time_seconds
+                return getattr(self.device, self.key, 0)
             case "today_avg_time":
-                today_avg_time_seconds = getattr(self.device, self.key, 0)
-                return today_avg_time_seconds
+                return getattr(self.device, self.key, 0)
             case "yesterday_drinking_time":
-                # Handle yesterday_drinking_time as raw seconds value
-                yesterday_drinking_time_seconds = getattr(self.device, self.key, 0)
-                return yesterday_drinking_time_seconds
+                return getattr(self.device, self.key, 0)
             case "wifi_rssi":
-                # Handle wifi_rssi to display only the numeric value
                 wifi_rssi = getattr(self.device, self.key, None)
                 if wifi_rssi is not None:
                     if self._last_sensor_state.get(self.key) != wifi_rssi:
@@ -128,10 +110,8 @@ class PetLibroSensorEntity(PetLibroEntity[_DeviceT], SensorEntity):
                     getattr(self.device, key.removesuffix("_volume"), 0) * self.device.feed_conv_factor, 
                     None, Unit.MILLILITERS, True)
             case _:
-                # Default behavior for other sensors
                 if self.entity_description.should_report(self.device):
                     val = getattr(self.device, self.key, None)
-                    # Log only if the state has changed
                     if self._last_sensor_state.get(self.key) != val:
                         _LOGGER.debug(f"Raw {self.key} for device {self.device.serial}: {val}")
                         self._last_sensor_state[self.key] = val
@@ -148,36 +128,30 @@ class PetLibroSensorEntity(PetLibroEntity[_DeviceT], SensorEntity):
         """Return the native unit of measurement to use in the frontend, if any."""
         match self.key:
             case "temperature":
-                # For temperature, display as Fahrenheit
                 return "°F"
             case key if key in (
                 "today_eating_time", 
                 "today_drinking_time", 
                 "today_avg_time"
             ):
-                # For today_eating_time, display as seconds in the frontend
                 return UnitOfTime.SECONDS
             case key if key in (
                 "remaining_cleaning_days", 
                 "remaining_filter_days", 
                 "remaining_desiccant"
             ):
-                # For remaining_desiccant, remaining_cleaning_days & remaining_filter_days, display as days in the frontend
                 return UnitOfTime.DAYS
             case "wifi_rssi":
-                # For wifi_rssi, display as dBm
                 return SIGNAL_STRENGTH_DECIBELS_MILLIWATT
             case key if key in (
                 "use_water_interval", 
                 "use_water_duration"
             ):
-                # For use_water_interval and use_water_duration, display as minutes
                 return UnitOfTime.MINUTES
             case key if key in (
                 "weight_percent", 
                 "electric_quantity"
             ):
-                # For weight_percent, display as a percentage
                 return PERCENTAGE
             case key if key in (
                 "remaining_water", 
@@ -232,22 +206,6 @@ class PetLibroSensorEntity(PetLibroEntity[_DeviceT], SensorEntity):
     def extra_state_attributes(self):
         """Return entity specific state attributes."""        
         match self.key:
-            case "feeding_plan_state":
-                plans = self.device.feeding_plan_today_data.get("plans", [])
-                unit = self.member.feedUnitType
-                weight = unit if unit in (Unit.GRAMS, Unit.OUNCES) else Unit.GRAMS
-                volume = unit if unit in (Unit.MILLILITERS, Unit.CUPS) else Unit.MILLILITERS           
-                return {
-                    self.device.feeding_plan_data.get(str(plan["planId"]), {}).get("label") or f"plan_{plan['index']}": {
-                        "time": plan["time"],
-                        "amount (weight)": f"{Unit.convert_feed(plan['grainNum'] * self.device.feed_conv_factor, None, weight, True)} {weight.symbol}",
-                        "amount (volume)": f"{Unit.convert_feed(plan['grainNum'] * self.device.feed_conv_factor, None, volume, True)} {volume.symbol}",
-                        "state": {1: "Pending", 2: "Skipped", 3: "Completed", 4: "Skipped, Time Passed"}.get(plan["state"], "Unknown"),
-                        "repeat": plan["repeat"],
-                        "planID": plan["planId"]
-                    }
-                    for plan in plans
-                }
             case "next_feed_time":
                 next_feed = self.device.get_next_feed
                 next_feed_data = self.device.feeding_plan_data.get(str(next_feed.get("id")), {})
@@ -286,7 +244,7 @@ class PetLibroSensorEntity(PetLibroEntity[_DeviceT], SensorEntity):
                 return { 
                     unit.symbol: VolumeConverter.convert(getattr(self.device, key, 0), UnitOfVolume.MILLILITERS, unit.symbol)
                     for unit in VALID_UNIT_TYPES[API.WATER_UNIT] if unit
-                }                
+                }
         return super().extra_state_attributes
 
 DEVICE_SENSOR_MAP: dict[type[Device], list[PetLibroSensorEntityDescription]] = {
@@ -320,13 +278,6 @@ DEVICE_SENSOR_MAP: dict[type[Device], list[PetLibroSensorEntityDescription]] = {
             device_class=SensorDeviceClass.BATTERY,
             state_class=SensorStateClass.MEASUREMENT,
             name="Battery / AC %"
-        ),
-        PetLibroSensorEntityDescription[AirSmartFeeder](
-            key="feeding_plan_state",
-            translation_key="feeding_plan_state",
-            icon="mdi:calendar-check",
-            name="Feeding Plan State",
-            should_report=lambda device: device.feeding_plan_state is not None,
         ),
         PetLibroSensorEntityDescription[AirSmartFeeder](
             key="today_feeding_quantity_weight",
@@ -408,7 +359,7 @@ DEVICE_SENSOR_MAP: dict[type[Device], list[PetLibroSensorEntityDescription]] = {
             translation_key="child_lock_switch",
             icon="mdi:lock",
             name="Buttons Lock"
-        ),
+        )
     ],
     GranarySmartFeeder: [
         PetLibroSensorEntityDescription[GranarySmartFeeder](
@@ -449,13 +400,6 @@ DEVICE_SENSOR_MAP: dict[type[Device], list[PetLibroSensorEntityDescription]] = {
             name="Battery / AC %"
         ),
         PetLibroSensorEntityDescription[GranarySmartFeeder](
-            key="feeding_plan_state",
-            translation_key="feeding_plan_state",
-            icon="mdi:calendar-check",
-            name="Feeding Plan State",
-            should_report=lambda device: device.feeding_plan_state is not None,
-        ),
-        PetLibroSensorEntityDescription[GranarySmartFeeder](
             key="today_feeding_quantity_weight",
             translation_key="today_feeding_quantity_weight",
             name="Today Feeding Quantity (Weight)",
@@ -535,7 +479,7 @@ DEVICE_SENSOR_MAP: dict[type[Device], list[PetLibroSensorEntityDescription]] = {
             translation_key="child_lock_switch",
             icon="mdi:lock",
             name="Buttons Lock"
-        ),
+        )
     ],
     GranarySmartCameraFeeder: [
         PetLibroSensorEntityDescription[GranarySmartCameraFeeder](
@@ -574,13 +518,6 @@ DEVICE_SENSOR_MAP: dict[type[Device], list[PetLibroSensorEntityDescription]] = {
             device_class=SensorDeviceClass.BATTERY,
             state_class=SensorStateClass.MEASUREMENT,
             name="Battery / AC %"
-        ),
-        PetLibroSensorEntityDescription[GranarySmartCameraFeeder](
-            key="feeding_plan_state",
-            translation_key="feeding_plan_state",
-            icon="mdi:calendar-check",
-            name="Feeding Plan State",
-            should_report=lambda device: device.feeding_plan_state is not None,
         ),
         PetLibroSensorEntityDescription[GranarySmartCameraFeeder](
             key="today_feeding_quantity_weight",
@@ -675,29 +612,29 @@ DEVICE_SENSOR_MAP: dict[type[Device], list[PetLibroSensorEntityDescription]] = {
             translation_key="night_vision",
             icon="mdi:weather-night",
             name="Night Vision Mode",
-            should_report=lambda device: device.night_vision is not None  # Corrected name
+            should_report=lambda device: device.night_vision is not None
         ),
         PetLibroSensorEntityDescription[GranarySmartCameraFeeder](
             key="enable_video_record",
             translation_key="enable_video_record",
             icon="mdi:video",
             name="Video Recording Enabled",
-            should_report=lambda device: device.enable_video_record is not None  # Corrected name
+            should_report=lambda device: device.enable_video_record is not None
         ),
         PetLibroSensorEntityDescription[GranarySmartCameraFeeder](
             key="video_record_switch",
             translation_key="video_record_switch",
             icon="mdi:video-outline",
             name="Video Recording Switch",
-            should_report=lambda device: device.video_record_switch is not None  # Corrected name
+            should_report=lambda device: device.video_record_switch is not None
         ),
         PetLibroSensorEntityDescription[GranarySmartCameraFeeder](
             key="video_record_mode",
             translation_key="video_record_mode",
             icon="mdi:motion-sensor",
             name="Video Recording Mode",
-            should_report=lambda device: device.video_record_mode is not None  # Corrected name
-        ),
+            should_report=lambda device: device.video_record_mode is not None
+        )
     ],
     OneRFIDSmartFeeder: [
         PetLibroSensorEntityDescription[OneRFIDSmartFeeder](
@@ -736,13 +673,6 @@ DEVICE_SENSOR_MAP: dict[type[Device], list[PetLibroSensorEntityDescription]] = {
             device_class=SensorDeviceClass.BATTERY,
             state_class=SensorStateClass.MEASUREMENT,
             name="Battery / AC %"
-        ),
-        PetLibroSensorEntityDescription[OneRFIDSmartFeeder](
-            key="feeding_plan_state",
-            translation_key="feeding_plan_state",
-            icon="mdi:calendar-check",
-            name="Feeding Plan State",
-            should_report=lambda device: device.feeding_plan_state is not None,
         ),
         PetLibroSensorEntityDescription[OneRFIDSmartFeeder](
             key="today_feeding_quantity_weight",
@@ -869,13 +799,6 @@ DEVICE_SENSOR_MAP: dict[type[Device], list[PetLibroSensorEntityDescription]] = {
             name="Battery / AC %"
         ),
         PetLibroSensorEntityDescription[PolarWetFoodFeeder](
-            key="feeding_plan_state",
-            translation_key="feeding_plan",
-            icon="mdi:calendar-check",
-            name="Feeding Plan",
-            should_report=lambda device: device.feeding_plan_state is not None,
-        ),
-        PetLibroSensorEntityDescription[PolarWetFoodFeeder](
             key="next_feeding_day",
             translation_key="next_feeding_day",
             icon="mdi:calendar-clock",
@@ -938,13 +861,6 @@ DEVICE_SENSOR_MAP: dict[type[Device], list[PetLibroSensorEntityDescription]] = {
             device_class=SensorDeviceClass.BATTERY,
             state_class=SensorStateClass.MEASUREMENT,
             name="Battery / AC %"
-        ),
-        PetLibroSensorEntityDescription[SpaceSmartFeeder](
-            key="feeding_plan_state",
-            translation_key="feeding_plan_state",
-            icon="mdi:calendar-check",
-            name="Feeding Plan State",
-            should_report=lambda device: device.feeding_plan_state is not None,
         ),
         PetLibroSensorEntityDescription[SpaceSmartFeeder](
             key="today_feeding_quantity_weight",
@@ -1592,22 +1508,18 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up PETLIBRO sensors using config entry."""
-    # Retrieve the hub from hass.data that was set up in __init__.py
     hub: PetLibroHub = hass.data[DOMAIN].get(entry.entry_id)
 
     if not hub:
         _LOGGER.error("Hub not found for entry: %s", entry.entry_id)
         return
 
-    # Ensure that the member is loaded
     if not (member := hub.member):
         _LOGGER.warning("No member found in hub during sensor setup.")
 
-    # Ensure that the devices are loaded
     if not (devices := hub.devices):
         _LOGGER.warning("No devices found in hub during sensor setup.")
 
-    # Ensure that the pets are loaded
     if not (pets := hub.pets):
         _LOGGER.warning("No pets found in hub during sensor setup.")
 
@@ -1617,17 +1529,13 @@ async def async_setup_entry(
     entities = []
 
     if devices:
-        # Log the contents of the hub data for debugging
         _LOGGER.debug("Hub data: %s", hub)
-
-        # Devices should already be loaded in the hub
         _LOGGER.debug("Devices in hub: %s", devices)
 
-        # Create sensor entities for each device based on the sensor map
         entities.extend(
             [
                 PetLibroSensorEntity(device, hub, description)
-                for device in devices.values()  # Iterate through devices from the hub
+                for device in devices.values()
                 for device_type, entity_descriptions in DEVICE_SENSOR_MAP.items()
                 if isinstance(device, device_type)
                 for description in entity_descriptions
@@ -1637,7 +1545,6 @@ async def async_setup_entry(
     if not entities:
         _LOGGER.warning("No device sensors added, entities list is empty!")
     else:
-        # Log the number of entities and their details
         _LOGGER.debug("Adding %d PetLibro sensors", len(entities))
         for entity in entities:
             _LOGGER.debug(
@@ -1646,7 +1553,6 @@ async def async_setup_entry(
                 entity.device.name,
             )
 
-    # Create Member sensor entity for front-end use.
     if member:
         entities.append(MemberEntity(member))
         _LOGGER.debug("Adding sensor entity for Petlibro member: %s", member.email)
@@ -1656,5 +1562,4 @@ async def async_setup_entry(
             entities.extend(pet.entities(PL_PetSensorEntity, hub))
 
     if entities:
-        # Add sensor entities to Home Assistant
         async_add_entities(entities)

--- a/custom_components/petlibro/services.py
+++ b/custom_components/petlibro/services.py
@@ -1,0 +1,140 @@
+"""PETLIBRO feeding plan services."""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.exceptions import ServiceValidationError
+from homeassistant.helpers import device_registry as dr
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+# Service names
+SERVICE_EDIT_FEEDING_PLAN = "edit_feeding_plan"
+SERVICE_ADD_FEEDING_PLAN  = "add_feeding_plan"
+
+# Field keys
+_DEVICE_ID = "device_id"
+_PLAN_ID   = "plan_id"
+_TIME      = "time"
+_PORTIONS  = "portions"
+_LABEL     = "label"
+_DAYS      = "days"
+_SOUND     = "sound"
+
+
+def _get_feeder(hass: HomeAssistant, device_id: str):
+    """Resolve a HA device_id to a PetLibro feeder device instance."""
+    dev_reg = dr.async_get(hass)
+    device_entry = dev_reg.async_get(device_id)
+    if not device_entry:
+        raise ServiceValidationError(
+            "Device not found. Please select a dry food feeder."
+        )
+
+    serial = next(
+        (identifier[1] for identifier in device_entry.identifiers if identifier[0] == DOMAIN),
+        None,
+    )
+    if not serial:
+        raise ServiceValidationError(
+            "Selected device is not a PETLIBRO device. Please select a dry food feeder."
+        )
+
+    for _, hub in hass.data.get(DOMAIN, {}).items():
+        device = hub.devices.get(serial)
+        if device is not None:
+            if not hasattr(device, "feeding_plan_data"):
+                raise ServiceValidationError(
+                    f"{device.name} does not support feeding plan services. "
+                    "Please select a dry food feeder, not a pet or fountain."
+                )
+            return device
+
+    raise ServiceValidationError(
+        "Selected device is not a dry food feeder, or is not currently loaded."
+    )
+
+
+async def async_setup_services(hass: HomeAssistant) -> None:
+    """Register PETLIBRO feeding plan services."""
+    if hass.services.has_service(DOMAIN, SERVICE_ADD_FEEDING_PLAN):
+        return  # Already registered
+
+    # ------------------------------------------------------------------
+    # edit_feeding_plan
+    # ------------------------------------------------------------------
+    async def handle_edit_feeding_plan(call: ServiceCall) -> None:
+        device = _get_feeder(hass, call.data[_DEVICE_ID])
+        plan_id: int = call.data[_PLAN_ID]
+
+        existing = device.feeding_plan_data.get(str(plan_id))
+        if not existing:
+            raise ServiceValidationError(
+                f"Plan ID {plan_id} not found on {device.name}. "
+                "Check the Feeding Schedule sensor attributes for valid plan IDs."
+            )
+
+        if (label := call.data.get(_LABEL, "")):
+            if " " in label:
+                raise ServiceValidationError(
+                    "Label cannot contain spaces. Use something like 'MorningFeed' instead."
+                )
+
+        payload: dict[str, Any] = {**existing, "id": plan_id}
+        if (v := call.data.get(_TIME)) is not None:
+            payload["executionTime"] = v[:5]
+        if (v := call.data.get(_PORTIONS)) is not None:
+            payload["grainNum"] = v
+        if (v := call.data.get(_LABEL)) is not None:
+            payload["label"] = v
+        if (v := call.data.get(_DAYS)) is not None:
+            payload["repeatDay"] = "[" + ",".join(str(int(d)) for d in v) + "]"
+        if (v := call.data.get(_SOUND)) is not None:
+            payload["enableAudio"] = v
+
+        await device.api.feeding_plan_update(device.serial, payload)
+        await device.refresh()
+        _LOGGER.debug("Edited feeding plan %d on %s", plan_id, device.name)
+
+    hass.services.async_register(DOMAIN, SERVICE_EDIT_FEEDING_PLAN, handle_edit_feeding_plan)
+
+    # ------------------------------------------------------------------
+    # add_feeding_plan
+    # ------------------------------------------------------------------
+    async def handle_add_feeding_plan(call: ServiceCall) -> None:
+        device = _get_feeder(hass, call.data[_DEVICE_ID])
+
+        if (label := call.data.get(_LABEL, "")):
+            if " " in label:
+                raise ServiceValidationError(
+                    "Label cannot contain spaces. Use something like 'MorningFeed' instead."
+                )
+
+        payload: dict[str, Any] = {
+            "executionTime": call.data[_TIME][:5],
+            "grainNum": call.data[_PORTIONS],
+            "label": call.data.get(_LABEL, ""),
+            "repeatDay": "[" + ",".join(str(int(d)) for d in call.data.get(_DAYS, [])) + "]",
+            "enableAudio": call.data.get(_SOUND, False),
+        }
+        await device.api.feeding_plan_add(device.serial, payload)
+        await device.refresh()
+        _LOGGER.debug("Added new feeding plan on %s", device.name)
+
+    hass.services.async_register(DOMAIN, SERVICE_ADD_FEEDING_PLAN, handle_add_feeding_plan)
+
+    _LOGGER.debug("PETLIBRO feeding plan services registered.")
+
+
+async def async_unload_services(hass: HomeAssistant) -> None:
+    """Remove PETLIBRO feeding plan services when the integration is unloaded."""
+    for service in (
+        SERVICE_EDIT_FEEDING_PLAN,
+        SERVICE_ADD_FEEDING_PLAN,
+    ):
+        hass.services.async_remove(DOMAIN, service)
+    _LOGGER.debug("PETLIBRO feeding plan services removed.")

--- a/custom_components/petlibro/services.yaml
+++ b/custom_components/petlibro/services.yaml
@@ -1,0 +1,137 @@
+edit_feeding_plan:
+  name: Edit Feeding Plan
+  description: >
+    Edit an existing scheduled feeding plan on a dry food feeder.
+    Only the fields you provide will be changed — anything left blank keeps its current value.
+    Find the Plan ID in the feeder's Feeding Schedule sensor attributes.
+  fields:
+    device_id:
+      name: Device
+      description: The feeder to target.
+      required: true
+      selector:
+        device:
+          integration: petlibro
+    plan_id:
+      name: Plan ID
+      description: >
+        The ID of the plan to edit. Find this in the feeder's
+        Feeding Schedule sensor attributes (planID field).
+      required: true
+      selector:
+        number:
+          min: 1
+          max: 99999999
+          mode: box
+    time:
+      name: Time
+      description: "New feed time (e.g. 08:00)."
+      required: false
+      selector:
+        time:
+    portions:
+      name: Portions
+      description: Number of portions to dispense (1–48).
+      required: false
+      selector:
+        number:
+          min: 1
+          max: 48
+          mode: box
+    label:
+      name: Label
+      description: "A name for this feeding plan. No spaces allowed (e.g. MorningFeed)."
+      required: false
+      example: "MorningFeed"
+      selector:
+        text:
+    days:
+      name: Repeat Days
+      description: Days of the week to repeat. Leave empty to keep existing days.
+      required: false
+      selector:
+        select:
+          multiple: true
+          options:
+            - label: Monday
+              value: "1"
+            - label: Tuesday
+              value: "2"
+            - label: Wednesday
+              value: "3"
+            - label: Thursday
+              value: "4"
+            - label: Friday
+              value: "5"
+            - label: Saturday
+              value: "6"
+            - label: Sunday
+              value: "7"
+    sound:
+      name: Meal Call Sound
+      description: Play the meal call sound when dispensing.
+      required: false
+      selector:
+        boolean:
+
+add_feeding_plan:
+  name: Add Feeding Plan
+  description: Add a new scheduled feeding plan to a dry food feeder.
+  fields:
+    device_id:
+      name: Device
+      description: The feeder to target.
+      required: true
+      selector:
+        device:
+          integration: petlibro
+    time:
+      name: Time
+      description: "Feed time (e.g. 08:00)."
+      required: true
+      selector:
+        time:
+    portions:
+      name: Portions
+      description: Number of portions to dispense (1–48).
+      required: true
+      selector:
+        number:
+          min: 1
+          max: 48
+          mode: box
+    label:
+      name: Label
+      description: "A name for this feeding plan. No spaces allowed (e.g. MorningFeed)."
+      required: false
+      example: "MorningFeed"
+      selector:
+        text:
+    days:
+      name: Repeat Days
+      description: Days of the week to repeat. Leave empty for a one-time feed.
+      required: false
+      selector:
+        select:
+          multiple: true
+          options:
+            - label: Monday
+              value: "1"
+            - label: Tuesday
+              value: "2"
+            - label: Wednesday
+              value: "3"
+            - label: Thursday
+              value: "4"
+            - label: Friday
+              value: "5"
+            - label: Saturday
+              value: "6"
+            - label: Sunday
+              value: "7"
+    sound:
+      name: Meal Call Sound
+      description: Play the meal call sound when dispensing.
+      required: false
+      selector:
+        boolean:

--- a/custom_components/petlibro/translations/en.json
+++ b/custom_components/petlibro/translations/en.json
@@ -430,10 +430,10 @@
                 "name": "Water Dispensing State"
             },
             "feeding_plan_state": {
-                "name": "Feeding Schedule"
+                "name": "Today's Feeding Schedule"
             },
             "feeding_schedule": {
-                "name": "Today's Feeding Schedule"
+                "name": "Feeding Schedule"
             }
         },
         "number": {
@@ -506,10 +506,10 @@
                 "name": "Manual Feed Quantity"
             },
             "feeding_plan_select": {
-                "name": "Feeding Plan"
+                "name": "Feeding Schedule"
             },
             "feeding_plan_today_select": {
-                "name": "Today's Feeding Plan"
+                "name": "Today's Feeding Schedule"
             },
             "vacuum_mode": {
                 "name": "Vacuum Mode"

--- a/custom_components/petlibro/translations/en.json
+++ b/custom_components/petlibro/translations/en.json
@@ -434,7 +434,7 @@
             },
             "feeding_schedule": {
                 "name": "Today's Feeding Schedule"
-            },
+            }
         },
         "number": {
             "sound_level": {

--- a/custom_components/petlibro/translations/en.json
+++ b/custom_components/petlibro/translations/en.json
@@ -430,11 +430,11 @@
                 "name": "Water Dispensing State"
             },
             "feeding_plan_state": {
-                "name": "Feeding Plan"
+                "name": "Feeding Schedule"
             },
             "feeding_schedule": {
-                "name": "Feeding Schedule"
-            }
+                "name": "Today's Feeding Schedule"
+            },
         },
         "number": {
             "sound_level": {

--- a/custom_components/petlibro/translations/en.json
+++ b/custom_components/petlibro/translations/en.json
@@ -165,9 +165,6 @@
             "next_feed_quantity_volume": {
                 "name": "Next Feed Quantity (Volume)"
             },
-            "feeding_plan_state": {
-                "name": "Today's Feeding Plan"
-            },
             "today_drinking_amount": {
                 "name": "Today's Water Consumption"
             },
@@ -215,9 +212,6 @@
             },
             "next_feeding_end_time": {
                 "name": "Feeding Ends"
-            },
-            "feeding_plan": {
-                "name": "Feeding Plan"
             },
             "temperature": {
                 "name": "Temperature"
@@ -317,10 +311,10 @@
                 "name": "Manual Cleaning"
             },
             "enable_feeding_plan": {
-                "name": "Enable Feeding Plan"
+                "name": "Enable Feeding Schedule"
             },
             "disable_feeding_plan": {
-                "name": "Disable Feeding Plan"
+                "name": "Disable Feeding Schedule"
             },
             "manual_lid_open": {
                 "name": "Manually Open Lid"
@@ -366,6 +360,27 @@
             },
             "filter_reset": {
                 "name": "Filter Reset"
+            },
+            "feeding_plan_enable": {
+                "name": "Enable Selected Plan"
+            },
+            "feeding_plan_disable": {
+                "name": "Disable Selected Plan"
+            },
+            "feeding_plan_delete": {
+                "name": "Delete Selected Plan"
+            },
+            "feeding_plan_skip_today": {
+                "name": "Skip Selected Plan Today"
+            },
+            "feeding_plan_unskip_today": {
+                "name": "Un-skip Selected Plan Today"
+            },
+            "feeding_plan_today_enable_all": {
+                "name": "Enable Today's Feeding Schedule"
+            },
+            "feeding_plan_today_disable_all": {
+                "name": "Disable Today's Feeding Schedule"
             }
         },
         "binary_sensor": {
@@ -413,6 +428,12 @@
             },
             "water_state": {
                 "name": "Water Dispensing State"
+            },
+            "feeding_plan_state": {
+                "name": "Feeding Plan"
+            },
+            "feeding_schedule": {
+                "name": "Feeding Schedule"
             }
         },
         "number": {
@@ -483,6 +504,15 @@
             },
             "manual_feed_quantity_cups": {
                 "name": "Manual Feed Quantity"
+            },
+            "feeding_plan_select": {
+                "name": "Feeding Plan"
+            },
+            "feeding_plan_today_select": {
+                "name": "Today's Feeding Plan"
+            },
+            "vacuum_mode": {
+                "name": "Vacuum Mode"
             },
             "pet_sex": {
                 "name": "Sex",


### PR DESCRIPTION
<!--
Before opening this pull request please review the guidelines in the checklist below. If this PR does not meet those guidelines it will not be accepted, and everyone will be sad.

Please include a summary of the change. Screenshots and/or videos can also be helpful if appropriate. New devices or enhancements should include example(s) of relevant information.
-->

## Proposed change:

Closes #26, Closes #79, Closes #195, Closes #196

This PR adds full feeding plan management for all dry food feeders, including the ability to add, edit, enable, disable, skip, and delete individual scheduled feeding plans directly from Home Assistant.

---

### Services

Two new services have been added:

**`petlibro.add_feeding_plan`** — Add a new scheduled feeding plan to a dry food feeder. Takes a device target, feed time, number of portions, an optional label, optional repeat days, and an optional meal call sound toggle.

<img width="1223" height="836" alt="Screenshot 2026-03-29 171358" src="https://github.com/user-attachments/assets/eb6d9574-c07f-41ca-ab4d-a83035eb8aaa" />

**`petlibro.edit_feeding_plan`** — Edit an existing scheduled feeding plan on a dry food feeder. Only the fields you provide will be changed — anything left blank keeps its current value. The Plan ID can be found in the feeder's Feeding Schedule binary sensor attributes OR in the new select entity, where it is named "Label - Plan ID".

<img width="1223" height="941" alt="Screenshot 2026-03-29 171323" src="https://github.com/user-attachments/assets/e0684c5d-5e58-4e14-a4bf-a46ba5a45aeb" />

> **Note on portions:** Both services use raw portions rather than the user-configured unit. Services dont support dynamically changing the UOM based on the integration settings - we would have no way to replace the slider with a dropdown for the cups for example.

---

### Select Entities

Two new select entities are added per dry feeder:

- **Feeding Schedule** (`feeding_plan_select`) — Lists all plans in the recurring schedule. Used to target a specific plan for the enable, disable, and delete buttons.
- **Today's Feeding Schedule** (`feeding_plan_today_select`) — Lists only today's scheduled feeds. Used to target a specific plan for the skip and un-skip buttons.

<img width="312" height="280" alt="Screenshot 2026-03-29 170911" src="https://github.com/user-attachments/assets/37104d26-3d2b-4bb8-944c-6c88edb789cd" />
<img width="321" height="154" alt="Screenshot 2026-03-29 170921" src="https://github.com/user-attachments/assets/698cac5f-c53d-407e-ab3a-75bc41a1cc06" />

---

### Button Entities

Seven new button entities are added per dry feeder for direct control of the schedule:

| Button | Description |
|---|---|
| **Enable Selected Plan** | Enables the plan currently selected in the Feeding Schedule selector |
| **Disable Selected Plan** | Disables the plan currently selected in the Feeding Schedule selector |
| **Delete Selected Plan** | Permanently removes the plan currently selected in the Feeding Schedule selector |
| **Skip Selected Plan Today** | Skips the plan currently selected in Today's Feeding Schedule selector for today only |
| **Un-skip Selected Plan Today** | Restores a previously skipped plan in Today's Feeding Schedule selector |
| **Enable Today's Feeding Schedule** | Enables all feeding plan events for today |
| **Disable Today's Feeding Schedule** | Disables all feeding plan events for today |
> **Note on skip + un-skip:** These will give formatted responses directly from the API if you are trying to skip an event that has already passed. "Failed to perform the action button/press. Code: 1217, Message: FEEDING_PLAN_HAS_EXPIRED". didnt feel that it was neccesary to give a custom error message, as i though this was clear enough already.


<img width="321" height="54" alt="Screenshot 2026-03-29 171011" src="https://github.com/user-attachments/assets/03fd008c-6e1f-42d5-be2b-fd66e4de5ffc" />
<img width="315" height="51" alt="Screenshot 2026-03-29 171022" src="https://github.com/user-attachments/assets/1f7dba04-7a99-4f93-b781-e82e884f6f7a" />
<img width="322" height="46" alt="Screenshot 2026-03-29 171033" src="https://github.com/user-attachments/assets/ffc71797-3f1e-425e-a5be-91f8580fe65f" />
<img width="323" height="53" alt="Screenshot 2026-03-29 171043" src="https://github.com/user-attachments/assets/fa44e89e-6836-4fc7-9509-1264981dc1db" />
<img width="309" height="50" alt="Screenshot 2026-03-29 171059" src="https://github.com/user-attachments/assets/27b30359-aa0e-444c-9da9-3b2ff271dec8" />
<img width="314" height="50" alt="Screenshot 2026-03-29 171111" src="https://github.com/user-attachments/assets/fa42c93b-57ea-40c4-a83f-981811044501" />
<img width="314" height="46" alt="Screenshot 2026-03-29 171123" src="https://github.com/user-attachments/assets/f5f584d2-1450-4b60-a87b-83a7a90d2c51" />
<img width="310" height="42" alt="Screenshot 2026-03-29 171135" src="https://github.com/user-attachments/assets/cc50c3ab-dc50-49da-b23f-f9865bfde356" />

---

### Binary Sensor Entities

The existing `feeding_plan_state` and `feeding_schedule` sensors have been converted from sensors to **binary sensors** (`on` = schedule globally enabled, `off` = disabled):

- **Feeding Schedule** (`feeding_plan_state`) — State reflects whether the feeding schedule is globally enabled. Attributes contain today's scheduled feeds with formatted weight and volume amounts, and their current status (Pending / Skipped / Completed).
- **Today's Feeding Schedule** (`feeding_schedule`) — Same on/off state. Attributes contain the full recurring schedule with time, portions, repeat days, and sound settings.

<img width="565" height="184" alt="Screenshot 2026-03-29 170943" src="https://github.com/user-attachments/assets/3e5dc18a-96a7-4720-add9-6baf73d648ff" />
<img width="553" height="171" alt="Screenshot 2026-03-29 170957" src="https://github.com/user-attachments/assets/c909293e-f833-4156-9fc2-383cfbda6d77" />

---

### Entity Naming

As part of this PR, all entity **friendly names** that refer to the entire set of planned feeds have been updated to use the word **"Schedule"**, while individual planned feed events are referred to as a **"Plan"**. The rationale:

- A **plan** is a single scheduled feed event.
- A **schedule** is the full collection of plans.

This distinction was necessary given the number of new controls — users now interact with both the schedule as a whole and individual plans within it, so clear naming avoids confusion.

> **Important:** This is a breaking change for people who are acting on the schedule sensor, unlikely, but possible, as it is now a binary_sensor.

---

## Type of change:
- [ ] New device.
- [ ] Bug fix (non-breaking change which fixes an issue).
- [X] New feature or enhancement (non-breaking change which adds functionality).
- [ ] Documentation only.
- [ ] Other (please explain).

## Checklist:
- [X] If applicable, I have added corresponding documentation changes.
- [X] If applicable, I have reviewed the [feature / enhancement](https://github.com/jjjonesjr33/petlibro/wiki/Feature-&-Enhancement-Guidelines) guidelines before submitting my request.
- [X] If applicable, I have tested my code for new features & regressions on the latest version of Home Assistant.

## Additional notes: