### PR TITLE
Reduce log noise: demote "No pets" messages from WARNING to DEBUG

### DIFF
--- a/custom_components/petlibro/date.py
+++ b/custom_components/petlibro/date.py
@@ -53,7 +53,7 @@ async def async_setup_entry(
 
     # Ensure that the pets are loaded
     if not (pets := hub.pets):
-        _LOGGER.warning("No pets found in hub during date setup.")
+        _LOGGER.debug("No pets found in hub during date setup.")
 
     if not (pets): # or devices
         return

--- a/custom_components/petlibro/hub.py
+++ b/custom_components/petlibro/hub.py
@@ -189,7 +189,7 @@ class PetLibroHub:
                 _LOGGER.error("Error fetching shared pet info.")
 
         if not pet_list:
-            _LOGGER.warning("No pets found in the API response.")
+            _LOGGER.debug("No pets found in the API response.")
             return  # Early return if no pets found
 
         for pet_data in pet_list:
@@ -243,7 +243,7 @@ class PetLibroHub:
         if not self.member:
             _LOGGER.warning("No member to refresh.")
         if not self.pets:
-            _LOGGER.warning("No pets to refresh.")
+            _LOGGER.debug("No pets to refresh.")
 
         now = utcnow()
         refresh_tasks, data_objects = [], []

--- a/custom_components/petlibro/image.py
+++ b/custom_components/petlibro/image.py
@@ -58,7 +58,7 @@ async def async_setup_entry(
 
     # Ensure that the pets are loaded
     if not (pets := hub.pets):
-        _LOGGER.warning("No pets found in hub during image setup.")
+        _LOGGER.debug("No pets found in hub during image setup.")
 
     if not (pets): # or devices
         return

--- a/custom_components/petlibro/number.py
+++ b/custom_components/petlibro/number.py
@@ -570,7 +570,7 @@ async def async_setup_entry(
 
     # Ensure that the pets are loaded
     if not (pets := hub.pets):
-        _LOGGER.warning("No pets found in hub during number setup.")
+        _LOGGER.debug("No pets found in hub during number setup.")
 
     if not (devices or pets):
         return

--- a/custom_components/petlibro/select.py
+++ b/custom_components/petlibro/select.py
@@ -473,7 +473,7 @@ async def async_setup_entry(
 
     # Ensure that the pets are loaded
     if not (pets := hub.pets):
-        _LOGGER.warning("No pets found in hub during select setup.")
+        _LOGGER.debug("No pets found in hub during select setup.")
 
     if not (devices or pets):
         return

--- a/custom_components/petlibro/sensor.py
+++ b/custom_components/petlibro/sensor.py
@@ -1521,7 +1521,7 @@ async def async_setup_entry(
         _LOGGER.warning("No devices found in hub during sensor setup.")
 
     if not (pets := hub.pets):
-        _LOGGER.warning("No pets found in hub during sensor setup.")
+        _LOGGER.debug("No pets found in hub during sensor setup.")
 
     if not (devices or member or pets):
         return

--- a/custom_components/petlibro/switch.py
+++ b/custom_components/petlibro/switch.py
@@ -136,7 +136,7 @@ async def async_setup_entry(
 
     # Ensure that the pets are loaded
     if not (pets := hub.pets):
-        _LOGGER.warning("No pets found in hub during switch setup.")
+        _LOGGER.debug("No pets found in hub during switch setup.")
 
     if not (devices or pets):
         return

--- a/custom_components/petlibro/text.py
+++ b/custom_components/petlibro/text.py
@@ -144,7 +144,7 @@ async def async_setup_entry(
     ]
 
     if not entities:
-        _LOGGER.warning("No text entities added, entities list is empty!")
+        _LOGGER.debug("No text entities added, entities list is empty!")
     else:
         # Log the text of entities and their details
         _LOGGER.debug("Adding %d PetLibro text entities", len(entities))


### PR DESCRIPTION
<!--
Before opening this pull request please review the guidelines in the checklist below. If this PR does not meet those guidelines it will not be accepted, and everyone will be sad.

Please include a summary of the change. Screenshots and/or videos can also be helpful if appropriate. New devices or enhancements should include example(s) of relevant information.
-->
## Proposed change:

This PR reduces log noise by demoting several non-critical "No pets" and similar messages from `WARNING` level to `DEBUG` level.

These warnings were being logged repeatedly for users who do not have pets registered in their Petlibro account (a common use case), cluttering the logs.

**Files modified:**
- `date.py`
- `hub.py`
- `image.py`
- `number.py`
- `select.py`
- `sensor.py`
- `switch.py`
- `text.py`

Closes #240 

## Type of change:
- [ ] New device.
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature or enhancement (non-breaking change which adds functionality).
- [ ] Documentation only.
- [ ] Other (please explain).

## Checklist:
- [ ] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have reviewed the [feature / enhancement](https://github.com/jjjonesjr33/petlibro/wiki/Feature-&-Enhancement-Guidelines) guidlines before submitting my request.
- [x] If applicable, I have tested my code for new features & regressions on the latest version of Home Assistant.

## Additional notes:
- All changes are purely logging level adjustments.
- No functional behavior is altered.
- This significantly improves the user experience for users without pets by reducing log spam while keeping the information available at debug level for troubleshooting.