### PR TITLE
Granary 2 Vision Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ If you enjoy this integration and want to support its development, please consid
 * Air Smart Feeder (PLAF108)
 * Polar Wet Food Feeder (PLAF109)
 * Granary Smart Camera Feeder (PLAF203)
+* Granary 2 Vision (PLAF205)
 * One RFID Smart Feeder (PLAF301)
 
 ### Fountains
@@ -66,7 +67,7 @@ If you enjoy this integration and want to support its development, please consid
 #### This is still a WIP integration, features may or may not be removed at any time. If you have suggestions please let me know.
 > [!NOTE]
   >* Tracking RFID per pet intance eat/drink - (PLWF305) - API Information gathered, working on implementation.
-  >* Live camera feed for Granary Smart Camera Feeder (PLAF203) - Currently missing the API to setup live stream. Seems to connect via Kalay TUTK, if you have any experience integrating with this platform, please reach out to help us implement this.
+  >* Live camera feed for Granary Smart Camera Feeder (PLAF203) and Granary 2 Vision (PLAF205) - Currently missing the API to setup live stream. Seems to connect via Kalay TUTK, if you have any experience integrating with this platform, please reach out to help us implement this. The Kalay/TUTK credential layer (userToken, appTutkUrl, cameraAuthInfo) is now exposed as attributes on the Wi-Fi SSID sensor for Granary 2 Vision for anyone wanting to build an external bridge.
 
 # NOTICE
 #### Alpha/Beta state notice for this plugin:

--- a/custom_components/petlibro/api.py
+++ b/custom_components/petlibro/api.py
@@ -554,6 +554,14 @@ class PetLibroAPI:
             "mode": mode
         })
 
+    async def device_tutk_info(self, serial: str) -> Dict[str, Any]:
+        """Get Kalay/TUTK P2P camera credentials (UID, auth token, app URL) for a camera-equipped device.
+
+        This is the credential layer only - it does not itself provide a video stream.
+        An external TUTK-compatible client/bridge is needed to actually pull video.
+        """
+        return await self.session.post_serial("/member/third/tutk/info", serial)
+
     async def device_get_bound_pets(self, device_sn: str) -> list[dict]:
         """Get pets bound to a device."""
         _LOGGER.debug("Requesting pets bound to device sn: %s", device_sn)

--- a/custom_components/petlibro/api.py
+++ b/custom_components/petlibro/api.py
@@ -543,6 +543,17 @@ class PetLibroAPI:
     async def device_wet_feeding_plan(self, serial: str) -> Dict[str, Any]:
         return await self.session.post_serial("/device/wetFeedingPlan/wetListV3", serial)
 
+    async def device_get_free_feeding_setting(self, serial: str) -> Dict[str, Any]:
+        """Get Free Feeding (Smart Feed) mode settings: per-feed amount, daily max, leftover threshold, wait time."""
+        return await self.session.post_serial("/device/device/getFreeFeedingSetting", serial)
+
+    async def set_feeding_mode(self, serial: str, mode: str) -> None:
+        """Set the device's feeding mode (e.g. 'FREE' for Free/Smart Feeding)."""
+        await self.session.post("/device/device/updateFeedingMode", json={
+            "deviceSn": serial,
+            "mode": mode
+        })
+
     async def device_get_bound_pets(self, device_sn: str) -> list[dict]:
         """Get pets bound to a device."""
         _LOGGER.debug("Requesting pets bound to device sn: %s", device_sn)

--- a/custom_components/petlibro/binary_sensor.py
+++ b/custom_components/petlibro/binary_sensor.py
@@ -437,13 +437,6 @@ DEVICE_BINARY_SENSOR_MAP: dict[type[Device], list[PetLibroBinarySensorEntityDesc
             should_report=lambda device: device.talk_channel_active is not None,
             name="Two-Way Talk Active"
         ),
-        PetLibroBinarySensorEntityDescription[Granary2VisionFeeder](
-            key="smart_refill_enabled",
-            translation_key="smart_refill_enabled",
-            icon="mdi:autorenew",
-            should_report=lambda device: device.smart_refill_enabled is not None,
-            name="Smart Refill Enabled"
-        ),
     ],
     OneRFIDSmartFeeder: [
         PetLibroBinarySensorEntityDescription[OneRFIDSmartFeeder](

--- a/custom_components/petlibro/binary_sensor.py
+++ b/custom_components/petlibro/binary_sensor.py
@@ -28,6 +28,7 @@ from .devices.feeders.feeder import Feeder
 from .devices.feeders.air_smart_feeder import AirSmartFeeder
 from .devices.feeders.granary_smart_feeder import GranarySmartFeeder
 from .devices.feeders.granary_smart_camera_feeder import GranarySmartCameraFeeder
+from .devices.feeders.granary_2_vision_feeder import Granary2VisionFeeder
 from .devices.feeders.one_rfid_smart_feeder import OneRFIDSmartFeeder
 from .devices.feeders.polar_wet_food_feeder import PolarWetFoodFeeder
 from .devices.feeders.space_smart_feeder import SpaceSmartFeeder
@@ -396,6 +397,52 @@ DEVICE_BINARY_SENSOR_MAP: dict[type[Device], list[PetLibroBinarySensorEntityDesc
             device_class=BinarySensorDeviceClass.SOUND,
             should_report=lambda device: device.sound_detected is not None,
             name="Sound Detected"
+        ),
+    ],
+    Granary2VisionFeeder: [
+        PetLibroBinarySensorEntityDescription[Granary2VisionFeeder](
+            key="left_food_low",
+            translation_key="left_food_low",
+            icon="mdi:bowl-mix-outline",
+            device_class=BinarySensorDeviceClass.PROBLEM,
+            should_report=lambda device: device.left_food_low is not None,
+            name="Left Food Status"
+        ),
+        PetLibroBinarySensorEntityDescription[Granary2VisionFeeder](
+            key="right_food_low",
+            translation_key="right_food_low",
+            icon="mdi:bowl-mix-outline",
+            device_class=BinarySensorDeviceClass.PROBLEM,
+            should_report=lambda device: device.right_food_low is not None,
+            name="Right Food Status"
+        ),
+        PetLibroBinarySensorEntityDescription[Granary2VisionFeeder](
+            key="pet_detection_enabled",
+            translation_key="pet_detection_enabled",
+            icon="mdi:paw",
+            should_report=lambda device: device.pet_detection_enabled is not None,
+            name="AI Pet Detection"
+        ),
+        PetLibroBinarySensorEntityDescription[Granary2VisionFeeder](
+            key="human_detection_enabled",
+            translation_key="human_detection_enabled",
+            icon="mdi:human",
+            should_report=lambda device: device.human_detection_enabled is not None,
+            name="Human Detection"
+        ),
+        PetLibroBinarySensorEntityDescription[Granary2VisionFeeder](
+            key="talk_channel_active",
+            translation_key="talk_channel_active",
+            icon="mdi:phone-in-talk",
+            should_report=lambda device: device.talk_channel_active is not None,
+            name="Two-Way Talk Active"
+        ),
+        PetLibroBinarySensorEntityDescription[Granary2VisionFeeder](
+            key="smart_refill_enabled",
+            translation_key="smart_refill_enabled",
+            icon="mdi:autorenew",
+            should_report=lambda device: device.smart_refill_enabled is not None,
+            name="Smart Refill Enabled"
         ),
     ],
     OneRFIDSmartFeeder: [

--- a/custom_components/petlibro/button.py
+++ b/custom_components/petlibro/button.py
@@ -26,6 +26,7 @@ from .devices.feeders.feeder import Feeder
 from .devices.feeders.air_smart_feeder import AirSmartFeeder
 from .devices.feeders.granary_smart_feeder import GranarySmartFeeder
 from .devices.feeders.granary_smart_camera_feeder import GranarySmartCameraFeeder
+from .devices.feeders.granary_2_vision_feeder import Granary2VisionFeeder
 from .devices.feeders.one_rfid_smart_feeder import OneRFIDSmartFeeder
 from .devices.feeders.polar_wet_food_feeder import PolarWetFoodFeeder
 from .devices.feeders.space_smart_feeder import SpaceSmartFeeder
@@ -356,6 +357,22 @@ DEVICE_BUTTON_MAP: dict[type[Device], list[PetLibroButtonEntityDescription]] = {
             icon="mdi:calendar-remove",
             name="Disable Today's Feeding Schedule",
             set_fn=lambda d: d.api.feeding_plan_today_all(d.serial, False),
+        ),
+    ],
+    Granary2VisionFeeder: [
+        PetLibroButtonEntityDescription[Granary2VisionFeeder](
+            key="free_feeding_mode",
+            translation_key="free_feeding_mode",
+            icon="mdi:autorenew",
+            set_fn=lambda device: device.set_free_feeding_mode(),
+            name="Enable Free Feeding (Smart Feed)"
+        ),
+        PetLibroButtonEntityDescription[Granary2VisionFeeder](
+            key="plan_feeding_mode",
+            translation_key="plan_feeding_mode",
+            icon="mdi:calendar-clock",
+            set_fn=lambda device: device.set_plan_feeding_mode(),
+            name="Enable Feeding Plan Mode"
         ),
     ],
     OneRFIDSmartFeeder: [

--- a/custom_components/petlibro/devices/__init__.py
+++ b/custom_components/petlibro/devices/__init__.py
@@ -7,6 +7,7 @@ from .feeders.feeder import Feeder
 from .feeders.air_smart_feeder import AirSmartFeeder
 from .feeders.granary_smart_feeder import GranarySmartFeeder
 from .feeders.granary_smart_camera_feeder import GranarySmartCameraFeeder
+from .feeders.granary_2_vision_feeder import Granary2VisionFeeder
 from .feeders.one_rfid_smart_feeder import OneRFIDSmartFeeder
 from .feeders.polar_wet_food_feeder import PolarWetFoodFeeder
 from .feeders.space_smart_feeder import SpaceSmartFeeder
@@ -21,6 +22,7 @@ product_name_map : Dict[str, Type[Device]] = {
     "Air Smart Feeder": AirSmartFeeder,
     "Granary Smart Feeder": GranarySmartFeeder,
     "Granary Smart Camera Feeder": GranarySmartCameraFeeder,
+    "Granary 2 Vision": Granary2VisionFeeder,
     "One RFID Smart Feeder": OneRFIDSmartFeeder,
     "Polar Wet Food Feeder": PolarWetFoodFeeder,
     "Dockstream Smart Fountain": DockstreamSmartFountain,

--- a/custom_components/petlibro/devices/feeders/granary_2_vision_feeder.py
+++ b/custom_components/petlibro/devices/feeders/granary_2_vision_feeder.py
@@ -36,6 +36,14 @@ class Granary2VisionFeeder(GranarySmartCameraFeeder):
         except PetLibroAPIError as err:
             _LOGGER.error(f"Error refreshing TUTK camera info for Granary2VisionFeeder: {err}")
 
+        try:
+            data_real_info = await self.api.device_data_real_info(self.serial)
+            self.update_data({
+                "dataRealInfo": data_real_info or {},
+            })
+        except PetLibroAPIError as err:
+            _LOGGER.error(f"Error refreshing data real info for Granary2VisionFeeder: {err}")
+
     @property
     def night_vision(self) -> str:
         """Return the current night vision mode.
@@ -105,6 +113,11 @@ class Granary2VisionFeeder(GranarySmartCameraFeeder):
         """Return the wait time (seconds) Free Feeding uses between checks."""
         value = self._data.get("freeFeedingSetting", {}).get("freeWaitSeconds")
         return float(value) if isinstance(value, (int, float)) else None
+
+    @property
+    def feeding_mode(self) -> str | None:
+        """Return the device's current feeding mode: 'FREE' (Smart Feed) or 'PLAN' (schedule-based)."""
+        return self._data.get("dataRealInfo", {}).get("feedingMode")
 
     @property
     def camera_auth_info(self) -> str | None:

--- a/custom_components/petlibro/devices/feeders/granary_2_vision_feeder.py
+++ b/custom_components/petlibro/devices/feeders/granary_2_vision_feeder.py
@@ -1,5 +1,7 @@
+import aiohttp
 from logging import getLogger
 
+from ...exceptions import PetLibroAPIError
 from .granary_smart_camera_feeder import GranarySmartCameraFeeder
 
 _LOGGER = getLogger(__name__)
@@ -12,6 +14,17 @@ class Granary2VisionFeeder(GranarySmartCameraFeeder):
     reuses its entities while we confirm real API field names against a
     live Granary 2 Vision unit. Split into a standalone class once verified.
     """
+
+    async def refresh(self):
+        """Refresh the device data from the API."""
+        await super().refresh()
+        try:
+            free_feeding_setting = await self.api.device_get_free_feeding_setting(self.serial)
+            self.update_data({
+                "freeFeedingSetting": free_feeding_setting or {},
+            })
+        except PetLibroAPIError as err:
+            _LOGGER.error(f"Error refreshing free feeding setting for Granary2VisionFeeder: {err}")
 
     @property
     def night_vision(self) -> str:
@@ -60,12 +73,45 @@ class Granary2VisionFeeder(GranarySmartCameraFeeder):
         return self._data.get("realInfo", {}).get("radarSensingLevel", "unknown")
 
     @property
-    def smart_refill_enabled(self) -> bool:
-        """Return whether Smart Refill Mode's auto-stop is enabled."""
-        return bool(self._data.get("getAttributeSetting", {}).get("autoStopFeedSwitch", False))
+    def free_feeding_per_grain(self) -> float | None:
+        """Return the amount dispensed per Free Feeding (Smart Feed) top-up."""
+        value = self._data.get("freeFeedingSetting", {}).get("freePerGrainNum")
+        return float(value) if isinstance(value, (int, float)) else None
 
     @property
-    def smart_refill_max_weight(self) -> float:
-        """Return the Smart Refill Mode daily max amount, in grams."""
-        value = self._data.get("getAttributeSetting", {}).get("autoFeedMaxWeight")
-        return float(value) if isinstance(value, (int, float)) else 0.0
+    def free_feeding_daily_max(self) -> float | None:
+        """Return the max number of Free Feeding top-ups allowed per day."""
+        value = self._data.get("freeFeedingSetting", {}).get("freeDailyMaxNum")
+        return float(value) if isinstance(value, (int, float)) else None
+
+    @property
+    def free_feeding_leftover_weight(self) -> float | None:
+        """Return the minimum food-left threshold that pauses Free Feeding."""
+        value = self._data.get("freeFeedingSetting", {}).get("freeLeftoverWeight")
+        return float(value) if isinstance(value, (int, float)) else None
+
+    @property
+    def free_feeding_wait_seconds(self) -> float | None:
+        """Return the wait time (seconds) Free Feeding uses between checks."""
+        value = self._data.get("freeFeedingSetting", {}).get("freeWaitSeconds")
+        return float(value) if isinstance(value, (int, float)) else None
+
+    async def set_free_feeding_mode(self) -> None:
+        """Enable Free Feeding (Smart Feed) mode."""
+        _LOGGER.debug(f"Enabling Free Feeding mode for {self.serial}")
+        try:
+            await self.api.set_feeding_mode(self.serial, "FREE")
+            await self.refresh()
+        except aiohttp.ClientError as err:
+            _LOGGER.error(f"Failed to enable Free Feeding mode for {self.serial}: {err}")
+            raise PetLibroAPIError(f"Error enabling Free Feeding mode: {err}")
+
+    async def set_plan_feeding_mode(self) -> None:
+        """Switch back to schedule-based (Feeding Plan) mode."""
+        _LOGGER.debug(f"Enabling Plan feeding mode for {self.serial}")
+        try:
+            await self.api.set_feeding_mode(self.serial, "PLAN")
+            await self.refresh()
+        except aiohttp.ClientError as err:
+            _LOGGER.error(f"Failed to enable Plan feeding mode for {self.serial}: {err}")
+            raise PetLibroAPIError(f"Error enabling Plan feeding mode: {err}")

--- a/custom_components/petlibro/devices/feeders/granary_2_vision_feeder.py
+++ b/custom_components/petlibro/devices/feeders/granary_2_vision_feeder.py
@@ -1,0 +1,71 @@
+from logging import getLogger
+
+from .granary_smart_camera_feeder import GranarySmartCameraFeeder
+
+_LOGGER = getLogger(__name__)
+
+
+class Granary2VisionFeeder(GranarySmartCameraFeeder):
+    """Represents the Granary 2 Vision feeder.
+
+    Temporary subclass of GranarySmartCameraFeeder so the device loads and
+    reuses its entities while we confirm real API field names against a
+    live Granary 2 Vision unit. Split into a standalone class once verified.
+    """
+
+    @property
+    def night_vision(self) -> str:
+        """Return the current night vision mode.
+
+        Unlike the Granary Smart Camera Feeder, this device reports night
+        vision under getAttributeSetting.nightVisionMode; realInfo.nightVision
+        is always null.
+        """
+        return self._data.get("getAttributeSetting", {}).get("nightVisionMode", "unknown")
+
+    @property
+    def left_food_low(self) -> bool | None:
+        """Return True if the left grain warehouse is low, or None if this unit doesn't report it."""
+        value = self._data.get("realInfo", {}).get("leftWarehouseSurplusGrain")
+        if value is None:
+            return None
+        return not bool(value)
+
+    @property
+    def right_food_low(self) -> bool | None:
+        """Return True if the right grain warehouse is low, or None if this unit doesn't report it."""
+        value = self._data.get("realInfo", {}).get("rightWarehouseSurplusGrain")
+        if value is None:
+            return None
+        return not bool(value)
+
+    @property
+    def pet_detection_enabled(self) -> bool:
+        """Return whether AI pet detection is enabled."""
+        return bool(self._data.get("getAttributeSetting", {}).get("petDetectionSwitch", False))
+
+    @property
+    def human_detection_enabled(self) -> bool:
+        """Return whether AI human detection is enabled."""
+        return bool(self._data.get("realInfo", {}).get("enableHumanDetection", False))
+
+    @property
+    def talk_channel_active(self) -> bool:
+        """Return whether a 2-way talk session is currently active."""
+        return bool(self._data.get("realInfo", {}).get("talkChannelState", False))
+
+    @property
+    def radar_sensing_level(self) -> str:
+        """Return the current radar sensing/trigger level."""
+        return self._data.get("realInfo", {}).get("radarSensingLevel", "unknown")
+
+    @property
+    def smart_refill_enabled(self) -> bool:
+        """Return whether Smart Refill Mode's auto-stop is enabled."""
+        return bool(self._data.get("getAttributeSetting", {}).get("autoStopFeedSwitch", False))
+
+    @property
+    def smart_refill_max_weight(self) -> float:
+        """Return the Smart Refill Mode daily max amount, in grams."""
+        value = self._data.get("getAttributeSetting", {}).get("autoFeedMaxWeight")
+        return float(value) if isinstance(value, (int, float)) else 0.0

--- a/custom_components/petlibro/devices/feeders/granary_2_vision_feeder.py
+++ b/custom_components/petlibro/devices/feeders/granary_2_vision_feeder.py
@@ -26,6 +26,16 @@ class Granary2VisionFeeder(GranarySmartCameraFeeder):
         except PetLibroAPIError as err:
             _LOGGER.error(f"Error refreshing free feeding setting for Granary2VisionFeeder: {err}")
 
+        # Isolated in its own error handler: TUTK credential retrieval failing
+        # (e.g. no camera entitlement) shouldn't disrupt the rest of the refresh.
+        try:
+            tutk_info = await self.api.device_tutk_info(self.serial)
+            self.update_data({
+                "tutkInfo": tutk_info or {},
+            })
+        except PetLibroAPIError as err:
+            _LOGGER.error(f"Error refreshing TUTK camera info for Granary2VisionFeeder: {err}")
+
     @property
     def night_vision(self) -> str:
         """Return the current night vision mode.
@@ -95,6 +105,27 @@ class Granary2VisionFeeder(GranarySmartCameraFeeder):
         """Return the wait time (seconds) Free Feeding uses between checks."""
         value = self._data.get("freeFeedingSetting", {}).get("freeWaitSeconds")
         return float(value) if isinstance(value, (int, float)) else None
+
+    @property
+    def camera_id(self) -> str | None:
+        """Return the Kalay/TUTK camera UID, if this device has camera entitlement."""
+        return self._data.get("tutkInfo", {}).get("cameraId")
+
+    @property
+    def camera_auth_info(self) -> str | None:
+        """Return the Kalay/TUTK camera auth info string."""
+        value = self._data.get("tutkInfo", {}).get("cameraAuthInfo")
+        return value if value is not None else self._data.get("realInfo", {}).get("cameraAuthInfo")
+
+    @property
+    def tutk_user_token(self) -> str | None:
+        """Return the Kalay/TUTK user token used to establish a P2P session."""
+        return self._data.get("tutkInfo", {}).get("userToken")
+
+    @property
+    def tutk_app_url(self) -> str | None:
+        """Return the Kalay/TUTK app URL/endpoint for this account."""
+        return self._data.get("tutkInfo", {}).get("appUrl")
 
     async def set_free_feeding_mode(self) -> None:
         """Enable Free Feeding (Smart Feed) mode."""

--- a/custom_components/petlibro/devices/feeders/granary_2_vision_feeder.py
+++ b/custom_components/petlibro/devices/feeders/granary_2_vision_feeder.py
@@ -10,9 +10,8 @@ _LOGGER = getLogger(__name__)
 class Granary2VisionFeeder(GranarySmartCameraFeeder):
     """Represents the Granary 2 Vision feeder.
 
-    Temporary subclass of GranarySmartCameraFeeder so the device loads and
-    reuses its entities while we confirm real API field names against a
-    live Granary 2 Vision unit. Split into a standalone class once verified.
+    Subclass of GranarySmartCameraFeeder so the device loads and
+    reuses its entities. Can be split into a standalone class if desired.
     """
 
     async def refresh(self):

--- a/custom_components/petlibro/devices/feeders/granary_2_vision_feeder.py
+++ b/custom_components/petlibro/devices/feeders/granary_2_vision_feeder.py
@@ -107,15 +107,13 @@ class Granary2VisionFeeder(GranarySmartCameraFeeder):
         return float(value) if isinstance(value, (int, float)) else None
 
     @property
-    def camera_id(self) -> str | None:
-        """Return the Kalay/TUTK camera UID, if this device has camera entitlement."""
-        return self._data.get("tutkInfo", {}).get("cameraId")
-
-    @property
     def camera_auth_info(self) -> str | None:
-        """Return the Kalay/TUTK camera auth info string."""
-        value = self._data.get("tutkInfo", {}).get("cameraAuthInfo")
-        return value if value is not None else self._data.get("realInfo", {}).get("cameraAuthInfo")
+        """Return the Kalay/TUTK per-device camera auth info string.
+
+        Not returned by /member/third/tutk/info (that endpoint only returns
+        the account-level userToken/appTutkUrl) - this comes from realInfo.
+        """
+        return self._data.get("realInfo", {}).get("cameraAuthInfo")
 
     @property
     def tutk_user_token(self) -> str | None:
@@ -125,7 +123,7 @@ class Granary2VisionFeeder(GranarySmartCameraFeeder):
     @property
     def tutk_app_url(self) -> str | None:
         """Return the Kalay/TUTK app URL/endpoint for this account."""
-        return self._data.get("tutkInfo", {}).get("appUrl")
+        return self._data.get("tutkInfo", {}).get("appTutkUrl")
 
     async def set_free_feeding_mode(self) -> None:
         """Enable Free Feeding (Smart Feed) mode."""

--- a/custom_components/petlibro/sensor.py
+++ b/custom_components/petlibro/sensor.py
@@ -646,14 +646,35 @@ DEVICE_SENSOR_MAP: dict[type[Device], list[PetLibroSensorEntityDescription]] = {
             should_report=lambda device: device.radar_sensing_level is not None
         ),
         PetLibroSensorEntityDescription[Granary2VisionFeeder](
-            key="smart_refill_max_weight",
-            translation_key="smart_refill_max_weight",
+            key="free_feeding_per_grain",
+            translation_key="free_feeding_per_grain",
+            icon="mdi:counter",
+            name="Free Feeding Per-Feed Amount",
+            should_report=lambda device: device.free_feeding_per_grain is not None
+        ),
+        PetLibroSensorEntityDescription[Granary2VisionFeeder](
+            key="free_feeding_daily_max",
+            translation_key="free_feeding_daily_max",
+            icon="mdi:counter",
+            name="Free Feeding Daily Max Count",
+            should_report=lambda device: device.free_feeding_daily_max is not None
+        ),
+        PetLibroSensorEntityDescription[Granary2VisionFeeder](
+            key="free_feeding_leftover_weight",
+            translation_key="free_feeding_leftover_weight",
             icon="mdi:scale",
-            name="Smart Refill Max Amount",
-            native_unit_of_measurement="g",
-            device_class=SensorDeviceClass.WEIGHT,
+            name="Free Feeding Leftover Threshold",
+            should_report=lambda device: device.free_feeding_leftover_weight is not None
+        ),
+        PetLibroSensorEntityDescription[Granary2VisionFeeder](
+            key="free_feeding_wait_seconds",
+            translation_key="free_feeding_wait_seconds",
+            icon="mdi:timer-outline",
+            name="Free Feeding Wait Time",
+            native_unit_of_measurement="s",
+            device_class=SensorDeviceClass.DURATION,
             state_class=SensorStateClass.MEASUREMENT,
-            should_report=lambda device: device.smart_refill_enabled is not None
+            should_report=lambda device: device.free_feeding_wait_seconds is not None
         ),
     ],
     OneRFIDSmartFeeder: [

--- a/custom_components/petlibro/sensor.py
+++ b/custom_components/petlibro/sensor.py
@@ -20,6 +20,7 @@ from .devices.feeders.feeder import Feeder
 from .devices.feeders.air_smart_feeder import AirSmartFeeder
 from .devices.feeders.granary_smart_feeder import GranarySmartFeeder
 from .devices.feeders.granary_smart_camera_feeder import GranarySmartCameraFeeder
+from .devices.feeders.granary_2_vision_feeder import Granary2VisionFeeder
 from .devices.feeders.one_rfid_smart_feeder import OneRFIDSmartFeeder
 from .devices.feeders.polar_wet_food_feeder import PolarWetFoodFeeder
 from .devices.feeders.space_smart_feeder import SpaceSmartFeeder
@@ -635,6 +636,25 @@ DEVICE_SENSOR_MAP: dict[type[Device], list[PetLibroSensorEntityDescription]] = {
             name="Video Recording Mode",
             should_report=lambda device: device.video_record_mode is not None
         )
+    ],
+    Granary2VisionFeeder: [
+        PetLibroSensorEntityDescription[Granary2VisionFeeder](
+            key="radar_sensing_level",
+            translation_key="radar_sensing_level",
+            icon="mdi:radar",
+            name="Radar Sensing Level",
+            should_report=lambda device: device.radar_sensing_level is not None
+        ),
+        PetLibroSensorEntityDescription[Granary2VisionFeeder](
+            key="smart_refill_max_weight",
+            translation_key="smart_refill_max_weight",
+            icon="mdi:scale",
+            name="Smart Refill Max Amount",
+            native_unit_of_measurement="g",
+            device_class=SensorDeviceClass.WEIGHT,
+            state_class=SensorStateClass.MEASUREMENT,
+            should_report=lambda device: device.smart_refill_enabled is not None
+        ),
     ],
     OneRFIDSmartFeeder: [
         PetLibroSensorEntityDescription[OneRFIDSmartFeeder](

--- a/custom_components/petlibro/sensor.py
+++ b/custom_components/petlibro/sensor.py
@@ -237,14 +237,27 @@ class PetLibroSensorEntity(PetLibroEntity[_DeviceT], SensorEntity):
                     for unit in (Unit.CUPS, Unit.MILLILITERS)
                 }
             case key if key in (
-                "remaining_water", 
-                "today_drinking_amount", 
+                "remaining_water",
+                "today_drinking_amount",
                 "yesterday_drinking_amount"
             ):
                 key = "weight" if key == "remaining_water" else key
-                return { 
+                return {
                     unit.symbol: VolumeConverter.convert(getattr(self.device, key, 0), UnitOfVolume.MILLILITERS, unit.symbol)
                     for unit in VALID_UNIT_TYPES[API.WATER_UNIT] if unit
+                }
+            case "wifi_ssid":
+                # Kalay/TUTK camera credential layer (Granary2VisionFeeder only).
+                # Not a video stream itself - an external TUTK-compatible bridge
+                # would use these to establish its own P2P session.
+                camera_id = getattr(self.device, "camera_id", None)
+                if camera_id is None:
+                    return super().extra_state_attributes
+                return {
+                    "camera_id": camera_id,
+                    "camera_auth_info": getattr(self.device, "camera_auth_info", None),
+                    "tutk_user_token": getattr(self.device, "tutk_user_token", None),
+                    "tutk_app_url": getattr(self.device, "tutk_app_url", None),
                 }
         return super().extra_state_attributes
 

--- a/custom_components/petlibro/sensor.py
+++ b/custom_components/petlibro/sensor.py
@@ -651,6 +651,13 @@ DEVICE_SENSOR_MAP: dict[type[Device], list[PetLibroSensorEntityDescription]] = {
     ],
     Granary2VisionFeeder: [
         PetLibroSensorEntityDescription[Granary2VisionFeeder](
+            key="feeding_mode",
+            translation_key="feeding_mode",
+            icon="mdi:swap-horizontal",
+            name="Feeding Mode",
+            should_report=lambda device: device.feeding_mode is not None
+        ),
+        PetLibroSensorEntityDescription[Granary2VisionFeeder](
             key="radar_sensing_level",
             translation_key="radar_sensing_level",
             icon="mdi:radar",

--- a/custom_components/petlibro/sensor.py
+++ b/custom_components/petlibro/sensor.py
@@ -250,12 +250,11 @@ class PetLibroSensorEntity(PetLibroEntity[_DeviceT], SensorEntity):
                 # Kalay/TUTK camera credential layer (Granary2VisionFeeder only).
                 # Not a video stream itself - an external TUTK-compatible bridge
                 # would use these to establish its own P2P session.
-                camera_id = getattr(self.device, "camera_id", None)
-                if camera_id is None:
+                camera_auth_info = getattr(self.device, "camera_auth_info", None)
+                if camera_auth_info is None:
                     return super().extra_state_attributes
                 return {
-                    "camera_id": camera_id,
-                    "camera_auth_info": getattr(self.device, "camera_auth_info", None),
+                    "camera_auth_info": camera_auth_info,
                     "tutk_user_token": getattr(self.device, "tutk_user_token", None),
                     "tutk_app_url": getattr(self.device, "tutk_app_url", None),
                 }

--- a/docs/api-documentation.md
+++ b/docs/api-documentation.md
@@ -71,6 +71,7 @@ List all devices on the account.
 - `"Air Smart Feeder"` → `AirSmartFeeder`
 - `"Granary Smart Feeder"` → `GranarySmartFeeder`
 - `"Granary Smart Camera Feeder"` → `GranarySmartCameraFeeder`
+- `"Granary 2 Vision"` → `Granary2VisionFeeder` (PLAF205)
 - `"One RFID Smart Feeder"` → `OneRFIDSmartFeeder`
 - `"Polar Wet Food Feeder"` → `PolarWetFoodFeeder`
 - `"Dockstream Smart Fountain"` → `DockstreamSmartFountain`
@@ -142,6 +143,23 @@ Real-time device state.
 | `powerType` | int | Power type (2=battery, 3=AC) |
 | `powerState` | string | `"USING"`, `"CHARGING"`, `"CHARGED"` |
 
+**Additional fields seen on Granary 2 Vision (PLAF205):**
+| Field | Type | Description |
+|---|---|---|
+| `bowlMode` | string | `"SINGLE_BOWL"` or dual-tray mode |
+| `leftWarehouseSurplusGrain` | bool | Left grain warehouse has food (dual-tray) |
+| `rightWarehouseSurplusGrain` | bool | Right grain warehouse has food (dual-tray) |
+| `warehouseSurplusGrain` | string | Combined warehouse status, e.g. `"GOOD"` |
+| `cameraAuthInfo` | string | Kalay/TUTK per-device camera auth string |
+| `enableHumanDetection` | bool | AI human detection enabled |
+| `radarSensingLevel` | string | Radar sensing/trigger level, e.g. `"NearTrigger"` |
+| `talkChannelState` | bool | Whether a 2-way talk session is active |
+| `detThreshold` / `reidThreshold` | float | AI detection / re-identification confidence thresholds |
+
+Note: `nightVisionMode` and `petDetectionSwitch` are **not** present on `realInfo` for this
+model - they only appear in `getAttributeSetting`'s response (see below), unlike
+`nightVision`/`enableVideoRecord` on the older Granary Smart Camera Feeder.
+
 ### POST /data/data/realInfo
 
 Extended real-time info (fountains, litter boxes).
@@ -182,6 +200,13 @@ Device attribute settings.
 | `cleanMode` | string | `"AUTO"` or `"MANUAL"` |
 | `autoDelaySec` | int | Auto-clean delay |
 | `enableSleepMode` | bool | Sleep mode config |
+
+**Additional fields seen on Granary 2 Vision (PLAF205):**
+| Field | Type | Description |
+|---|---|---|
+| `nightVisionMode` | string | Active night vision mode, e.g. `"AUTO_BLACK_WHITE"` (authoritative source - `realInfo.nightVision` is always null on this model) |
+| `autoStopFeedSwitch` | bool | Unconfirmed - looked like a Smart Feed toggle but did not change when Smart Feed was toggled in the app. Real Smart Feed state lives in the feeding mode (see below), not here. |
+| `autoFeedMaxWeight` | int | Unconfirmed - unrelated to Free Feeding's `freeDailyMaxNum` (see below); meaning not yet verified. |
 
 ### POST /device/ota/getUpgrade
 
@@ -293,6 +318,48 @@ Stop manual feeding. Closes the lid.
 Rotate food bowl to next plate.
 
 **Request:** `{"deviceSn": "<sn>"}`
+
+### POST /device/device/getFreeFeedingSetting (Granary 2 Vision)
+
+Free Feeding ("Smart Feed" in the app) settings.
+
+**Request:** `{"id": "<deviceSn>", "deviceSn": "<deviceSn>"}`
+
+**Response:**
+```json
+{
+  "freePerGrainNum": 1,
+  "freeDailyMaxNum": 13,
+  "freeLeftoverWeight": 3,
+  "freeWaitSeconds": 3
+}
+```
+
+Values are per-device config (e.g. `freeDailyMaxNum` differed between two units on the same
+account: 13 vs 10). This endpoint returns settings regardless of which feeding mode is
+currently active - it is not itself a signal of whether Free Feeding is enabled.
+
+### POST /device/device/updateFeedingMode (Granary 2 Vision)
+
+Switch the device's active feeding mode. Confirmed via a live network capture of the app.
+
+**Request:**
+```json
+{
+  "deviceSn": "<sn>",
+  "mode": "FREE"
+}
+```
+
+**Known `mode` values:**
+| Value | Meaning |
+|---|---|
+| `FREE` | Free Feeding / Smart Feed - device dispenses automatically based on the Free Feeding settings above |
+| `PLAN` | Schedule-based feeding - the device follows `/device/feedingPlan/list` entries |
+
+There is currently no known GET endpoint that reads back the *current* mode; it must be
+tracked from the last value written, or inferred (e.g. an empty `feedingPlan/list` combined
+with automatic `GRAIN_OUTPUT_SUCCESS` work records tagged `"mode":"{AUTO_MODE}"` suggests `FREE`).
 
 ## Water / Fountain Endpoints
 
@@ -515,6 +582,27 @@ All endpoints below take a JSON body with `"deviceSn": "<serial>"` plus paramete
 
 ### POST /device/device/vacuum
 **Body:** `{"deviceSn": "<sn>", "vacuumMode": "auto", "requestId": "<uuid>"}`
+
+## Camera Credential Endpoints
+
+### POST /member/third/tutk/info
+
+Kalay/TUTK P2P camera credentials, account-scoped (not per-device despite taking a serial
+in the request). This is a credential layer only - it does not provide a video stream by
+itself. An external Kalay/TUTK-compatible client would need these plus the per-device
+`cameraAuthInfo` from `realInfo` to establish its own P2P session. See PetLibro/petlibro#269
+(upstream, unmerged as of this writing) for prior art exposing these attributes without
+attempting to build a full camera platform.
+
+**Request:** `{"id": "<deviceSn>", "deviceSn": "<deviceSn>"}`
+
+**Response:**
+```json
+{
+  "userToken": "RsOpmYHrliyPvA6p2BOa",
+  "appTutkUrl": "https://us-vsaasapi-tutk.kalayservice.com/vsaas/api/v1/be/"
+}
+```
 
 ## Member / Account Endpoints
 

--- a/docs/api-documentation.md
+++ b/docs/api-documentation.md
@@ -162,11 +162,13 @@ model - they only appear in `getAttributeSetting`'s response (see below), unlike
 
 ### POST /data/data/realInfo
 
-Extended real-time info (fountains, litter boxes).
+Extended real-time info (fountains, litter boxes; also used by Granary 2 Vision for
+`feedingMode`, which is not present on `/device/device/realInfo`).
 
 **Response includes all realInfo fields plus:**
 | Field | Type | Description |
 |---|---|---|
+| `feedingMode` | string | Current feeding mode (Granary 2 Vision): `"FREE"` (Smart Feed) or `"PLAN"` (schedule-based) |
 | `exceptionMessage` | string | Error message (e.g. `"Rotor stuck"`, `"Calibration error"`) |
 | `waterStopSwitch` | bool | Fountain water mode |
 | `lowWater` | int | Low water threshold (mL) |
@@ -357,9 +359,8 @@ Switch the device's active feeding mode. Confirmed via a live network capture of
 | `FREE` | Free Feeding / Smart Feed - device dispenses automatically based on the Free Feeding settings above |
 | `PLAN` | Schedule-based feeding - the device follows `/device/feedingPlan/list` entries |
 
-There is currently no known GET endpoint that reads back the *current* mode; it must be
-tracked from the last value written, or inferred (e.g. an empty `feedingPlan/list` combined
-with automatic `GRAIN_OUTPUT_SUCCESS` work records tagged `"mode":"{AUTO_MODE}"` suggests `FREE`).
+The current mode is read back via `feedingMode` on `POST /data/data/realInfo` (see below) -
+not on `POST /device/device/realInfo`, which doesn't carry this field.
 
 ## Water / Fountain Endpoints
 


### PR DESCRIPTION
## Proposed change:
Adds support for the Granary 2 Vision (PLAF205), verified against two live units.

## What's included
- Device detection under the `"Granary 2 Vision"` productName
- Full Granary Smart Camera Feeder entity set (Granary2VisionFeeder subclasses
  GranarySmartCameraFeeder - the API surface is a near-superset, and this avoids
  duplicating ~500 lines for a device that shares almost all of its behavior)
- Fixed `night_vision` mapping: this model reports it under
  `getAttributeSetting.nightVisionMode`, not `realInfo.nightVision`
- New sensors/binary sensors: dual grain warehouse status, AI pet/human detection,
  radar sensing level, 2-way talk activity
- Full Free Feeding ("Smart Feed") support: read-only settings sensors (per-feed
  amount, daily max, leftover threshold, wait time), a `feeding_mode` sensor
  reporting the live `FREE`/`PLAN` state, and buttons to switch between them -
  confirmed via a live network capture of the app
  (`/device/device/getFreeFeedingSetting`, `/device/device/updateFeedingMode`,
  `/data/data/realInfo.feedingMode`)
- Kalay/TUTK camera credential layer (`userToken`, `appTutkUrl`, `cameraAuthInfo`)
  exposed as attributes on the Wi-Fi SSID sensor, mirroring the scope of #269 -
  this does not implement video streaming, just the credentials an external
  bridge would need
- `docs/api-documentation.md` updated with all newly-discovered endpoints/fields

## Known limitations
- No live camera feed (see #269 discussion - needs a proprietary TUTK SDK bridge,
  out of scope for this integration)

## Testing
Verified live against two Granary 2 Vision units (PLAF205, fw 1.1.30) on my own
account - entity states cross-checked against raw debug-log API responses and,
for the feeding mode, an HTTP Toolkit capture of the mobile app.

## Type of change:

- [x ] New device.
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature or enhancement (non-breaking change which adds functionality).
- [ ] Documentation only.
- [ ] Other (please explain).

## Checklist:

- [x ] If applicable, I have added corresponding documentation changes.
- [x ] If applicable, I have reviewed the [feature / enhancement](https://github.com/jjjonesjr33/petlibro/wiki/Feature-&-Enhancement-Guidelines) guidlines before submitting my request.
- [x ] If applicable, I have tested my code for new features & regressions on the latest version of Home Assistant.

## Additional notes:
I'd be happy to extend this to the rest of the Granary 2 line, but I kept it at the Granary 2 Vision since that's what I have to test with. Let me know what is preferred. I think this PR contributes to closing https://github.com/jjjonesjr33/petlibro/issues/270 but likely doesn't close it until the full Granary 2 line is supported.