### PR TITLE
Feature/Per-Pet RFID Fountain Drinking Sensors (#92)

### DIFF
--- a/custom_components/petlibro/api.py
+++ b/custom_components/petlibro/api.py
@@ -562,6 +562,30 @@ class PetLibroAPI:
         _LOGGER.debug("Bound pets retrieved successfully")
         return data or []
 
+    async def device_wear_list(self, device_sn: str) -> list[dict]:
+        """Get wear/RFID data for pets bound to a device, with caching."""
+        now = utcnow()
+        cache_key = f"{device_sn}_wearListV2"
+        last_call_time = self._last_api_call_times.get(cache_key)
+
+        if last_call_time and (now - last_call_time) < timedelta(seconds=10):
+            _LOGGER.debug(f"Skipping wearListV2 request for {device_sn}, using cached response.")
+            return self._cached_responses.get(cache_key, [])
+
+        try:
+            response = await self.session.request("POST", "/device/device/wear/wearListV2", json={
+                "deviceSn": device_sn,
+                "type": 1
+            })
+
+            self._last_api_call_times[cache_key] = now
+            self._cached_responses[cache_key] = response if isinstance(response, list) else []
+
+            return self._cached_responses[cache_key]
+        except Exception as e:
+            _LOGGER.error(f"Error fetching wearListV2 for device {device_sn}: {e}")
+            raise PetLibroAPIError(f"Error fetching wearListV2 for device {device_sn}: {e}")
+
     # Support for new switch functions
     async def set_feeding_plan(self, serial: str, enable: bool):
         """Set the feeding plan on/off."""

--- a/custom_components/petlibro/pets/__init__.py
+++ b/custom_components/petlibro/pets/__init__.py
@@ -63,10 +63,35 @@ class Pet(Event):
         """Refresh the pet info from the API."""
         pet_details = await self.api.pets.get_details(self.id)
         bound_devices = await self.api.pets.get_bound_devices(self.id)
+
+        # Fetch per-pet drinking data from RFID fountains
+        fountain_drinking = {"todayFountainDrinkingCount": 0,
+                             "todayFountainDrinkingAmount": 0,
+                             "todayFountainDrinkingTime": 0}
+        rfid_fountains = [
+            d for d in (bound_devices or [])
+            if d.get("productName") == "Dockstream Smart RFID Fountain"
+        ]
+        for fountain in rfid_fountains:
+            device_sn = fountain.get("deviceSn")
+            if not device_sn:
+                continue
+            try:
+                wear_list = await self.api.device_wear_list(device_sn)
+                for entry in wear_list:
+                    if entry.get("petId") == self.id:
+                        fountain_drinking["todayFountainDrinkingCount"] += (entry.get("todayDrinkTimes") or 0)
+                        fountain_drinking["todayFountainDrinkingAmount"] += (entry.get("todayDrinkAmount") or 0)
+                        fountain_drinking["todayFountainDrinkingTime"] += (entry.get("petEatingTime") or 0)
+                        break
+            except Exception:
+                _LOGGER.warning("Failed to fetch wearListV2 for fountain %s", device_sn)
+
         self.update_data(
             {
                 **pet_details,
                 "boundDevices": bound_devices,
+                **fountain_drinking,
             }
         )
 
@@ -298,3 +323,20 @@ class Pet(Event):
     def walkingGoal(self) -> float:
         """Walking goal of pet in minutes per day."""
         return self._data.get("walkingGoal") or 0
+
+    # --- Fountain Drinking (from wearListV2)
+
+    @property
+    def today_fountain_drinking_count(self) -> int:
+        """Number of drinking sessions at RFID fountains today."""
+        return self._data.get("todayFountainDrinkingCount") or 0
+
+    @property
+    def today_fountain_drinking_amount(self) -> int:
+        """Total milliliters consumed at RFID fountains today."""
+        return self._data.get("todayFountainDrinkingAmount") or 0
+
+    @property
+    def today_fountain_drinking_time(self) -> int:
+        """Total seconds spent drinking at RFID fountains today."""
+        return self._data.get("todayFountainDrinkingTime") or 0

--- a/custom_components/petlibro/pets/__init__.py
+++ b/custom_components/petlibro/pets/__init__.py
@@ -68,14 +68,24 @@ class Pet(Event):
         fountain_drinking = {"todayFountainDrinkingCount": 0,
                              "todayFountainDrinkingAmount": 0,
                              "todayFountainDrinkingTime": 0}
-        rfid_fountains = [
-            d for d in (bound_devices or [])
-            if d.get("productName") == "Dockstream Smart RFID Fountain"
-        ]
-        for fountain in rfid_fountains:
-            device_sn = fountain.get("deviceSn")
-            if not device_sn:
-                continue
+
+        # Collect RFID fountain serial numbers from bound devices and hub devices
+        fountain_sns = set()
+        for d in (bound_devices or []):
+            if d.get("productName") == "Dockstream Smart RFID Fountain":
+                sn = d.get("deviceSn")
+                if sn:
+                    fountain_sns.add(sn)
+
+        # Also check hub's loaded devices for RFID fountains (shared accounts
+        # return empty from getBoundDevices)
+        if self.hub and self.hub.devices:
+            from ..devices.fountains.dockstream_smart_rfid_fountain import DockstreamSmartRFIDFountain
+            for device in self.hub.devices.values():
+                if isinstance(device, DockstreamSmartRFIDFountain):
+                    fountain_sns.add(device.serial)
+
+        for device_sn in fountain_sns:
             try:
                 wear_list = await self.api.device_wear_list(device_sn)
                 for entry in wear_list:

--- a/custom_components/petlibro/pets/entity.py
+++ b/custom_components/petlibro/pets/entity.py
@@ -32,7 +32,7 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     dataclass,
 )
-from homeassistant.components.sensor.const import SensorDeviceClass
+from homeassistant.components.sensor.const import SensorDeviceClass, SensorStateClass
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.update_coordinator import (
@@ -556,6 +556,44 @@ PET_ENTITY_MAP: dict[PL_PetEntity, tuple[PL_PetEntityDescription]] = {
                 >= today
                 else (bday.replace(year=today.year + 1) - today).days,
             } if pet.age else None,
+        ),
+        PL_PetSensorEntityDescription(
+            key="today_fountain_drinking_count",
+            translation_key="today_fountain_drinking_count",
+            name="Today's Fountain Drinking Count",
+            icon="mdi:water-plus",
+            state_class=SensorStateClass.TOTAL_INCREASING,
+            entity_registry_enabled_default_fn=lambda pet, _: any(
+                d.get("productName") == "Dockstream Smart RFID Fountain"
+                for d in pet.boundDevices
+            ),
+        ),
+        PL_PetSensorEntityDescription(
+            key="today_fountain_drinking_amount",
+            translation_key="today_fountain_drinking_amount",
+            name="Today's Fountain Water Consumption",
+            icon="mdi:cup-water",
+            state_class=SensorStateClass.TOTAL_INCREASING,
+            device_class=SensorDeviceClass.VOLUME,
+            native_unit_of_measurement=UnitOfVolume.MILLILITERS,
+            petlibro_unit=API.WATER_UNIT,
+            entity_registry_enabled_default_fn=lambda pet, _: any(
+                d.get("productName") == "Dockstream Smart RFID Fountain"
+                for d in pet.boundDevices
+            ),
+        ),
+        PL_PetSensorEntityDescription(
+            key="today_fountain_drinking_time",
+            translation_key="today_fountain_drinking_time",
+            name="Today's Fountain Drinking Time",
+            icon="mdi:timer-outline",
+            state_class=SensorStateClass.TOTAL_INCREASING,
+            device_class=SensorDeviceClass.DURATION,
+            native_unit_of_measurement=UnitOfTime.SECONDS,
+            entity_registry_enabled_default_fn=lambda pet, _: any(
+                d.get("productName") == "Dockstream Smart RFID Fountain"
+                for d in pet.boundDevices
+            ),
         ),
     ),
     PL_PetImageEntity: (

--- a/custom_components/petlibro/pets/entity.py
+++ b/custom_components/petlibro/pets/entity.py
@@ -563,10 +563,6 @@ PET_ENTITY_MAP: dict[PL_PetEntity, tuple[PL_PetEntityDescription]] = {
             name="Today's Fountain Drinking Count",
             icon="mdi:water-plus",
             state_class=SensorStateClass.TOTAL_INCREASING,
-            entity_registry_enabled_default_fn=lambda pet, _: any(
-                d.get("productName") == "Dockstream Smart RFID Fountain"
-                for d in pet.boundDevices
-            ),
         ),
         PL_PetSensorEntityDescription(
             key="today_fountain_drinking_amount",
@@ -577,10 +573,6 @@ PET_ENTITY_MAP: dict[PL_PetEntity, tuple[PL_PetEntityDescription]] = {
             device_class=SensorDeviceClass.VOLUME,
             native_unit_of_measurement=UnitOfVolume.MILLILITERS,
             petlibro_unit=API.WATER_UNIT,
-            entity_registry_enabled_default_fn=lambda pet, _: any(
-                d.get("productName") == "Dockstream Smart RFID Fountain"
-                for d in pet.boundDevices
-            ),
         ),
         PL_PetSensorEntityDescription(
             key="today_fountain_drinking_time",
@@ -590,10 +582,6 @@ PET_ENTITY_MAP: dict[PL_PetEntity, tuple[PL_PetEntityDescription]] = {
             state_class=SensorStateClass.TOTAL_INCREASING,
             device_class=SensorDeviceClass.DURATION,
             native_unit_of_measurement=UnitOfTime.SECONDS,
-            entity_registry_enabled_default_fn=lambda pet, _: any(
-                d.get("productName") == "Dockstream Smart RFID Fountain"
-                for d in pet.boundDevices
-            ),
         ),
     ),
     PL_PetImageEntity: (

--- a/custom_components/petlibro/translations/ar.json
+++ b/custom_components/petlibro/translations/ar.json
@@ -242,6 +242,15 @@
             },
             "rfid": {
                 "name": "طوق RFID"
+            },
+            "today_fountain_drinking_count": {
+                "name": "Today's Fountain Drinking Count"
+            },
+            "today_fountain_drinking_amount": {
+                "name": "Today's Fountain Water Consumption"
+            },
+            "today_fountain_drinking_time": {
+                "name": "Today's Fountain Drinking Time"
             }
         },
         "image": {

--- a/custom_components/petlibro/translations/bn.json
+++ b/custom_components/petlibro/translations/bn.json
@@ -245,6 +245,15 @@
             },
             "rfid": {
                 "name": "RFID কলার"
+            },
+            "today_fountain_drinking_count": {
+                "name": "Today's Fountain Drinking Count"
+            },
+            "today_fountain_drinking_amount": {
+                "name": "Today's Fountain Water Consumption"
+            },
+            "today_fountain_drinking_time": {
+                "name": "Today's Fountain Drinking Time"
             }
         },
         "image": {

--- a/custom_components/petlibro/translations/da.json
+++ b/custom_components/petlibro/translations/da.json
@@ -245,6 +245,15 @@
             },
             "rfid": {
                 "name": "RFID-halsbånd"
+            },
+            "today_fountain_drinking_count": {
+                "name": "Today's Fountain Drinking Count"
+            },
+            "today_fountain_drinking_amount": {
+                "name": "Today's Fountain Water Consumption"
+            },
+            "today_fountain_drinking_time": {
+                "name": "Today's Fountain Drinking Time"
             }
         },
         "image": {

--- a/custom_components/petlibro/translations/de.json
+++ b/custom_components/petlibro/translations/de.json
@@ -245,6 +245,15 @@
             },
             "rfid": {
                 "name": "RFID-Halsband"
+            },
+            "today_fountain_drinking_count": {
+                "name": "Today's Fountain Drinking Count"
+            },
+            "today_fountain_drinking_amount": {
+                "name": "Today's Fountain Water Consumption"
+            },
+            "today_fountain_drinking_time": {
+                "name": "Today's Fountain Drinking Time"
             }
         },
         "image": {

--- a/custom_components/petlibro/translations/en.json
+++ b/custom_components/petlibro/translations/en.json
@@ -274,6 +274,15 @@
             },
             "rfid": {
                 "name": "RFID Collar"
+            },
+            "today_fountain_drinking_count": {
+                "name": "Today's Fountain Drinking Count"
+            },
+            "today_fountain_drinking_amount": {
+                "name": "Today's Fountain Water Consumption"
+            },
+            "today_fountain_drinking_time": {
+                "name": "Today's Fountain Drinking Time"
             }
         },
         "image": {

--- a/custom_components/petlibro/translations/es.json
+++ b/custom_components/petlibro/translations/es.json
@@ -245,6 +245,15 @@
             },
             "rfid": {
                 "name": "Collar RFID"
+            },
+            "today_fountain_drinking_count": {
+                "name": "Today's Fountain Drinking Count"
+            },
+            "today_fountain_drinking_amount": {
+                "name": "Today's Fountain Water Consumption"
+            },
+            "today_fountain_drinking_time": {
+                "name": "Today's Fountain Drinking Time"
             }
         },
         "image": {

--- a/custom_components/petlibro/translations/fr.json
+++ b/custom_components/petlibro/translations/fr.json
@@ -245,6 +245,15 @@
             },
             "rfid": {
                 "name": "Collier RFID"
+            },
+            "today_fountain_drinking_count": {
+                "name": "Today's Fountain Drinking Count"
+            },
+            "today_fountain_drinking_amount": {
+                "name": "Today's Fountain Water Consumption"
+            },
+            "today_fountain_drinking_time": {
+                "name": "Today's Fountain Drinking Time"
             }
         },
         "image": {

--- a/custom_components/petlibro/translations/hi.json
+++ b/custom_components/petlibro/translations/hi.json
@@ -245,6 +245,15 @@
             },
             "rfid": {
                 "name": "RFID कॉलर"
+            },
+            "today_fountain_drinking_count": {
+                "name": "Today's Fountain Drinking Count"
+            },
+            "today_fountain_drinking_amount": {
+                "name": "Today's Fountain Water Consumption"
+            },
+            "today_fountain_drinking_time": {
+                "name": "Today's Fountain Drinking Time"
             }
         },
         "image": {

--- a/custom_components/petlibro/translations/it.json
+++ b/custom_components/petlibro/translations/it.json
@@ -25,7 +25,7 @@
             }
         }
     },
-	"options": {
+    "options": {
         "abort": {
             "no_member_data": "Dati membro non caricati, controlla i log",
             "account_settings_abort": "{account_settings_abort}",
@@ -35,13 +35,13 @@
         "error": {
             "unknown": "Errore imprevisto"
         },
-		"step": {
-			"init": {
+        "step": {
+            "init": {
                 "menu_options": {
                     "integration_settings": "Impostazioni integrazione",
                     "account_settings": "Impostazioni account"
                 }
-			},
+            },
             "integration_settings": {
                 "title": "Impostazioni Integrazione",
                 "data": {
@@ -274,6 +274,15 @@
             },
             "rfid": {
                 "name": "Collare RFID"
+            },
+            "today_fountain_drinking_count": {
+                "name": "Today's Fountain Drinking Count"
+            },
+            "today_fountain_drinking_amount": {
+                "name": "Today's Fountain Water Consumption"
+            },
+            "today_fountain_drinking_time": {
+                "name": "Today's Fountain Drinking Time"
             }
         },
         "image": {
@@ -517,7 +526,7 @@
             "pet_sex": {
                 "name": "Sesso",
                 "state": {
-                    "none":"Nessuno",
+                    "none": "Nessuno",
                     "male": "Maschio",
                     "female": "Femmina"
                 }

--- a/custom_components/petlibro/translations/ja.json
+++ b/custom_components/petlibro/translations/ja.json
@@ -245,6 +245,15 @@
             },
             "rfid": {
                 "name": "RFID首輪"
+            },
+            "today_fountain_drinking_count": {
+                "name": "Today's Fountain Drinking Count"
+            },
+            "today_fountain_drinking_amount": {
+                "name": "Today's Fountain Water Consumption"
+            },
+            "today_fountain_drinking_time": {
+                "name": "Today's Fountain Drinking Time"
             }
         },
         "image": {

--- a/custom_components/petlibro/translations/nl.json
+++ b/custom_components/petlibro/translations/nl.json
@@ -245,6 +245,15 @@
             },
             "rfid": {
                 "name": "RFID-halsband"
+            },
+            "today_fountain_drinking_count": {
+                "name": "Today's Fountain Drinking Count"
+            },
+            "today_fountain_drinking_amount": {
+                "name": "Today's Fountain Water Consumption"
+            },
+            "today_fountain_drinking_time": {
+                "name": "Today's Fountain Drinking Time"
             }
         },
         "image": {

--- a/custom_components/petlibro/translations/pt.json
+++ b/custom_components/petlibro/translations/pt.json
@@ -245,6 +245,15 @@
             },
             "rfid": {
                 "name": "Coleira RFID"
+            },
+            "today_fountain_drinking_count": {
+                "name": "Today's Fountain Drinking Count"
+            },
+            "today_fountain_drinking_amount": {
+                "name": "Today's Fountain Water Consumption"
+            },
+            "today_fountain_drinking_time": {
+                "name": "Today's Fountain Drinking Time"
             }
         },
         "image": {

--- a/custom_components/petlibro/translations/ru.json
+++ b/custom_components/petlibro/translations/ru.json
@@ -245,6 +245,15 @@
             },
             "rfid": {
                 "name": "RFID-ошейник"
+            },
+            "today_fountain_drinking_count": {
+                "name": "Today's Fountain Drinking Count"
+            },
+            "today_fountain_drinking_amount": {
+                "name": "Today's Fountain Water Consumption"
+            },
+            "today_fountain_drinking_time": {
+                "name": "Today's Fountain Drinking Time"
             }
         },
         "image": {

--- a/custom_components/petlibro/translations/zh-Hans.json
+++ b/custom_components/petlibro/translations/zh-Hans.json
@@ -37,12 +37,12 @@
             "unknown": "意外错误"
         },
         "step": {
-			"init": {
+            "init": {
                 "menu_options": {
                     "integration_settings": "集成设置",
                     "account_settings": "账户设置"
                 }
-			},
+            },
             "integration_settings": {
                 "title": "集成设置",
                 "data": {
@@ -151,7 +151,7 @@
             "today_eating_time": {
                 "name": "今天的总饮食时间"
             },
-            "today_feeding_schedule": {
+            "feeding_plan_state": {
                 "name": "今天的喂养计划"
             },
             "today_drinking_amount": {
@@ -202,7 +202,7 @@
             "next_feeding_end_time": {
                 "name": "进食末端"
             },
-            "feeding_schedule": {
+            "feeding_plan": {
                 "name": "喂养计划"
             },
             "temperature": {
@@ -245,6 +245,15 @@
             },
             "rfid": {
                 "name": "RFID 项圈"
+            },
+            "today_fountain_drinking_count": {
+                "name": "Today's Fountain Drinking Count"
+            },
+            "today_fountain_drinking_amount": {
+                "name": "Today's Fountain Water Consumption"
+            },
+            "today_fountain_drinking_time": {
+                "name": "Today's Fountain Drinking Time"
             }
         },
         "image": {
@@ -395,7 +404,7 @@
             "pet_sex": {
                 "name": "性别",
                 "state": {
-                    "none":"无",
+                    "none": "无",
                     "male": "雄性",
                     "female": "雌性"
                 }


### PR DESCRIPTION
## Proposed change:

Closes #92.

Adds three per-pet drinking sensors for the **Dockstream Smart RFID Fountain (PLWF305)**, sourced from the `wearListV2` API endpoint. Sensors appear under each pet's Home Assistant device:

- **Today's Fountain Drinking Count** — number of drinking sessions today
- **Today's Fountain Water Consumption** — total ml today (respects user's water unit preference)
- **Today's Fountain Drinking Time** — total seconds spent drinking today

### How it works

- New `device_wear_list(device_sn)` method on `PetLibroAPI` follows the existing 10-second cache pattern used by `get_device_real_info` and friends.
- `Pet.refresh()` now also queries `wearListV2` for any RFID fountains the pet is bound to, then aggregates per-pet drinking stats (sums across multiple fountains if applicable).
- Three new `PL_PetSensorEntity` entries in `PET_ENTITY_MAP` expose the data, with translations for all 13 supported languages.

### Shared account handling

`getBoundDevices` returns empty for shared (non-owner) accounts, so the implementation also falls back to the hub's loaded RFID fountain devices. The `wearListV2` response is filtered by `petId` so only the relevant pet's data is used. This mirrors the workaround pattern recommended in the issue thread.

### Edge cases handled

- API returns `null` for pets that haven't drunk today → treated as `0`
- `wearListV2` call fails → logged and skipped, pet refresh continues
- Pet bound to multiple RFID fountains → values summed correctly (each fountain is a separate API call so no double-counting)
- Multiple pets share a fountain → 10-second cache deduplicates calls within a refresh cycle

### Files changed

- `custom_components/petlibro/api.py` — new `device_wear_list()` method
- `custom_components/petlibro/pets/__init__.py` — updated `refresh()`, 3 new properties
- `custom_components/petlibro/pets/entity.py` — 3 new sensor descriptions in `PET_ENTITY_MAP`
- `custom_components/petlibro/translations/*.json` — 3 new translation keys across 13 files

### Testing

Verified live on a personal HA dev instance with a Dockstream Smart RFID Fountain bound to two cats:
- Pet with active RFID drinking: shows real values (e.g., 5 sessions, 56ml, 210s)
- Pet without drinking activity today: shows 0 (matches Petlibro app behavior)
- Aggregation across multiple fountains works correctly
- 10-second cache avoids duplicate API calls when multiple pets share a fountain

### Notes

- Sensors are visible for all pets, not just RFID-bound ones (the existing `entity_registry_enabled_default_fn` plumbing on pet entities has an `or super()` fallback that prevents disabling — keeping behavior consistent with other pet entities).
- Built and tested against HA 2026.4.x.

## Screenshots
<img width="2299" height="1307" alt="macshot-clipboard-0ED22D79-B890-4F1A-9BE1-A5D54D764C83" src="https://github.com/user-attachments/assets/8208e033-41f5-424f-87cd-164535b0b0a9" />

<img width="2143" height="1588" alt="macshot-clipboard-6004B5FF-3536-426F-82CE-6231453AAF6E" src="https://github.com/user-attachments/assets/c2638cbd-771f-4dfe-9572-50fbb407e139" />