### PR TITLE
feat(#272): add cleaning reminder sensors and cleaning reset button for Polar Wet Food Feeder

### DIFF
--- a/custom_components/petlibro/button.py
+++ b/custom_components/petlibro/button.py
@@ -510,6 +510,12 @@ DEVICE_BUTTON_MAP: dict[type[Device], list[PetLibroButtonEntityDescription]] = {
             set_fn=lambda device: device.set_light_off(),
             name="Turn Off Indicator"
         ),
+        PetLibroButtonEntityDescription[PolarWetFoodFeeder](
+            key="cleaning_reset",
+            translation_key="cleaning_reset",
+            set_fn=lambda device: device.set_cleaning_reset(),
+            name="Cleaning Reset"
+        ),
     ],
     SpaceSmartFeeder: [
         PetLibroButtonEntityDescription[SpaceSmartFeeder](

--- a/custom_components/petlibro/devices/feeders/polar_wet_food_feeder.py
+++ b/custom_components/petlibro/devices/feeders/polar_wet_food_feeder.py
@@ -7,6 +7,7 @@ from ...exceptions import PetLibroAPIError
 from ..device import Device
 from typing import cast
 from logging import getLogger
+from homeassistant.util import dt as dt_util
 
 _LOGGER = getLogger(__name__)
 
@@ -158,6 +159,46 @@ class PolarWetFoodFeeder(Device):
         celsius = self._data.get("realInfo", {}).get("temperature", 0.0)
         fahrenheit = celsius * 9 / 5 + 32
         return round(fahrenheit, 1)  # Round to 1 decimal place
+
+    @property
+    def remaining_cleaning_days(self) -> float | None:
+        """Get the remaining cleaning days."""
+        value = self._data.get("realInfo", {}).get("remainingCleaningDays")
+        try:
+            return float(value) if value is not None else None
+        except (TypeError, ValueError):
+            return None
+
+    @property
+    def last_clean_date(self) -> datetime | None:
+        """Return the timestamp of the last machine cleaning as a datetime object (UTC)."""
+        timestamp_ms = self._data.get("realInfo", {}).get("machineCleaningTime")
+        if not timestamp_ms:
+            return None
+        try:
+            return dt_util.utc_from_timestamp(timestamp_ms / 1000)
+        except (TypeError, ValueError, OSError):
+            return None
+
+    @property
+    def next_clean_date(self) -> datetime | None:
+        """Return the timestamp of the next machine cleaning as a datetime object (UTC)."""
+        timestamp_ms = self._data.get("realInfo", {}).get("machineNextCleaningTime")
+        if not timestamp_ms:
+            return None
+        try:
+            return dt_util.utc_from_timestamp(timestamp_ms / 1000)
+        except (TypeError, ValueError, OSError):
+            return None
+
+    async def set_cleaning_reset(self) -> None:
+        _LOGGER.debug(f"Triggering machine cleaning reset for {self.serial}")
+        try:
+            await self.api.set_cleaning_reset(self.serial)
+            await self.refresh()  # Refresh the state after the action
+        except aiohttp.ClientError as err:
+            _LOGGER.error(f"Failed to trigger machine cleaning reset for {self.serial}: {err}")
+            raise PetLibroAPIError(f"Error triggering machine cleaning reset: {err}")
 
     @property
     def unit_type(self) -> int:

--- a/custom_components/petlibro/devices/feeders/polar_wet_food_feeder.py
+++ b/custom_components/petlibro/devices/feeders/polar_wet_food_feeder.py
@@ -177,7 +177,7 @@ class PolarWetFoodFeeder(Device):
             return None
         try:
             return dt_util.utc_from_timestamp(timestamp_ms / 1000)
-        except (TypeError, ValueError, OSError):
+        except (TypeError, ValueError, OverflowError, OSError):
             return None
 
     @property
@@ -188,7 +188,7 @@ class PolarWetFoodFeeder(Device):
             return None
         try:
             return dt_util.utc_from_timestamp(timestamp_ms / 1000)
-        except (TypeError, ValueError, OSError):
+        except (TypeError, ValueError, OverflowError, OSError):
             return None
 
     async def set_cleaning_reset(self) -> None:

--- a/custom_components/petlibro/sensor.py
+++ b/custom_components/petlibro/sensor.py
@@ -832,6 +832,29 @@ DEVICE_SENSOR_MAP: dict[type[Device], list[PetLibroSensorEntityDescription]] = {
             name="Plate Position",
             should_report=lambda device: device.plate_position is not None,
         ),
+        PetLibroSensorEntityDescription[PolarWetFoodFeeder](
+            key="remaining_cleaning_days",
+            translation_key="remaining_cleaning_days",
+            icon="mdi:package",
+            native_unit_of_measurement="d",
+            device_class=SensorDeviceClass.DURATION,
+            state_class=SensorStateClass.MEASUREMENT,
+            name="Remaining Cleaning Days"
+        ),
+        PetLibroSensorEntityDescription[PolarWetFoodFeeder](
+            key="last_clean_date",
+            translation_key="last_clean_date",
+            icon="mdi:calendar-check",
+            name="Last Clean Date",
+            device_class=SensorDeviceClass.TIMESTAMP,
+        ),
+        PetLibroSensorEntityDescription[PolarWetFoodFeeder](
+            key="next_clean_date",
+            translation_key="next_clean_date",
+            icon="mdi:calendar-clock",
+            name="Next Clean Date",
+            device_class=SensorDeviceClass.TIMESTAMP,
+        ),
     ],
     SpaceSmartFeeder: [
         PetLibroSensorEntityDescription[SpaceSmartFeeder](

--- a/custom_components/petlibro/translations/en.json
+++ b/custom_components/petlibro/translations/en.json
@@ -210,6 +210,12 @@
             "remaining_cleaning_days": {
                 "name": "Remaining Cleaning Days"
             },
+            "last_clean_date": {
+                "name": "Last Clean Date"
+            },
+            "next_clean_date": {
+                "name": "Next Clean Date"
+            },
             "resolution": {
                 "name": "Camera Resolution"
             },


### PR DESCRIPTION
## Summary

Closes #272 — add cleaning reminder tracking to the Polar Wet Food Feeder (PLAF109), matching the existing Dockstream fountain pattern.

Issue author @casscassca confirmed the API fields exist in `baseInfo`/`realInfo` for the PLAF109.

## Changes

- `polar_wet_food_feeder.py`:
  - `remaining_cleaning_days` property (from `realInfo.remainingCleaningDays`)
  - `last_clean_date` property (`machineCleaningTime`, epoch ms → UTC datetime)
  - `next_clean_date` property (`machineNextCleaningTime`, epoch ms → UTC datetime)
  - `set_cleaning_reset()` method (calls existing `api.set_cleaning_reset`)
- `sensor.py`: `remaining_cleaning_days` (duration), `last_clean_date` + `next_clean_date` (timestamp sensors) in the `PolarWetFoodFeeder` block
- `button.py`: `cleaning_reset` button in the `PolarWetFoodFeeder` block
- `translations/en.json`: `last_clean_date` + `next_clean_date` keys

## Scope

Small addition mirroring the fountains. Enables HA automations to track and reset the cleaning cycle for the Polar Wet Food Feeder.

## Review feedback applied

- `OverflowError` guard added to the timestamp conversions