### PR TITLE
fix(#260): retry device loading when initial load returns no devices

### DIFF
--- a/custom_components/petlibro/hub.py
+++ b/custom_components/petlibro/hub.py
@@ -235,6 +235,13 @@ class PetLibroHub:
     async def refresh_data(self) -> bool:
         """Refresh all known devices, member and pets info from the PETLIBRO API."""
 
+        # If the initial device load failed or returned no devices (e.g. a transient
+        # API/server error during setup), retry so the integration can recover
+        # without requiring a reinstall.
+        if not self.devices:
+            _LOGGER.debug("No devices loaded yet, attempting to load devices again.")
+            await self.load_devices()
+
         if not self.devices and not self.member and not self.pets:
             _LOGGER.error("No devices, member, or pets to refresh.")
             return False

--- a/custom_components/petlibro/hub.py
+++ b/custom_components/petlibro/hub.py
@@ -242,6 +242,14 @@ class PetLibroHub:
             _LOGGER.debug("No devices loaded yet, attempting to load devices again.")
             await self.load_devices()
 
+            if self.devices:
+                _LOGGER.debug(
+                    "Device reload successful, %d device(s) loaded.",
+                    len(self.devices),
+                )
+            else:
+                _LOGGER.debug("Device reload completed, but no devices were found.")
+
         if not self.devices and not self.member and not self.pets:
             _LOGGER.error("No devices, member, or pets to refresh.")
             return False


### PR DESCRIPTION
## Summary

Closes #260 — the Granary Smart Feeder (and any device) sometimes never appears as an HA entity because `load_devices()` is only called **once** during setup. If the Petlibro API returns no devices at that moment (e.g. transient 504/server errors, as shown in the issue logs), the integration logs "No devices found in the API response." and the device list is never retried — leaving the integration permanently without entities until a reinstall.

## Change

In `PetLibroHub.refresh_data()`, if `self.devices` is empty, attempt `load_devices()` again before building the refresh tasks. The retry is:

- **Idempotent** — already-loaded serials are skipped via `devices_helper.loaded_device_sn`
- **Safe** — `load_devices()` already swallows exceptions internally, so a failed retry won't crash the coordinator refresh
- **Self-healing** — once the API starts returning devices again, they appear within one refresh interval without reinstalling

## Files changed

- `custom_components/petlibro/hub.py`

## Testing

- `python3 -m compileall custom_components/petlibro/hub.py` passes
- No test framework exists in this repo; verified via compile + logic review